### PR TITLE
Make application, determination and review forms hashable

### DIFF
--- a/hypha/apply/funds/models/forms.py
+++ b/hypha/apply/funds/models/forms.py
@@ -45,13 +45,18 @@ class AbstractRelatedForm(Orderable):
 
     def __eq__(self, other):
         try:
-            return self.fields == other.fields and self.sort_order == other.sort_order
+            if self.fields == other.fields and self.sort_order == other.sort_order:
+                # If the objects are saved to db. pk should also be compared
+                if hasattr(other, 'pk') and hasattr(self, 'pk'):
+                    return self.pk == other.pk
+                return True
+            return False
         except AttributeError:
             return False
 
     def __hash__(self):
         fields = [field.id for field in self.fields]
-        return hash((tuple(fields), self.sort_order))
+        return hash((tuple(fields), self.sort_order, self.pk))
 
     def __str__(self):
         return self.form.name
@@ -89,13 +94,18 @@ class AbstractRelatedDeterminationForm(Orderable):
 
     def __eq__(self, other):
         try:
-            return self.fields == other.fields and self.sort_order == other.sort_order
+            if self.fields == other.fields and self.sort_order == other.sort_order:
+                # If the objects are saved to db. pk should also be compared
+                if hasattr(other, 'pk') and hasattr(self, 'pk'):
+                    return self.pk == other.pk
+                return True
+            return False
         except AttributeError:
             return False
-            
+
     def __hash__(self):
         fields = [field.id for field in self.fields]
-        return hash((tuple(fields), self.sort_order))
+        return hash((tuple(fields), self.sort_order, self.pk))
 
     def __str__(self):
         return self.form.name
@@ -119,13 +129,18 @@ class AbstractRelatedReviewForm(Orderable):
 
     def __eq__(self, other):
         try:
-            return self.fields == other.fields and self.sort_order == other.sort_order
+            if self.fields == other.fields and self.sort_order == other.sort_order:
+                # If the objects are saved to db. pk should also be compared
+                if hasattr(other, 'pk') and hasattr(self, 'pk'):
+                    return self.pk == other.pk
+                return True
+            return False
         except AttributeError:
             return False
 
     def __hash__(self):
         fields = [field.id for field in self.fields]
-        return hash((tuple(fields), self.sort_order))
+        return hash((tuple(fields), self.sort_order, self.pk))
 
     def __str__(self):
         return self.form.name

--- a/hypha/apply/funds/models/forms.py
+++ b/hypha/apply/funds/models/forms.py
@@ -49,6 +49,10 @@ class AbstractRelatedForm(Orderable):
         except AttributeError:
             return False
 
+    def __hash__(self):
+        fields = [field.id for field in self.fields]
+        return hash((tuple(fields), self.sort_order))
+
     def __str__(self):
         return self.form.name
 
@@ -88,6 +92,10 @@ class AbstractRelatedDeterminationForm(Orderable):
             return self.fields == other.fields and self.sort_order == other.sort_order
         except AttributeError:
             return False
+            
+    def __hash__(self):
+        fields = [field.id for field in self.fields]
+        return hash((tuple(fields), self.sort_order))
 
     def __str__(self):
         return self.form.name
@@ -114,6 +122,10 @@ class AbstractRelatedReviewForm(Orderable):
             return self.fields == other.fields and self.sort_order == other.sort_order
         except AttributeError:
             return False
+
+    def __hash__(self):
+        fields = [field.id for field in self.fields]
+        return hash((tuple(fields), self.sort_order))
 
     def __str__(self):
         return self.form.name

--- a/hypha/apply/funds/tests/test_models.py
+++ b/hypha/apply/funds/tests/test_models.py
@@ -172,7 +172,8 @@ class TestRoundModelWorkflowAndForms(TestCase):
     def test_forms_are_copied_to_new_rounds(self):
         self.round.save()
         for round_form, fund_form in itertools.zip_longest(self.round.forms.all(), self.fund.forms.all()):
-            self.assertEqual(round_form, fund_form)
+            self.assertEqual(round_form.fields, fund_form.fields)
+            self.assertEqual(round_form.sort_order, fund_form.sort_order)
 
     def test_can_change_round_form_not_fund(self):
         self.round.save()


### PR DESCRIPTION
This fixes the Type Error: unhashable type: 'ApplicationBaseForm', when editing and publishing funds.

### How to reproduce

This bug is not only specific to Reset. And can be reproduced with any funds. And also not only with attaching application form but it can also be reproduced for `Review` and `Determination` forms. Here are the steps:

- Select a fund for editing.
- As you see, it has a review form attached:
<img width="1055" alt="Screenshot 2020-11-20 at 3 30 09 PM" src="https://user-images.githubusercontent.com/22263040/99787390-aec7ce80-2b45-11eb-91a6-f3b0258517ce.png">

- Delete the `Review Form` attached:
<img width="990" alt="Screenshot 2020-11-20 at 3 29 58 PM" src="https://user-images.githubusercontent.com/22263040/99787410-b4bdaf80-2b45-11eb-8bb6-527b4bfce363.png">

- Attach a `Review Form`:
<img width="1070" alt="Screenshot 2020-11-20 at 3 29 50 PM" src="https://user-images.githubusercontent.com/22263040/99787424-ba1afa00-2b45-11eb-8b20-716d40589675.png">

- Do publish.
- This will lead to the error `TypeError: unhashable type: 'ApplicationBaseReviewForm'`

### Why is it happening

All the forms listed here, overrides their [__eq__](https://github.com/OpenTechFund/hypha/blob/392b789d15b547eb3955879daa79e8752d2ca69f/hypha/apply/funds/models/forms.py#L46) methods. But doesn't overrides the `__hash__` method.

It has been mandatory to override __hash__ when you override `__eq__` of an object. Otherwise `__hash__` of that object will be set as `None`. Hence making the object unhashable. 

See [this](https://stackoverflow.com/a/61235311) stackoverflow answer for more.

### Fix

- Add `__hash__` method for all the forms overriding `__eq__`.
- There was one other problem in the `__eq__` method which is fixed now: if the objects are saved in db, pk should be checked to make sure if they are equal. Otherwise in the above flow that I described, form will not get added, as the deleted and the new form would be considered equal.