### PR TITLE
Allow PASSWORD_RESET_TIMEOUT_DAYS to be set as an enviroment variable…

### DIFF
--- a/hypha/settings/base.py
+++ b/hypha/settings/base.py
@@ -319,7 +319,8 @@ AUTH_PASSWORD_VALIDATORS = [
 ]
 
 # Number of days that password reset and account activation links are valid (default 3).
-PASSWORD_RESET_TIMEOUT_DAYS = 8
+if 'PASSWORD_RESET_TIMEOUT_DAYS' in env:
+    PASSWORD_RESET_TIMEOUT_DAYS = int(env['PASSWORD_RESET_TIMEOUT_DAYS'])
 
 # Internationalization
 # https://docs.djangoproject.com/en/stable/topics/i18n/


### PR DESCRIPTION
…. If not set the Django default value is used.
