### PR TITLE
Bypass django forms widget templates

### DIFF
--- a/hypha/templates/wagtailadmin/widgets/date_input.html
+++ b/hypha/templates/wagtailadmin/widgets/date_input.html
@@ -1,0 +1,1 @@
+{% include "django/forms/widgets/input.html" %}<script>initDateChooser("{{ widget.attrs.id|escapejs }}", {{ widget.config_json|safe }});</script>

--- a/hypha/templates/wagtailadmin/widgets/datetime_input.html
+++ b/hypha/templates/wagtailadmin/widgets/datetime_input.html
@@ -1,0 +1,1 @@
+{% include "django/forms/widgets/input.html" %}<script>initDateTimeChooser("{{ widget.attrs.id|escapejs }}", {{ widget.config_json|safe }});</script>


### PR DESCRIPTION
It is a fix for a [Reset Issue](https://github.com/ResetNetwork/apply-app/issues/129#issuecomment-954761104)

Problem:  Wagtail is using django forms template. And we were overwriting django forms templates.

Solution: Bypass wagtail date and datetime templates directly to django input widget template.


@frjo Please check if it looks good to you. Now we are using wagtail default behaviour for date and datetime templates but there is no placeholder. Let me know if we need placeholder.