### PR TITLE
Add .editorconfig

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,9 @@
+root = true
+
+[*]
+charset = utf-8
+end_of_line = lf
+indent_size = 4
+indent_style = space
+insert_final_newline = true
+trim_trailing_whitespace = true


### PR DESCRIPTION
Fixes #2716 

This PR adds an editorconfig definition for the repository

[Editorconfig](https://editorconfig.org/) is a standard that helps editors know what whitespace rules
to follow for a given project.

These rules were determined based on inspection of the existing code
base; it appears that we use 2 spaces for everything except python and
json files.
