### PR TITLE
Hide the Dashboard "admin" button for users without wagtail admin access

### DIFF
--- a/hypha/apply/dashboard/templates/dashboard/dashboard.html
+++ b/hypha/apply/dashboard/templates/dashboard/dashboard.html
@@ -14,10 +14,12 @@
         {% block page_header %}
             <h1 class="gamma heading heading--no-margin heading--bold">{% trans "Dashboard" %}</h1>
         {% endblock %}
-        <a href="{% url 'wagtailadmin_home' %}" class="button button--primary button--arrow-pixels-white">
-            {% trans "Apply admin" %}
-            <svg><use xlink:href="#arrow-head-pixels--solid"></use></svg>
-        </a>
+        {% if has_wagtail_admin_access %}
+            <a href="{% url 'wagtailadmin_home' %}" id="wagtail-admin-button" class="button button--primary button--arrow-pixels-white">
+                {% trans "Apply admin" %}
+                <svg><use xlink:href="#arrow-head-pixels--solid"></use></svg>
+            </a>
+        {% endif %}
     </div>
 </div>
 <div class="wrapper wrapper--large wrapper--inner-space-medium">

--- a/hypha/apply/dashboard/tests/test_views.py
+++ b/hypha/apply/dashboard/tests/test_views.py
@@ -19,6 +19,9 @@ from hypha.apply.users.tests.factories import (
     GroupFactory,
     ReviewerFactory,
     StaffFactory,
+    StaffWithWagtailAdminAccessFactory,
+    StaffWithoutWagtailAdminAccessFactory,
+    AdminFactory,
 )
 from hypha.apply.utils.testing.tests import BaseViewTestCase
 
@@ -148,6 +151,25 @@ class TestStaffDashboard(BaseViewTestCase):
         self.assertContains(response, "Projects awaiting approval")
 
 
+class TestStaffDashboardWithWagtailAdminRights(BaseViewTestCase):
+    user_factory = StaffWithWagtailAdminAccessFactory
+    url_name = 'dashboard:{}'
+    base_view_name = 'dashboard'
+
+    def test_does_show_admin_button_to_staff_with_wagtail_admin_access(self):
+        response = self.get_page()
+        self.assertContains(response, 'wagtail-admin-button')
+
+
+class TestStaffDashboardWithoutWagtailAdminRights(BaseViewTestCase):
+    user_factory = StaffWithoutWagtailAdminAccessFactory
+    url_name = 'dashboard:{}'
+    base_view_name = 'dashboard'
+    def test_doesnt_show_admin_button_to_staff_without_wagtail_admin_access(self):
+        response = self.get_page()
+        self.assertNotContains(response, 'wagtail-admin-button')
+
+
 class TestReviewerDashboard(BaseViewTestCase):
     user_factory = ReviewerFactory
     url_name = 'dashboard:{}'
@@ -171,3 +193,13 @@ class TestReviewerDashboard(BaseViewTestCase):
         response = self.get_page()
         self.assertNotContains(response, submission.title)
         self.assertEquals(response.context['in_review_count'], 0)
+
+
+class TestAdminDashboard(BaseViewTestCase):
+    user_factory = AdminFactory
+    url_name = 'dashboard:{}'
+    base_view_name = 'dashboard'
+
+    def test_does_show_admin_button_to_admins(self):
+        response = self.get_page()
+        self.assertContains(response, 'wagtail-admin-button')

--- a/hypha/apply/dashboard/views.py
+++ b/hypha/apply/dashboard/views.py
@@ -69,9 +69,13 @@ class AdminDashboardView(MyFlaggedMixin, TemplateView):
             'projects_to_approve': self.projects_to_approve(),
             'rounds': self.rounds(),
             'my_flagged': self.my_flagged(submissions),
+            'has_wagtail_admin_access': self.has_wagtail_admin_access(),
         })
 
         return context
+
+    def has_wagtail_admin_access(self):
+        return self.request.user.has_perm('wagtailadmin.access_admin')
 
     def awaiting_reviews(self, submissions):
         submissions = submissions.in_review_for(self.request.user).order_by('-submit_time')

--- a/hypha/apply/users/tests/factories.py
+++ b/hypha/apply/users/tests/factories.py
@@ -1,6 +1,7 @@
 import uuid
 
 import factory
+from django.contrib.auth.models import Permission
 from django.contrib.auth import get_user_model
 from django.contrib.auth.models import Group
 from django.utils.text import slugify
@@ -65,6 +66,32 @@ class StaffFactory(OAuthUserFactory):
     def groups(self, create, extracted, **kwargs):
         if create:
             self.groups.add(GroupFactory(name=STAFF_GROUP_NAME))
+
+
+def get_wagtail_admin_access_permission():
+    return Permission.objects.get(
+        content_type__app_label='wagtailadmin',
+        codename='access_admin'
+    )
+
+
+class StaffWithWagtailAdminAccessFactory(StaffFactory):
+    @factory.post_generation
+    def groups(self, create, extracted, **kwargs):
+        if create:
+            modifiedStaffGroup = GroupFactory(name=STAFF_GROUP_NAME)
+            wagtail_admin_access_permission = get_wagtail_admin_access_permission()
+            modifiedStaffGroup.permissions.add(wagtail_admin_access_permission)
+            self.groups.add(modifiedStaffGroup)
+
+class StaffWithoutWagtailAdminAccessFactory(StaffFactory):
+    @factory.post_generation
+    def groups(self, create, extracted, **kwargs):
+        if create:
+            modifiedStaffGroup = GroupFactory(name=STAFF_GROUP_NAME)
+            wagtail_admin_access_permission = get_wagtail_admin_access_permission()
+            modifiedStaffGroup.permissions.remove(wagtail_admin_access_permission)
+            self.groups.add(modifiedStaffGroup)
 
 
 class FinanceFactory(OAuthUserFactory):

--- a/hypha/apply/users/tests/factories.py
+++ b/hypha/apply/users/tests/factories.py
@@ -48,7 +48,7 @@ class OAuthUserFactory(UserFactory):
 
 
 class AdminFactory(UserFactory):
-    is_admin = True
+    is_superuser = True
 
 
 class StaffFactory(OAuthUserFactory):


### PR DESCRIPTION
Fixes #2724

This PR removes the "Admin" button on the dashboard for users who don't actually have access to the administrative interface.

Writing tests for this involved needing to create new factories to generate users with groups that had explicitly modified permissions; if there is a better way to accomplish this that doesn't involve two new factories please let me know.

It also makes a very small fix to a broken test factory (necessary in order to write tests for the functionality of this PR)