### PR TITLE
Fix reset production errors on sentry 

### DIFF
--- a/hypha/apply/determinations/views.py
+++ b/hypha/apply/determinations/views.py
@@ -430,7 +430,7 @@ class AdminDeterminationDetailView(DetailView):
     model = Determination
 
     def get_object(self, queryset=None):
-        return self.model.objects.get(submission=self.submission, id=self.kwargs['pk'])
+        return get_object_or_404(self.model, submission=self.submission, id=self.kwargs['pk'])
 
     def dispatch(self, request, *args, **kwargs):
         self.submission = get_object_or_404(ApplicationSubmission, id=self.kwargs['submission_pk'])
@@ -447,7 +447,7 @@ class ReviewerDeterminationDetailView(DetailView):
     model = Determination
 
     def get_object(self, queryset=None):
-        return self.model.objects.get(submission=self.submission, id=self.kwargs['pk'])
+        return get_object_or_404(self.model, submission=self.submission, id=self.kwargs['pk'])
 
     def dispatch(self, request, *args, **kwargs):
         self.submission = get_object_or_404(ApplicationSubmission, id=self.kwargs['submission_pk'])
@@ -505,7 +505,7 @@ class ApplicantDeterminationDetailView(DetailView):
     model = Determination
 
     def get_object(self, queryset=None):
-        return self.model.objects.get(submission=self.submission, id=self.kwargs['pk'])
+        return get_object_or_404(self.model, submission=self.submission, id=self.kwargs['pk'])
 
     def dispatch(self, request, *args, **kwargs):
         self.submission = get_object_or_404(ApplicationSubmission, id=self.kwargs['submission_pk'])

--- a/hypha/apply/funds/models/submissions.py
+++ b/hypha/apply/funds/models/submissions.py
@@ -985,12 +985,15 @@ class AssignedReviewersQuerySet(models.QuerySet):
     def bulk_create_reviewers(self, reviewers, submission):
         group = Group.objects.get(name=REVIEWER_GROUP_NAME)
         self.bulk_create(
-            self.model(
-                submission=submission,
-                role=None,
-                reviewer=reviewer,
-                type=group,
-            ) for reviewer in reviewers
+            [
+                self.model(
+                    submission=submission,
+                    role=None,
+                    reviewer=reviewer,
+                    type=group,
+                ) for reviewer in reviewers
+            ],
+            ignore_conflicts=True
         )
 
     def update_role(self, role, reviewer, *submissions):

--- a/hypha/public/search/views.py
+++ b/hypha/public/search/views.py
@@ -7,12 +7,15 @@ from django.shortcuts import render
 from wagtail.core.models import Page, Site
 from wagtail.search.models import Query
 
-from hypha.public.home.models import HomePage
-
 
 def search(request):
     site = Site.find_for_request(request)
-    if site != HomePage.objects.first().get_site():
+    if (
+        not site.is_default_site and
+        'apply' in site.site_name.lower() and
+        'apply' in site.hostname and
+        'apply' in site.root_page.title.lower()
+    ):
         raise Http404
 
     search_query = request.GET.get('query', None)


### PR DESCRIPTION
There are three commits:

1. Fixes error:
```
Determination.DoesNotExist /{var}
Unhandled Determination matching query does not exist.
```

2. Fixes the error while assigning reviewers.

3. Fixes the error while accessing `/search` on public site.
