### PR TITLE
Remove staff reviewers for a submission

### DIFF
--- a/hypha/apply/funds/forms.py
+++ b/hypha/apply/funds/forms.py
@@ -278,7 +278,7 @@ class UpdateReviewersForm(ApplicationSubmissionModelForm):
             if reviewer:
                 AssignedReviewers.objects.update_role(role, reviewer, instance)
             else:
-                AssignedReviewers.objects.filter(role=role, submission=instance).delete()
+                AssignedReviewers.objects.filter(role=role, submission=instance, review__isnull=True).delete()
 
         # 2. Update non-role reviewers
         # 2a. Remove those not on form

--- a/hypha/apply/funds/forms.py
+++ b/hypha/apply/funds/forms.py
@@ -135,7 +135,7 @@ class UpdateSubmissionLeadForm(ApplicationSubmissionModelForm):
         kwargs.pop('user')
         super().__init__(*args, **kwargs)
         lead_field = self.fields['lead']
-        lead_field.label = f'Update lead from { self.instance.lead } to'
+        lead_field.label = _('Update lead from {lead} to').format(lead=self.instance.lead)
         lead_field.queryset = lead_field.queryset.exclude(id=self.instance.lead.id)
 
 
@@ -361,7 +361,7 @@ def make_role_reviewer_fields():
         field_name = 'role_reviewer_' + slugify(role_name)
         field = forms.ModelChoiceField(
             queryset=staff_reviewers,
-            empty_label=_("Select a reviewer"),
+            empty_label=_('-- No reviewer selected --'),
             required=False,
             label=mark_safe(render_icon(role.icon) + _('{role_name} Reviewer').format(role_name=role_name)),
         )

--- a/hypha/apply/funds/forms.py
+++ b/hypha/apply/funds/forms.py
@@ -278,6 +278,8 @@ class UpdateReviewersForm(ApplicationSubmissionModelForm):
         for role, reviewer in assigned_roles.items():
             if reviewer:
                 AssignedReviewers.objects.update_role(role, reviewer, instance)
+            else:
+                AssignedReviewers.objects.filter(role=role, submission=instance).delete()
 
         # 2. Update non-role reviewers
         # 2a. Remove those not on form
@@ -354,9 +356,7 @@ def make_role_reviewer_fields():
         field_name = 'role_reviewer_' + slugify(role_name)
         field = forms.ModelChoiceField(
             queryset=staff_reviewers,
-            widget=Select2Widget(attrs={
-                'data-placeholder': _('Select a reviewer'),
-            }),
+            empty_label=_("Select a reviewer"),
             required=False,
             label=mark_safe(render_icon(role.icon) + _('{role_name} Reviewer').format(role_name=role_name)),
         )

--- a/hypha/apply/funds/forms.py
+++ b/hypha/apply/funds/forms.py
@@ -7,7 +7,6 @@ from django import forms
 from django.utils.safestring import mark_safe
 from django.utils.text import slugify
 from django.utils.translation import gettext_lazy as _
-from django_select2.forms import Select2Widget
 
 from hypha.apply.categories.models import MetaTerm
 from hypha.apply.users.models import User


### PR DESCRIPTION
Fixes #1575 

Change widget and delete an Assigned Reviewer object if user wants to just unassign that reviewer.
Previously, Select2Widget were look like a checkbox but wasn't an actual checkbox, we were not able to unselect that. 

@frjo "Select a Reviewer" message fine to unassign the reviewer or Should I change it to "-------" or "None"?