### PR TITLE
fix: Make filters' row scrollable, to avoid overflow issue

### DIFF
--- a/hypha/static_src/src/sass/apply/components/_form.scss
+++ b/hypha/static_src/src/sass/apply/components/_form.scss
@@ -164,6 +164,7 @@
             padding: 10px 0 30px;
             opacity: 0;
             transition: opacity $transition;
+            overflow: auto;
 
             .filters-open & {
                 opacity: 1;


### PR DESCRIPTION
Fixes #2432 

![Peek 2021-06-18 17-31](https://user-images.githubusercontent.com/23638629/122559882-86fa0400-d05d-11eb-96f9-91126276e617.gif)

The filter row was getting overflow, that's why I set `overflow: auto` to make it scrollable horizontally. So, it will be easily accessible and will not break any functionality.