### PR TITLE
Allow running project without webpack/node

### DIFF
--- a/hypha/apply/funds/templates/funds/grouped_application_list.html
+++ b/hypha/apply/funds/templates/funds/grouped_application_list.html
@@ -1,6 +1,6 @@
 {% extends "base-apply.html" %}
 {% load static %}
-{% load render_bundle from webpack_loader %}
+{% load render_bundle from webpack_tags %}
 
 {% block extra_css %}
 <link rel="stylesheet" href="{% static 'css/apply/fancybox.css' %}">
@@ -36,6 +36,3 @@
     <script src="{% static 'js/apply/batch-actions.js' %}"></script>
     <script src="{% static 'js/apply/flag.js' %}"></script>
 {% endblock %}
-
-
-{% load render_bundle from webpack_loader %}

--- a/hypha/apply/funds/templates/funds/submissions.html
+++ b/hypha/apply/funds/templates/funds/submissions.html
@@ -1,6 +1,6 @@
 {% extends "funds/base_submissions_table.html" %}
 {% load static %}
-{% load render_bundle from webpack_loader %}
+{% load render_bundle from webpack_tags %}
 
 {% block title %}Submissions{% endblock %}
 {% block content %}

--- a/hypha/apply/funds/templates/funds/submissions_by_round.html
+++ b/hypha/apply/funds/templates/funds/submissions_by_round.html
@@ -1,6 +1,6 @@
 {% extends "funds/base_submissions_table.html" %}
 {% load static %}
-{% load render_bundle from webpack_loader %}
+{% load render_bundle from webpack_tags %}
 
 {% block title %}{{ object }}{% endblock %}
 

--- a/hypha/apply/funds/templates/funds/submissions_by_status.html
+++ b/hypha/apply/funds/templates/funds/submissions_by_status.html
@@ -1,5 +1,5 @@
 {% extends "funds/base_submissions_table.html" %}
-{% load render_bundle from webpack_loader %}
+{% load render_bundle from webpack_tags %}
 
 {% block title %}{{ status }}{% endblock %}
 

--- a/hypha/apply/utils/templatetags/webpack_tags.py
+++ b/hypha/apply/utils/templatetags/webpack_tags.py
@@ -1,0 +1,18 @@
+from django import template
+from django.conf import settings
+from webpack_loader.templatetags import webpack_loader
+
+register = template.Library()
+
+
+@register.simple_tag
+def render_bundle(bundle_name, extension=None, config='DEFAULT', attrs=''):
+    """
+    Render webpack bundle if enabled in settings.
+
+    Passes the options to actual `render_bundle` template tag provided by `webpack_loader`.
+    Use this instead of `webpack_loader`.
+    """
+    if settings.ENABLE_WEBPACK_BUNDLES:
+        return webpack_loader.render_bundle(bundle_name, extension, config, attrs)
+    return ''

--- a/hypha/apply/utils/tests/test_templatetags.py
+++ b/hypha/apply/utils/tests/test_templatetags.py
@@ -1,0 +1,26 @@
+from unittest import mock
+
+from django.test import SimpleTestCase, override_settings
+
+from hypha.apply.utils.templatetags.webpack_tags import render_bundle
+
+
+class WebpackTagsTestCase(SimpleTestCase):
+
+    @override_settings(ENABLE_WEBPACK_BUNDLES=True)
+    def test_render_bundle_calls_webpack_loader_when_enabled(self):
+        render_bundle_path = 'hypha.apply.utils.templatetags.webpack_tags.webpack_loader.render_bundle'
+
+        with mock.patch(render_bundle_path, return_value='foo.js') as mocked_render_bundle:
+            self.assertEqual(render_bundle('foo', 'js'), 'foo.js')
+
+            mocked_render_bundle.assert_called_once_with('foo', 'js', 'DEFAULT', '')
+
+    @override_settings(ENABLE_WEBPACK_BUNDLES=False)
+    def test_render_bundle_does_not_call_webpack_loader_when_disabled(self):
+        render_bundle_path = 'hypha.apply.utils.templatetags.webpack_tags.webpack_loader.render_bundle'
+
+        with mock.patch(render_bundle_path, return_value='foo.js') as mocked_render_bundle:
+            self.assertEqual(render_bundle('foo', 'js'), '')
+
+            self.assertFalse(mocked_render_bundle.called)

--- a/hypha/settings/base.py
+++ b/hypha/settings/base.py
@@ -660,7 +660,9 @@ REFERRER_POLICY = env.get('SECURE_REFERRER_POLICY',
 
 # Webpack bundle loader
 # When disabled, all included bundles are silently ignored.
-ENABLE_WEBPACK_BUNDLES = True
+if env.get('ENABLE_WEBPACK_BUNDLES', 'true').lower().strip() == 'true':
+    ENABLE_WEBPACK_BUNDLES = True
+
 WEBPACK_LOADER = {
     'DEFAULT': {
         'BUNDLE_DIR_NAME': 'app/',

--- a/hypha/settings/base.py
+++ b/hypha/settings/base.py
@@ -139,7 +139,6 @@ INSTALLED_APPS = [
     'hijack',
     'compat',
     'pagedown',
-    'webpack_loader',
 
     'salesforce',
 
@@ -659,6 +658,9 @@ if env.get('COOKIE_SECURE', 'false').lower().strip() == 'true':
 REFERRER_POLICY = env.get('SECURE_REFERRER_POLICY',
                           'no-referrer-when-downgrade').strip()
 
+# Webpack bundle loader
+# When disabled, all included bundles are silently ignored.
+ENABLE_WEBPACK_BUNDLES = True
 WEBPACK_LOADER = {
     'DEFAULT': {
         'BUNDLE_DIR_NAME': 'app/',


### PR DESCRIPTION
Fixes #2250 

## Problem

Node/Webpack is needed to access pages which implement part of their functionality in React. 

E.g. Submissions have table view which is rendered using Django, it cannot be viewed without webpack/building js.

## Solution

Add a new `render_bundle` template tag which conditionally renders webpack-loader bundles based on `ENABLE_WEBPACK_BUNDLES` setting.

When disabled, it makes the React/Webpack loaded parts disappear.

## Demo

https://user-images.githubusercontent.com/7877501/119476186-7494ef00-bd6b-11eb-800a-57ac2f938301.mp4
