### PR TITLE
Parse locale for currency lookup with dash separator

### DIFF
--- a/hypha/apply/projects/forms/vendor.py
+++ b/hypha/apply/projects/forms/vendor.py
@@ -1,7 +1,7 @@
 import datetime
 from operator import itemgetter
 
-from babel.core import get_global, Locale
+from babel.core import Locale, get_global
 from babel.numbers import get_currency_name, get_territory_currencies
 from django import forms
 from django.conf import settings

--- a/hypha/apply/projects/forms/vendor.py
+++ b/hypha/apply/projects/forms/vendor.py
@@ -1,7 +1,7 @@
 import datetime
 from operator import itemgetter
 
-from babel.core import get_global
+from babel.core import get_global, Locale
 from babel.numbers import get_currency_name, get_territory_currencies
 from django import forms
 from django.conf import settings
@@ -83,7 +83,7 @@ class CreateVendorFormStep3(FileFormMixin, BaseVendorForm, forms.Form):
 
 class CreateVendorFormStep4(BaseVendorForm, forms.Form):
     CURRENCY_CHOICES = [
-        (currency, f'{get_currency_name(currency, locale=settings.LANGUAGE_CODE)} - {currency}')
+        (currency, f'{get_currency_name(currency, locale=Locale.parse(settings.LANGUAGE_CODE, sep="-"))} - {currency}')
         for currency in get_active_currencies()
     ]
 
@@ -116,7 +116,7 @@ class CreateVendorFormStep5(BaseVendorForm, forms.Form):
 
 class CreateVendorFormStep6(BaseVendorForm, forms.Form):
     CURRENCY_CHOICES = [
-        (currency, f'{get_currency_name(currency, locale=settings.LANGUAGE_CODE)} - {currency}')
+        (currency, f'{get_currency_name(currency, locale=Locale.parse(settings.LANGUAGE_CODE, sep="-"))} - {currency}')
         for currency in get_active_currencies()
     ]
     branch_address = AddressField()


### PR DESCRIPTION
Changes locale parsing for currency lookup to recognize dash separator, consistent with other parts of Hypha.

Fixes #2712 