### PR TITLE
fix: Project table filter's broken dropdown

### DIFF
--- a/hypha/apply/projects/filters.py
+++ b/hypha/apply/projects/filters.py
@@ -43,9 +43,9 @@ class ProjectListFilter(filters.FilterSet):
         (1, 'Behind schedule'),
     )
 
-    fund = Select2ModelMultipleChoiceFilter(label='Funds', queryset=get_used_funds)
-    lead = Select2ModelMultipleChoiceFilter(label='Lead', queryset=get_project_leads)
-    status = Select2MultipleChoiceFilter(label='Status', choices=PROJECT_STATUS_CHOICES)
+    project_fund = Select2ModelMultipleChoiceFilter(label='Funds', queryset=get_used_funds)
+    project_lead = Select2ModelMultipleChoiceFilter(label='Lead', queryset=get_project_leads)
+    project_status = Select2MultipleChoiceFilter(label='Status', choices=PROJECT_STATUS_CHOICES)
     query = filters.CharFilter(field_name='title', lookup_expr="icontains", widget=forms.HiddenInput)
     reporting = filters.ChoiceFilter(
         choices=REPORTING_CHOICES,
@@ -57,7 +57,7 @@ class ProjectListFilter(filters.FilterSet):
     )
 
     class Meta:
-        fields = ['status', 'lead', 'fund']
+        fields = ['project_status', 'project_lead', 'project_fund']
         model = Project
 
     def filter_reporting(self, queryset, name, value):

--- a/hypha/apply/projects/filters.py
+++ b/hypha/apply/projects/filters.py
@@ -43,9 +43,9 @@ class ProjectListFilter(filters.FilterSet):
         (1, 'Behind schedule'),
     )
 
-    project_fund = Select2ModelMultipleChoiceFilter(label='Funds', queryset=get_used_funds)
-    project_lead = Select2ModelMultipleChoiceFilter(label='Lead', queryset=get_project_leads)
-    project_status = Select2MultipleChoiceFilter(label='Status', choices=PROJECT_STATUS_CHOICES)
+    project_fund = Select2ModelMultipleChoiceFilter(field_name="submission__page", label='Funds', queryset=get_used_funds)
+    project_lead = Select2ModelMultipleChoiceFilter(field_name="lead", label='Lead', queryset=get_project_leads)
+    project_status = Select2MultipleChoiceFilter(field_name="status", label='Status', choices=PROJECT_STATUS_CHOICES)
     query = filters.CharFilter(field_name='title', lookup_expr="icontains", widget=forms.HiddenInput)
     reporting = filters.ChoiceFilter(
         choices=REPORTING_CHOICES,


### PR DESCRIPTION
Fixes #2388

As I left a [comment](https://github.com/HyphaApp/hypha/issues/2388#issuecomment-851174374) in the issue, these were getting overwritten because of their same names for django-filter. I tried to look into its templates code as well but I found this clue via its html(inspect, select's id and name).

Broken Filters Behaviour:
![image](https://user-images.githubusercontent.com/23638629/120203387-491b7400-c245-11eb-8e09-35ca4cbd4c90.png)


Fixed Behaviour:
![image](https://user-images.githubusercontent.com/23638629/120203804-b8916380-c245-11eb-8a19-fc0cd24fb863.png)

