### PR TITLE
Limit reviewers to access submission with AC review state or higher and not dismissed

### DIFF
--- a/hypha/apply/dashboard/views.py
+++ b/hypha/apply/dashboard/views.py
@@ -191,7 +191,12 @@ class ReviewerDashboardView(MyFlaggedMixin, MySubmissionContextMixin, TemplateVi
 
     def my_reviewed(self, submissions):
         """Staff reviewer's reviewed submissions for 'Previous reviews' block"""
-        submissions = submissions.reviewed_by(self.request.user).order_by('-submit_time')
+
+        # Submissions which has been reviewed and in AC review state or higher but
+        # not dismissed.
+        submissions = submissions.in_ac_review_state_or_higher_and_not_dismissed(
+            self.request.user
+        ).order_by('-submit_time')
 
         limit = 5
         return {

--- a/hypha/apply/funds/models/submissions.py
+++ b/hypha/apply/funds/models/submissions.py
@@ -52,6 +52,7 @@ from ..workflow import (
     STAGE_CHANGE_ACTIONS,
     WORKFLOWS,
     UserPermissions,
+    ac_review_or_higher_and_not_dismissed_statuses,
     active_statuses,
     get_review_active_statuses,
     review_statuses,
@@ -123,6 +124,16 @@ class ApplicationSubmissionQueryset(JSONOrderable):
             qs = qs.filter(reviewers=user)
             # If this user has agreed with a review, then they have reviewed this submission already
             qs = qs.exclude(reviews__opinions__opinion=AGREE, reviews__opinions__author__reviewer=user)
+        return qs.distinct()
+
+    def in_ac_review_state_or_higher_and_not_dismissed(self, user):
+        """
+        Returns a queryset of submissions which are reviewed and in AC review state or
+        higher but not dismissed.
+        """
+        qs = self.reviewed_by(user).filter(
+            Q(status__in=ac_review_or_higher_and_not_dismissed_statuses)
+        )
         return qs.distinct()
 
     def reviewed_by(self, user):

--- a/hypha/apply/funds/views.py
+++ b/hypha/apply/funds/views.py
@@ -98,6 +98,7 @@ from .workflow import (
     INITIAL_STATE,
     PHASES_MAPPING,
     STAGE_CHANGE_ACTIONS,
+    ac_review_or_higher_and_not_dismissed_statuses,
     active_statuses,
     review_statuses,
 )
@@ -738,8 +739,14 @@ class ReviewerSubmissionDetailView(ReviewContextMixin, ActivityContextMixin, Del
         # Reviewers may sometimes be applicants as well.
         if submission.user == request.user:
             return ApplicantSubmissionDetailView.as_view()(request, *args, **kwargs)
+
         if submission.status == DRAFT_STATE:
             raise Http404
+
+        # Reviewers should not be able to view a submission which is not in "AC review"
+        # state or higher and dismissed
+        if submission.status not in ac_review_or_higher_and_not_dismissed_statuses:
+            raise PermissionDenied
         return super().dispatch(request, *args, **kwargs)
 
 

--- a/hypha/apply/funds/views.py
+++ b/hypha/apply/funds/views.py
@@ -328,8 +328,11 @@ class BaseReviewerSubmissionsTable(BaseAdminSubmissionsTable):
     filterset_class = SubmissionReviewerFilterAndSearch
 
     def get_queryset(self):
-        # Reviewers can only see submissions they have reviewed
-        return super().get_queryset().reviewed_by(self.request.user)
+        # Reviewers can only see submissions they have reviewed and which are in AC review
+        # state but not dismissed.
+        return super().get_queryset().in_ac_review_state_or_higher_and_not_dismissed(
+            self.request.user
+        )
 
 
 @method_decorator(staff_required, name='dispatch')

--- a/hypha/apply/funds/workflow.py
+++ b/hypha/apply/funds/workflow.py
@@ -1013,6 +1013,30 @@ def get_review_statuses(user=None):
     return reviews
 
 
+def get_ac_review_or_higher_statuses_and_not_dismissed():
+    """
+    Returns a set of all the statuses for all workflow which are for AC Review
+    or higher than that. But exclude the status which is Dismissed.
+    """
+    ac_review_or_higher_statuses = set()
+
+    for workflow in WORKFLOWS.values():
+        step = None
+        for phase in workflow.values():
+            if phase.display_name == 'Dismissed':
+                continue
+            if phase.display_name == 'Advisory Council Review':
+                # Update the step for this workflow as AC review state
+                step = phase.step
+
+            # Phase should have step higher or equal than AC review state
+            # for this workflow
+            if step and phase.step >= step:
+                ac_review_or_higher_statuses.add(phase.name)
+    return ac_review_or_higher_statuses
+
+
+ac_review_or_higher_and_not_dismissed_statuses = get_ac_review_or_higher_statuses_and_not_dismissed()
 review_statuses = get_review_statuses()
 
 DETERMINATION_PHASES = list(phase_name for phase_name, _ in PHASES if '_discussion' in phase_name)

--- a/hypha/apply/funds/workflow.py
+++ b/hypha/apply/funds/workflow.py
@@ -1013,7 +1013,7 @@ def get_review_statuses(user=None):
     return reviews
 
 
-def get_ac_review_or_higher_statuses_and_not_dismissed():
+def get_ac_review_or_higher_and_not_dismissed_statuses():
     """
     Returns a set of all the statuses for all workflow which are for AC Review
     or higher than that. But exclude the status which is Dismissed.
@@ -1036,7 +1036,7 @@ def get_ac_review_or_higher_statuses_and_not_dismissed():
     return ac_review_or_higher_statuses
 
 
-ac_review_or_higher_and_not_dismissed_statuses = get_ac_review_or_higher_statuses_and_not_dismissed()
+ac_review_or_higher_and_not_dismissed_statuses = get_ac_review_or_higher_and_not_dismissed_statuses()
 review_statuses = get_review_statuses()
 
 DETERMINATION_PHASES = list(phase_name for phase_name, _ in PHASES if '_discussion' in phase_name)


### PR DESCRIPTION
Fixes https://github.com/OpenTechFund/hypha/issues/1182

This pr makes the following changes:

- Currently reviewers can view all the submissions they are assigned to by directly going the respective submission page.
   - These changes will restrict reviewers to access those submission until it is reached in "AC review" state or higher but not dismissed.
   - A method `get_ac_review_or_higher_and_not_dismissed_statuses ` has been created to get such states.
   - Old tests were written assuming that all the submission are accessible to reviewer but that is not the case now so the tests were failing, these changes fix those tests as well.

- Currently reviewers can view all the submissions they have reviewed, but now as discussed in the issue, we only want them to show the submissions which are in "AC review" states or higher and not dismissed
   - These changes will filter out such submissions
   - A queryset method `in_ac_review_state_or_higher_and_not_dismissed` has been created to get such submission.
   - And this method is used at places where we list submissions for reviewers, I.e at `/apply/submission/all` and also at the dashboard where we show `previous reviews` by that reviewer.

