### PR TITLE
Bugfix: Determination creation UI does not use default messages

### DIFF
--- a/hypha/apply/determinations/models.py
+++ b/hypha/apply/determinations/models.py
@@ -197,6 +197,9 @@ class DeterminationMessageSettings(BaseSetting):
         message_templates = {}
         prefix = f"{stage_name.lower()}_"
 
+        # requests and external requests use the same messages.
+        prefix = prefix.replace("ext", "")
+
         for field in self._meta.get_fields():
             if prefix in field.name:
                 key = field.name.replace(prefix, '')

--- a/hypha/apply/determinations/templates/determinations/base_determination_form.html
+++ b/hypha/apply/determinations/templates/determinations/base_determination_form.html
@@ -42,7 +42,16 @@
             {% else %}
                 {{ field }}
             {% endif %}
+
         {% endfor %}
+
+        {# Set up some hidden fields that we can use to map #}
+        {# between (seemingly) random field ids and canonical names #}
+        {# that our javascript can use. #}
+        {% for k, v in form_field_id_to_name.items %}
+            <input type=hidden id="id_{{v}}" name="id_{{v}}" value="{{k}}"/>
+        {% endfor %}
+
         {% block form_buttons %}
             {% if form.draft_button_name %}
                 <button class="button button--submit button--top-space button--white" type="submit" name="{{ form.draft_button_name }}" formnovalidate>Save Draft</button>
@@ -52,7 +61,6 @@
     </form>
     {% for type, message in message_templates.items %}
         <div class="is-hidden" data-type="{{ type }}" id="determination-message-{{ type }}">
-            <h1>message</h1>
             {{ message|bleach }}
         </div>
     {% endfor %}
@@ -61,5 +69,5 @@
 {% endblock %}
 
 {% block extra_js %}
-    {# Skip this until the script is improved. <script src="{% static 'js/apply/determination-template.js' %}"></script> #}
+    <script src="{% static 'js/apply/determination-template.js' %}"></script>
 {% endblock %}

--- a/hypha/apply/determinations/views.py
+++ b/hypha/apply/determinations/views.py
@@ -279,6 +279,7 @@ class DeterminationCreateOrUpdateView(BaseStreamForm, CreateOrUpdateView):
         return self.model.objects.get(submission=self.submission, is_draft=True)
 
     def dispatch(self, request, *args, **kwargs):
+
         self.submission = get_object_or_404(ApplicationSubmission, id=self.kwargs['submission_pk'])
 
         if not can_create_determination(request.user, self.submission):
@@ -309,9 +310,18 @@ class DeterminationCreateOrUpdateView(BaseStreamForm, CreateOrUpdateView):
         site = Site.find_for_request(self.request)
         determination_messages = DeterminationMessageSettings.for_site(site)
 
+        # Create a dict that maps between opaque field ids
+        # and canonical names for use in the template.
+        # TODO: Put this functionality higher in the class hierarchy.
+        determination_form_class = self.get_form_class()
+        form_field_id_to_name={}
+        for field_id in determination_form_class.display:
+            form_field_id_to_name[field_id] = determination_form_class.display[field_id].canonical_name
+
         return super().get_context_data(
             submission=self.submission,
             message_templates=determination_messages.get_for_stage(self.submission.stage.name),
+            form_field_id_to_name=form_field_id_to_name,
             **kwargs
         )
 

--- a/hypha/apply/stream_forms/blocks.py
+++ b/hypha/apply/stream_forms/blocks.py
@@ -39,6 +39,7 @@ class FormFieldBlock(StructBlock):
 
     field_class = forms.CharField
     widget = None
+    canonical_name = ""
 
     class Meta:
         template = 'stream_forms/render_field.html'

--- a/hypha/apply/stream_forms/models.py
+++ b/hypha/apply/stream_forms/models.py
@@ -59,6 +59,7 @@ class BaseStreamForm:
             struct_value = struct_child.value
             if isinstance(block, FormFieldBlock):
                 field_from_block = block.get_field(struct_value)
+                field_from_block.canonical_name = block.name
                 if draft and not issubclass(block.__class__, ApplicationMustIncludeFieldBlock):
                     field_from_block.required = False
                 field_from_block.help_link = struct_value.get('help_link')
@@ -100,6 +101,7 @@ class BaseStreamForm:
                 is_in_group = False
             else:
                 field_wrapper = BlockFieldWrapper(struct_child)
+                field_wrapper.canonical_name = block.name
                 field_wrapper.group_number = group_counter if is_in_group else 1
                 form_fields[struct_child.id] = field_wrapper
 

--- a/hypha/settings/base.py
+++ b/hypha/settings/base.py
@@ -522,7 +522,7 @@ SOCIAL_AUTH_PIPELINE = (
 )
 
 # Bleach Settings
-BLEACH_ALLOWED_TAGS = ['a', 'b', 'big', 'blockquote', 'br', 'cite', 'code', 'col', 'colgroup', 'dd', 'del', 'dl', 'dt', 'em', 'h2', 'h3', 'h4', 'h5', 'h6', 'hr', 'i', 'ins', 'li', 'ol', 'p', 'pre', 'small', 'span', 'strong', 'sub', 'sup', 'table', 'tbody', 'td', 'th', 'thead', 'tr', 'ul']
+BLEACH_ALLOWED_TAGS = ['a', 'b', 'big', 'blockquote', 'br', 'cite', 'code', 'col', 'colgroup', 'dd', 'del', 'dl', 'dt', 'em', 'h1', 'h2', 'h3', 'h4', 'h5', 'h6', 'hr', 'i', 'ins', 'li', 'ol', 'p', 'pre', 'small', 'span', 'strong', 'sub', 'sup', 'table', 'tbody', 'td', 'th', 'thead', 'tr', 'ul']
 
 BLEACH_ALLOWED_ATTRIBUTES = ['class', 'colspan', 'href', 'rowspan', 'target', 'title', 'width']
 

--- a/hypha/static_src/src/javascript/apply/determination-template.js
+++ b/hypha/static_src/src/javascript/apply/determination-template.js
@@ -1,12 +1,7 @@
 (function ($) {
-
     'use strict';
 
     let DeterminationCopy = class {
-        static selector() {
-            return '#id_outcome';
-        }
-
         constructor(node) {
             this.node = node[0];
             this.bindEventListeners();
@@ -14,29 +9,48 @@
 
         bindEventListeners() {
             this.node.addEventListener('change', (e) => {
-                this.getMatchingCopy(e.target.value);
+                /*
+                 * Every time there is a change to the value
+                 * in the dropdown, update the message's code
+                 * with the template message.
+                 */
+                const newContent = this.getMatchingCopy(e.target.value);
+                this.updateTextArea(newContent);
             }, false);
         }
 
         getMatchingCopy(value) {
             if (value === '0') {
-                this.text = document.querySelector('div[data-type="rejected"]').textContent;
+                return document.querySelector('div[data-type="rejected"]').innerHTML;
             }
             else if (value === '1') {
-                this.text = document.querySelector('div[data-type="more_info"]').textContent;
+                return document.querySelector('div[data-type="more_info"]').innerHTML;
             }
             else {
-                this.text = document.querySelector('div[data-type="accepted"]').textContent;
+                return document.querySelector('div[data-type="accepted"]').innerHTML;
             }
-            this.updateTextArea(this.text);
+            return "";
         }
 
         updateTextArea(text) {
-            window.tinyMCE.get('id_message').setContent(text);
+            window.tinyMCE.activeEditor.setContent(text, {format: 'html'});
         }
     };
 
-    $(DeterminationCopy.selector()).each((index, el) => {
+    /*
+     * The template that renders the determination form
+     * spits out several hidden inputs that map between
+     * a (to us) random field id and a more canonical name.
+     * We use that mapping to grab the drop-down box of the
+     * required determination field.
+     */
+    const determination_id = $("#id_determination").val();
+    $("#id_" + determination_id).each((index, el) => {
+        /*
+         * Now that we have hold of that dropdown, we add some
+         * event handlers that execute every time its value changes.
+         * (see above)
+         */
         new DeterminationCopy($(el));
     });
 


### PR DESCRIPTION
In Hypha, the user has the ability to create default determination
messages. These messages were not being properly populated in the UI
shown when creating a determination for an application. This change
fixes that bug.

Fixes #2455 
