### PR TITLE
Replace -placeholder with -uploads

### DIFF
--- a/hypha/apply/funds/views.py
+++ b/hypha/apply/funds/views.py
@@ -942,7 +942,7 @@ class BaseSubmissionEditView(UpdateView):
         instance = kwargs.pop('instance').from_draft()
         initial = instance.raw_data
         for field_id in instance.file_field_ids:
-            initial.pop(field_id + '-placeholder', False)
+            initial.pop(field_id + '-uploads', False)
             initial[field_id] = self.get_placeholder_file(
                 instance.raw_data.get(field_id)
             )

--- a/hypha/apply/stream_forms/fields.py
+++ b/hypha/apply/stream_forms/fields.py
@@ -3,7 +3,7 @@ from django.contrib.staticfiles.templatetags.staticfiles import static
 from django.core.validators import FileExtensionValidator
 from django.forms import FileField, Media
 from django.utils.functional import cached_property
-from django_file_form.forms import MultipleUploadedFileField, UploadedFileField
+from django_file_form.fields import MultipleUploadedFileField, UploadedFileField
 from django_file_form.widgets import UploadMultipleWidget, UploadWidget
 
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -11,7 +11,7 @@ django-basic-auth-ip-whitelist==0.3.4
 django-bleach==0.6.1
 django-countries==7.0
 django-extensions==3.1.0
-django-file-form==3.1.3
+django-file-form==3.2.2
 django-filter==2.4.0
 django-fsm==2.7.1
 django-heroku==0.3.1


### PR DESCRIPTION
Fixes #2430

[Uploaded files' field _id](https://github.com/mbraak/django-file-form/blob/dbe8090c3f7dd3f4bb626e201335bfe06d2a2f85/django_file_form/widgets.py#L41) has changed from `field_id-placeholder` to `field_id-uploads`.
