### PR TITLE
Fix project status view

### DIFF
--- a/hypha/apply/projects/views/project.py
+++ b/hypha/apply/projects/views/project.py
@@ -693,7 +693,7 @@ class ProjectOverviewView(TemplateView):
             key: {
                 'name': display,
                 'count': status_counts.get(key, 0),
-                'url': reverse_lazy("funds:projects:all") + '?status=' + key,
+                'url': reverse_lazy("funds:projects:all") + '?project_status=' + key,
             }
             for key, display in PROJECT_STATUS_CHOICES
         }


### PR DESCRIPTION
Fixes the filter when doing status view of projects on the projects overview page.

<img width="684" alt="Screenshot 2021-11-23 at 3 46 56 AM" src="https://user-images.githubusercontent.com/22263040/142943379-be3091a1-7fdc-4101-9317-f270e758ee0e.png">
