### PR TITLE
Make review options translatable.

### DIFF
--- a/hypha/apply/review/options.py
+++ b/hypha/apply/review/options.py
@@ -1,13 +1,15 @@
+from django.utils.translation import gettext as _
+
 NA = 99
 
 RATE_CHOICES = (
-    (0, '0. Need more info'),
-    (1, '1. Poor'),
-    (2, '2. Not so good'),
-    (3, '3. Is o.k.'),
-    (4, '4. Good'),
-    (5, '5. Excellent'),
-    (NA, 'n/a - choose not to answer'),
+    (0, _('0. Need more info')),
+    (1, _('1. Poor')),
+    (2, _('2. Not so good')),
+    (3, _('3. Is o.k.')),
+    (4, _('4. Good')),
+    (5, _('5. Excellent')),
+    (NA, _('n/a - choose not to answer')),
 )
 
 RATE_CHOICES_DICT = dict(RATE_CHOICES)
@@ -18,28 +20,28 @@ MAYBE = 1
 YES = 2
 
 RECOMMENDATION_CHOICES = (
-    (NO, 'No'),
-    (MAYBE, 'Maybe'),
-    (YES, 'Yes'),
+    (NO, _('No')),
+    (MAYBE, _('Maybe')),
+    (YES, _('Yes')),
 )
 
 DISAGREE = 0
 AGREE = 1
 
 OPINION_CHOICES = (
-    (AGREE, 'Agree'),
-    (DISAGREE, 'Disagree'),
+    (AGREE, _('Agree')),
+    (DISAGREE, _('Disagree')),
 )
 
 PRIVATE = 'private'
 REVIEWER = 'reviewers'
 
 VISIBILILTY_HELP_TEXT = {
-    PRIVATE: 'Visible only to staff.',
-    REVIEWER: 'Visible to other reviewers and staff.',
+    PRIVATE: _('Visible only to staff.'),
+    REVIEWER: _('Visible to other reviewers and staff.'),
 }
 
 VISIBILITY = {
-    PRIVATE: 'Private',
-    REVIEWER: 'Reviewers and Staff',
+    PRIVATE: _('Private'),
+    REVIEWER: _('Reviewers and Staff'),
 }

--- a/hypha/locale/django.pot
+++ b/hypha/locale/django.pot
@@ -2899,11 +2899,11 @@ msgstr ""
 msgid "No, it is a personal bank account"
 msgstr ""
 
-#: hypha/apply/projects/forms/vendor.py:105
+#: hypha/apply/projects/forms/vendor.py:105 hypha/apply/review/options.py:23
 msgid "No"
 msgstr ""
 
-#: hypha/apply/projects/forms/vendor.py:105
+#: hypha/apply/projects/forms/vendor.py:105 hypha/apply/review/options.py:25
 msgid "Yes"
 msgstr ""
 
@@ -3807,6 +3807,62 @@ msgstr ""
 
 #: hypha/apply/review/models.py:165
 msgid "Visibility"
+msgstr ""
+
+#: hypha/apply/review/options.py:6
+msgid "0. Need more info"
+msgstr ""
+
+#: hypha/apply/review/options.py:7
+msgid "1. Poor"
+msgstr ""
+
+#: hypha/apply/review/options.py:8
+msgid "2. Not so good"
+msgstr ""
+
+#: hypha/apply/review/options.py:9
+msgid "3. Is o.k."
+msgstr ""
+
+#: hypha/apply/review/options.py:10
+msgid "4. Good"
+msgstr ""
+
+#: hypha/apply/review/options.py:11
+msgid "5. Excellent"
+msgstr ""
+
+#: hypha/apply/review/options.py:12
+msgid "n/a - choose not to answer"
+msgstr ""
+
+#: hypha/apply/review/options.py:24
+msgid "Maybe"
+msgstr ""
+
+#: hypha/apply/review/options.py:32
+msgid "Agree"
+msgstr ""
+
+#: hypha/apply/review/options.py:33
+msgid "Disagree"
+msgstr ""
+
+#: hypha/apply/review/options.py:40
+msgid "Visible only to staff."
+msgstr ""
+
+#: hypha/apply/review/options.py:41
+msgid "Visible to other reviewers and staff."
+msgstr ""
+
+#: hypha/apply/review/options.py:45
+msgid "Private"
+msgstr ""
+
+#: hypha/apply/review/options.py:46
+msgid "Reviewers and Staff"
 msgstr ""
 
 #: hypha/apply/review/templates/review/includes/review_button.html:8

--- a/hypha/locale/en/LC_MESSAGES/django.po
+++ b/hypha/locale/en/LC_MESSAGES/django.po
@@ -2899,11 +2899,11 @@ msgstr ""
 msgid "No, it is a personal bank account"
 msgstr ""
 
-#: hypha/apply/projects/forms/vendor.py:105
+#: hypha/apply/projects/forms/vendor.py:105 hypha/apply/review/options.py:23
 msgid "No"
 msgstr ""
 
-#: hypha/apply/projects/forms/vendor.py:105
+#: hypha/apply/projects/forms/vendor.py:105 hypha/apply/review/options.py:25
 msgid "Yes"
 msgstr ""
 
@@ -3807,6 +3807,62 @@ msgstr ""
 
 #: hypha/apply/review/models.py:165
 msgid "Visibility"
+msgstr ""
+
+#: hypha/apply/review/options.py:6
+msgid "0. Need more info"
+msgstr ""
+
+#: hypha/apply/review/options.py:7
+msgid "1. Poor"
+msgstr ""
+
+#: hypha/apply/review/options.py:8
+msgid "2. Not so good"
+msgstr ""
+
+#: hypha/apply/review/options.py:9
+msgid "3. Is o.k."
+msgstr ""
+
+#: hypha/apply/review/options.py:10
+msgid "4. Good"
+msgstr ""
+
+#: hypha/apply/review/options.py:11
+msgid "5. Excellent"
+msgstr ""
+
+#: hypha/apply/review/options.py:12
+msgid "n/a - choose not to answer"
+msgstr ""
+
+#: hypha/apply/review/options.py:24
+msgid "Maybe"
+msgstr ""
+
+#: hypha/apply/review/options.py:32
+msgid "Agree"
+msgstr ""
+
+#: hypha/apply/review/options.py:33
+msgid "Disagree"
+msgstr ""
+
+#: hypha/apply/review/options.py:40
+msgid "Visible only to staff."
+msgstr ""
+
+#: hypha/apply/review/options.py:41
+msgid "Visible to other reviewers and staff."
+msgstr ""
+
+#: hypha/apply/review/options.py:45
+msgid "Private"
+msgstr ""
+
+#: hypha/apply/review/options.py:46
+msgid "Reviewers and Staff"
 msgstr ""
 
 #: hypha/apply/review/templates/review/includes/review_button.html:8


### PR DESCRIPTION
Fixes #2559 

Makes the options displayed on the Create Review page translatable. Uses `gettext` instead of `gettext_lazy` because `VISIBILILTY_HELP_TEXT` and `VISIBILITY` are concatenated in [blocks.py](https://github.com/HyphaApp/hypha/blob/edd0879554be163a1943588e867e04eb20f8a61f/hypha/apply/review/blocks.py#L154) and that throws an error. If that causes an issue, I can try to find a workaround.