### PR TITLE
Ensure errors are on top

### DIFF
--- a/hypha/static_src/src/sass/apply/components/_form.scss
+++ b/hypha/static_src/src/sass/apply/components/_form.scss
@@ -415,6 +415,7 @@
         margin: 20px 0 0;
         color: $color--white;
         background: $color--error;
+        z-index: 1;
 
         @include media-query(tablet-landscape) {
             position: absolute;

--- a/hypha/static_src/src/sass/public/components/_form.scss
+++ b/hypha/static_src/src/sass/public/components/_form.scss
@@ -389,6 +389,7 @@
         margin: 20px 0 0;
         color: $color--white;
         background: $color--error;
+        z-index: 1;
 
         @include media-query(tablet-landscape) {
             position: absolute;


### PR DESCRIPTION
Fixes #2718

This PR adds a z-index to error messages to ensure they are rendered on top of all other HTML elements.