### PR TITLE
Create webpack.static.dev config file for local dev

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -73,6 +73,7 @@ sass.compiler = require('sass');
 
 // Load webpack config
 var webpackDev = () => require(options.theme.app + 'webpack.dev.config.js');
+var webpackStaticDev = () => require(options.theme.app + 'webpack.static.dev.config.js');
 var webpackProd = () => require(options.theme.app + 'webpack.prod.config.js');
 var webpackAnalyze = () => require(options.theme.app + 'webpack.analyze.config.js');
 
@@ -178,7 +179,7 @@ gulp.task('scripts:production', gulp.series('clean:js', function js () {
 // Build App.
 gulp.task('app', function() {
     return gulp.src(options.theme.app + 'src/')
-        .pipe(webpackStrm( webpackDev() ))
+        .pipe(webpackStrm( webpackStaticDev() ))
         .pipe(gulp.dest(options.theme.app_dest));
 })
 

--- a/hypha/static_src/src/app/webpack.static.dev.config.js
+++ b/hypha/static_src/src/app/webpack.static.dev.config.js
@@ -1,0 +1,25 @@
+var webpack = require('webpack')
+var BundleTracker = require('webpack-bundle-tracker')
+
+var config = require('./webpack.base.config.js')
+
+staticDevConfig = config('production')
+
+staticDevConfig.output.path = require('path').resolve('./assets/dist')
+
+staticDevConfig.plugins = staticDevConfig.plugins.concat([
+    new BundleTracker({ filename: './hypha/static_compiled/app/webpack-stats.json' }),
+    new webpack.EnvironmentPlugin({
+        NODE_ENV: 'production',
+        API_BASE_URL: null ,
+    }),
+])
+
+staticDevConfig.optimization = {}
+
+
+/**
+ * A webpack config similar to production, but produces development-oriented webpack-stats file.
+ * This makes it possible to use React application without Webpack Dev Server.
+ */
+module.exports = staticDevConfig


### PR DESCRIPTION
`gulp build` creates `webpack-stats-prod.json`, which cannot be directly used in local development because Django local settings use `webpack-stats.json` instead of `webpack-stats-prod.json`.

`gulp app` uses dev config, which requires webpack dev server to be running.

This creates a new config to generate `webpack-stats.json` file with production config and uses it in `gulp app` task.

**Testing steps**:
- Delete contents under `hypha/static_compiled`
- View Submissions page, you'll see webapck error
- Run `gulp app`
- Verify that the page works and has react components.

**Proof**:

![image](https://user-images.githubusercontent.com/7877501/119809421-b99f5980-bf02-11eb-850a-989ef0120f79.png)
![image](https://user-images.githubusercontent.com/7877501/119809437-c15efe00-bf02-11eb-9857-85c53529408d.png)
