### PR TITLE
Set Salesforce integration default to 'off'

### DIFF
--- a/docker/Dockerfile.dev
+++ b/docker/Dockerfile.dev
@@ -11,7 +11,7 @@ ENV PYTHONDONTWRITEBYTECODE 1
 ENV PYTHONUNBUFFERED 1
 
 # Salesforce Integration
-ENV SALESFORCE_INTEGRATION true
+ENV SALESFORCE_INTEGRATION false
 
 # Set owner on /usr/local.
 RUN sudo chown -R circleci:circleci /usr/local


### PR DESCRIPTION
It makes no sense to default salesforce integration to enabled.  Anybody who wants it enabled has to add a salesforce.env file, as we don't ship one.  If we disable salesforce by default, the user at least gets a working hypha docker config.
