### PR TITLE
Update django-webpack-loader to 1.0.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -87,7 +87,7 @@
                 "stylelint-scss": "^4.1.0",
                 "webpack": "^4.46.0",
                 "webpack-bundle-analyzer": "^3.9.0",
-                "webpack-bundle-tracker": "^0.4.3",
+                "webpack-bundle-tracker": "^1.0.0",
                 "webpack-cli": "^3.3.12",
                 "webpack-dev-server": "^3.11.3",
                 "webpack-stream": "^5.2.1"
@@ -6267,15 +6267,6 @@
             },
             "funding": {
                 "url": "https://github.com/sponsors/ljharb"
-            }
-        },
-        "node_modules/deep-extend": {
-            "version": "0.6.0",
-            "resolved": "https://registry.npmjs.org/deep-extend/-/deep-extend-0.6.0.tgz",
-            "integrity": "sha512-LOHxIOaPYdHlJRtCQfDIVZtfw/ufM8+rVj649RIHzcm/vGwQRXFt6OPqIFWsm2XEMrNIEtWR64sY1LEKD2vAOA==",
-            "dev": true,
-            "engines": {
-                "node": ">=4.0.0"
             }
         },
         "node_modules/deep-is": {
@@ -12931,6 +12922,12 @@
             "resolved": "https://registry.npmjs.org/lodash._getnative/-/lodash._getnative-3.9.1.tgz",
             "integrity": "sha1-VwvH3t5G1hzc3mh9ZdPuy6o6r/U="
         },
+        "node_modules/lodash.assign": {
+            "version": "4.2.0",
+            "resolved": "https://registry.npmjs.org/lodash.assign/-/lodash.assign-4.2.0.tgz",
+            "integrity": "sha1-DZnzzNem0mHRm9rrkkUAXShYCOc=",
+            "dev": true
+        },
         "node_modules/lodash.clone": {
             "version": "4.5.0",
             "resolved": "https://registry.npmjs.org/lodash.clone/-/lodash.clone-4.5.0.tgz",
@@ -12947,6 +12944,12 @@
             "resolved": "https://registry.npmjs.org/lodash.debounce/-/lodash.debounce-4.0.8.tgz",
             "integrity": "sha1-gteb/zCmfEAF/9XiUVMArZyk168="
         },
