### PR TITLE
Switch docker to yarn to avoid bug in npm

### DIFF
--- a/docker/Dockerfile.dev
+++ b/docker/Dockerfile.dev
@@ -17,9 +17,9 @@ ENV SALESFORCE_INTEGRATION true
 RUN sudo chown -R circleci:circleci /usr/local
 
 # Install node dependencies.
-COPY package.json package-lock.json /usr/local/hypha/
-RUN npm install  --quiet --global gulp-cli
-RUN npm install  --quiet
+RUN sudo apt-get install -y yarn
+COPY package.json /usr/local/hypha/
+RUN yarn install --ignore-engines
 
 # Install python dependencies.
 COPY requirements.txt requirements-dev.txt /usr/local/hypha/


### PR DESCRIPTION
`npm install` consistently fails in Docker with a fairly generic error: "cb() never called".  According to the npm project (at https://github.com/npm/cli/wiki/%22cb()-never-called%3F--I'm-having-the-same-problem!%22) this just means a callback never got called.  npm interprets that as "something failed but I don't know what" and halts.

There's no way to reliably fix this bug, and npm won't do anything about it because it's actually a class of bugs, not just one thing.  Reporting it upstream won't help.

There are two solutions.  This PR is faster and more permanent than the alternative (which I describe below).  It is simply to switch to yarn, which proceeds with no problems.  This patch does that.  It installs yarn (via sudo because installing via npm triggers the callback bug), then uses yarn to install our node packages.

The other solution would be to step back through changes to package-lock and try to identify the entries in the 15000 line json file that are causing this problem and then to change those entries in some way (perhaps by moving to a different version).  Or perhaps to just delete the existing package-lock.json and starting over.  Finding the offending entry or entries would take a lot of time.  Either way, adjusting package-lock.json doesn't prevent this issue from arising again.  Switching to yarn seems to solve it more durably and simply.

At any rate, if you want me to track down the specific offending entries, I can.  I was hoping to avoid that effort, hence this PR.

One more thing: it is possible that the callback bug relates to network flakiness inside Docker containers.  Yarn reports "There
appears to be trouble with your network connection. Retrying..." and I know npm doesn't do well with poor network connections.
That said, I tried the docker install on several different networks, including a decent fiber line.  This problem does not appear to relate to the quality of the host machine's network connection.
