### PR TITLE
Add Timestamp for Upload Documents in Submission Details

### DIFF
--- a/hypha/apply/funds/models/mixins.py
+++ b/hypha/apply/funds/models/mixins.py
@@ -1,3 +1,5 @@
+from datetime import datetime
+
 from django.core.files import File
 from django.utils.safestring import mark_safe
 from django_file_form.models import PlaceholderUploadedFile
@@ -56,6 +58,7 @@ class AccessFormData:
         if isinstance(file, cls.stream_file_class):
             return file
         if isinstance(file, File):
+            file.name = datetime.now().strftime("%y%m%d") + "-" + file.name
             return cls.stream_file_class(instance, field, file, name=file.name, storage=cls.storage_class())
 
         if isinstance(file, PlaceholderUploadedFile):

--- a/hypha/apply/funds/models/mixins.py
+++ b/hypha/apply/funds/models/mixins.py
@@ -1,5 +1,3 @@
-from datetime import datetime
-
 from django.core.files import File
 from django.utils.safestring import mark_safe
 from django_file_form.models import PlaceholderUploadedFile
@@ -58,7 +56,6 @@ class AccessFormData:
         if isinstance(file, cls.stream_file_class):
             return file
         if isinstance(file, File):
-            file.name = datetime.now().strftime("%y%m%d") + "-" + file.name
             return cls.stream_file_class(instance, field, file, name=file.name, storage=cls.storage_class())
 
         if isinstance(file, PlaceholderUploadedFile):

--- a/hypha/apply/stream_forms/files.py
+++ b/hypha/apply/stream_forms/files.py
@@ -79,6 +79,10 @@ class StreamFieldFile(File):
             return self.file.size
         return self.storage.size(self.name)
 
+    @property
+    def modification_time(self):
+        return self.storage.get_modified_time(self.name).date()
+
     def serialize(self):
         return {
             'url': self.url,

--- a/hypha/apply/stream_forms/templates/stream_forms/includes/file_field.html
+++ b/hypha/apply/stream_forms/templates/stream_forms/includes/file_field.html
@@ -1,6 +1,7 @@
 <a class="link link--download" href="{{ file.url }}" target="_blank" rel="noopener noreferrer">
     <div>
         <svg><use xlink:href="#file"></use></svg>
+        <span>{{ file.modification_time }}</span>
         <span>{{ file.filename }}</span>
     </div>
     <svg><use xlink:href="#download"></use></svg>


### PR DESCRIPTION
Fixes #2344 

As we know, adding the upload timestamp will help someone who will be looking/reviewing the application. So, we didn't change the filename but we added the file last modification/creation date just before the filename on the submission details page so that a Manager or a Reviewer can see when these files got uploaded.

We didn't change the filename because from the user perspective, we are not sure if adding a date to the filename will help but it might create some confusion because of the complex name. 

It is simply looking like this.
![image](https://user-images.githubusercontent.com/23638629/121369958-ecf9d380-c959-11eb-8f0e-c20c0ebd0ae3.png)