+        "node_modules/lodash.defaults": {
+            "version": "4.2.0",
+            "resolved": "https://registry.npmjs.org/lodash.defaults/-/lodash.defaults-4.2.0.tgz",
+            "integrity": "sha1-0JF4cW/+pN3p5ft7N/bwgCJ0WAw=",
+            "dev": true
+        },
         "node_modules/lodash.escape": {
             "version": "4.0.1",
             "resolved": "https://registry.npmjs.org/lodash.escape/-/lodash.escape-4.0.1.tgz",
@@ -12957,6 +12960,12 @@
             "version": "4.4.0",
             "resolved": "https://registry.npmjs.org/lodash.flattendeep/-/lodash.flattendeep-4.4.0.tgz",
             "integrity": "sha1-+wMJF/hqMTTlvJvsDWngAT3f7bI=",
+            "dev": true
+        },
+        "node_modules/lodash.foreach": {
+            "version": "4.5.0",
+            "resolved": "https://registry.npmjs.org/lodash.foreach/-/lodash.foreach-4.5.0.tgz",
+            "integrity": "sha1-Gmo16s5AEoDH8G3d7DUWWrJ+PlM=",
             "dev": true
         },
         "node_modules/lodash.get": {
@@ -20208,35 +20217,37 @@
             }
         },
         "node_modules/webpack-bundle-tracker": {
-            "version": "0.4.3",
-            "resolved": "https://registry.npmjs.org/webpack-bundle-tracker/-/webpack-bundle-tracker-0.4.3.tgz",
-            "integrity": "sha512-Sl/+OsNhFAH3/c6XADupRu8jLvGojfXX0pZIIm3O5ZcJqkHHqlY4nLG+NVRcbDgM/jOeWimKDGQMVEa8FBeJ2g==",
+            "version": "1.4.0",
+            "resolved": "https://registry.npmjs.org/webpack-bundle-tracker/-/webpack-bundle-tracker-1.4.0.tgz",
+            "integrity": "sha512-5dbAdtS+DbvJfXIXfCytRv5D4I2EWBdBBVOzDMpSa52goTroryWcH4lm3h2qwVqSQEgTTWCkgLGGlZYZmYRM9g==",
             "dev": true,
             "dependencies": {
-                "deep-extend": "^0.6.0",
-                "mkdirp": "^0.5.1",
-                "strip-ansi": "^5.2.0"
+                "lodash.assign": "^4.2.0",
+                "lodash.defaults": "^4.2.0",
+                "lodash.foreach": "^4.5.0",
+                "lodash.get": "^4.4.2",
+                "strip-ansi": "^6.0.0"
             }
         },
         "node_modules/webpack-bundle-tracker/node_modules/ansi-regex": {
-            "version": "4.1.0",
-            "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-4.1.0.tgz",
-            "integrity": "sha512-1apePfXM1UOSqw0o9IiFAovVz9M5S1Dg+4TrDwfMewQ6p/rmMueb7tWZjQ1rx4Loy1ArBggoqGpfqqdI4rondg==",
+            "version": "5.0.1",
+            "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+            "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
             "dev": true,
             "engines": {
-                "node": ">=6"
+                "node": ">=8"
             }
         },
         "node_modules/webpack-bundle-tracker/node_modules/strip-ansi": {
-            "version": "5.2.0",
-            "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-5.2.0.tgz",
-            "integrity": "sha512-DuRs1gKbBqsMKIZlrffwlug8MHkcnpjs5VPmL1PAh+mA30U0DTotfDZ0d2UUsXpPmPmMMJ6W773MaA3J+lbiWA==",
+            "version": "6.0.1",
+            "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+            "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
             "dev": true,
             "dependencies": {
-                "ansi-regex": "^4.1.0"
+                "ansi-regex": "^5.0.1"
             },
             "engines": {
-                "node": ">=6"
+                "node": ">=8"
             }
         },
         "node_modules/webpack-cli": {
@@ -25938,12 +25949,6 @@
                 "regexp.prototype.flags": "^1.2.0"
             }
         },
-        "deep-extend": {
-            "version": "0.6.0",
-            "resolved": "https://registry.npmjs.org/deep-extend/-/deep-extend-0.6.0.tgz",
-            "integrity": "sha512-LOHxIOaPYdHlJRtCQfDIVZtfw/ufM8+rVj649RIHzcm/vGwQRXFt6OPqIFWsm2XEMrNIEtWR64sY1LEKD2vAOA==",
-            "dev": true
-        },
         "deep-is": {
             "version": "0.1.3",
             "resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.3.tgz",
@@ -31279,6 +31284,12 @@
             "resolved": "https://registry.npmjs.org/lodash._getnative/-/lodash._getnative-3.9.1.tgz",
             "integrity": "sha1-VwvH3t5G1hzc3mh9ZdPuy6o6r/U="
         },
+        "lodash.assign": {
+            "version": "4.2.0",
+            "resolved": "https://registry.npmjs.org/lodash.assign/-/lodash.assign-4.2.0.tgz",
+            "integrity": "sha1-DZnzzNem0mHRm9rrkkUAXShYCOc=",
+            "dev": true
+        },
         "lodash.clone": {
             "version": "4.5.0",
             "resolved": "https://registry.npmjs.org/lodash.clone/-/lodash.clone-4.5.0.tgz",
@@ -31295,6 +31306,12 @@
             "resolved": "https://registry.npmjs.org/lodash.debounce/-/lodash.debounce-4.0.8.tgz",
             "integrity": "sha1-gteb/zCmfEAF/9XiUVMArZyk168="
         },
