### PR TITLE
Add login redirect for private pages

### DIFF
--- a/hypha/apply/users/templates/users/login.html
+++ b/hypha/apply/users/templates/users/login.html
@@ -35,7 +35,9 @@
             {% include "forms/includes/field.html" %}
         {% endfor %}
         {{ form.extra_text|richtext }}
-        <p><a class="link link--small" href="{% url 'users:password_reset' %}">{% trans "Forgot your password?" %}</a></p>
+        {% if not is_public_site %}
+            <p><a class="link link--small" href="{% url 'users:password_reset' %}">{% trans "Forgot your password?" %}</a></p>
+        {% endif %}
         <button class="link link--button-secondary" type="submit">{% trans "Login" %}</button>
       {% else %}
         {{ wizard.form }}

--- a/hypha/apply/users/views.py
+++ b/hypha/apply/users/views.py
@@ -19,6 +19,7 @@ from wagtail.admin.views.account import password_management_enabled
 from wagtail.core.models import Site
 
 from hypha.apply.home.models import ApplyHomePage
+
 from .decorators import require_oauth_whitelist
 from .forms import BecomeUserForm, CustomAuthenticationForm, ProfileForm
 

--- a/hypha/apply/users/views.py
+++ b/hypha/apply/users/views.py
@@ -16,7 +16,9 @@ from hijack.views import login_with_id
 from two_factor.forms import AuthenticationTokenForm, BackupTokenForm
 from two_factor.views import LoginView as TwoFactorLoginView
 from wagtail.admin.views.account import password_management_enabled
+from wagtail.core.models import Site
 
+from hypha.apply.home.models import ApplyHomePage
 from .decorators import require_oauth_whitelist
 from .forms import BecomeUserForm, CustomAuthenticationForm, ProfileForm
 
@@ -29,6 +31,13 @@ class LoginView(TwoFactorLoginView):
         ('token', AuthenticationTokenForm),
         ('backup', BackupTokenForm),
     )
+
+    def get_context_data(self, form, **kwargs):
+        context_data = super(LoginView, self).get_context_data(form, **kwargs)
+        context_data["is_public_site"] = True
+        if Site.find_for_request(self.request) == ApplyHomePage.objects.first().get_site():
+            context_data["is_public_site"] = False
+        return context_data
 
 
 @method_decorator(login_required, name='dispatch')

--- a/hypha/settings/base.py
+++ b/hypha/settings/base.py
@@ -451,6 +451,7 @@ LOGGING = {
 
 
 # Wagtail settings
+WAGTAIL_FRONTEND_LOGIN_URL = '/login/'
 
 WAGTAIL_SITE_NAME = 'hypha'
 


### PR DESCRIPTION
Fixes #2599 

Added an extra field in context 'is_public_site' to identify the request url and hide/show reset password accordingly. Used is_public_site instead of is_apply_site to avoid the /admin/login/ issue. Because /admin/login/ endpoint is using inbuilt [LoginView](https://github.com/HyphaApp/hypha/blob/main/hypha/urls.py#L22) instead of our [customized one](https://github.com/HyphaApp/hypha/blob/main/hypha/apply/users/urls.py#L19).