+        "lodash.defaults": {
+            "version": "4.2.0",
+            "resolved": "https://registry.npmjs.org/lodash.defaults/-/lodash.defaults-4.2.0.tgz",
+            "integrity": "sha1-0JF4cW/+pN3p5ft7N/bwgCJ0WAw=",
+            "dev": true
+        },
         "lodash.escape": {
             "version": "4.0.1",
             "resolved": "https://registry.npmjs.org/lodash.escape/-/lodash.escape-4.0.1.tgz",
@@ -31305,6 +31322,12 @@
             "version": "4.4.0",
             "resolved": "https://registry.npmjs.org/lodash.flattendeep/-/lodash.flattendeep-4.4.0.tgz",
             "integrity": "sha1-+wMJF/hqMTTlvJvsDWngAT3f7bI=",
+            "dev": true
+        },
+        "lodash.foreach": {
+            "version": "4.5.0",
+            "resolved": "https://registry.npmjs.org/lodash.foreach/-/lodash.foreach-4.5.0.tgz",
+            "integrity": "sha1-Gmo16s5AEoDH8G3d7DUWWrJ+PlM=",
             "dev": true
         },
         "lodash.get": {
@@ -37084,29 +37107,31 @@
             }
         },
         "webpack-bundle-tracker": {
-            "version": "0.4.3",
-            "resolved": "https://registry.npmjs.org/webpack-bundle-tracker/-/webpack-bundle-tracker-0.4.3.tgz",
-            "integrity": "sha512-Sl/+OsNhFAH3/c6XADupRu8jLvGojfXX0pZIIm3O5ZcJqkHHqlY4nLG+NVRcbDgM/jOeWimKDGQMVEa8FBeJ2g==",
+            "version": "1.4.0",
+            "resolved": "https://registry.npmjs.org/webpack-bundle-tracker/-/webpack-bundle-tracker-1.4.0.tgz",
+            "integrity": "sha512-5dbAdtS+DbvJfXIXfCytRv5D4I2EWBdBBVOzDMpSa52goTroryWcH4lm3h2qwVqSQEgTTWCkgLGGlZYZmYRM9g==",
             "dev": true,
             "requires": {
-                "deep-extend": "^0.6.0",
-                "mkdirp": "^0.5.1",
-                "strip-ansi": "^5.2.0"
+                "lodash.assign": "^4.2.0",
+                "lodash.defaults": "^4.2.0",
+                "lodash.foreach": "^4.5.0",
+                "lodash.get": "^4.4.2",
+                "strip-ansi": "^6.0.0"
             },
             "dependencies": {
                 "ansi-regex": {
-                    "version": "4.1.0",
-                    "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-4.1.0.tgz",
-                    "integrity": "sha512-1apePfXM1UOSqw0o9IiFAovVz9M5S1Dg+4TrDwfMewQ6p/rmMueb7tWZjQ1rx4Loy1ArBggoqGpfqqdI4rondg==",
+                    "version": "5.0.1",
+                    "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+                    "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
                     "dev": true
                 },
                 "strip-ansi": {
-                    "version": "5.2.0",
-                    "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-5.2.0.tgz",
-                    "integrity": "sha512-DuRs1gKbBqsMKIZlrffwlug8MHkcnpjs5VPmL1PAh+mA30U0DTotfDZ0d2UUsXpPmPmMMJ6W773MaA3J+lbiWA==",
+                    "version": "6.0.1",
+                    "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+                    "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
                     "dev": true,
                     "requires": {
-                        "ansi-regex": "^4.1.0"
+                        "ansi-regex": "^5.0.1"
                     }
                 }
             }

--- a/package.json
+++ b/package.json
@@ -89,7 +89,7 @@
         "stylelint-scss": "^4.1.0",
         "webpack": "^4.46.0",
         "webpack-bundle-analyzer": "^3.9.0",
-        "webpack-bundle-tracker": "^0.4.3",
+        "webpack-bundle-tracker": "^1.0.0",
         "webpack-cli": "^3.3.12",
         "webpack-dev-server": "^3.11.3",
         "webpack-stream": "^5.2.1"

--- a/requirements.txt
+++ b/requirements.txt
@@ -27,7 +27,7 @@ django-storages==1.12.3
 django-tables2==2.4.1
 django-tinymce==3.4.0
 django-two-factor-auth==1.13.1
-django-webpack-loader==0.7.0
+django-webpack-loader==1.0.0
 django==2.2.26
 djangorestframework-api-key==2.1.0
 djangorestframework==3.12.4


### PR DESCRIPTION
Fixes #2527 

Update `webpack-bundle-tracker` to 1.0.0 as a dependency for `django-webpack-loader @1.0.0`. As it mentioned [here](https://github.com/django-webpack/django-webpack-loader#migrating-from-version--100).