### PR TITLE
Fix review sidebar item widths

### DIFF
--- a/hypha/static_src/src/app/src/components/ReviewBlock/index.js
+++ b/hypha/static_src/src/app/src/components/ReviewBlock/index.js
@@ -113,7 +113,7 @@ const ReviewBlock = ({children, recommendation, score}) => {
                     {!isNaN(parseFloat(score)) &&
                         <div>{parseFloat(score).toFixed(1)}</div>
                     }
-                    <div>Actions</div>
+                    <div></div>
                 </li>
             }
             {children}

--- a/hypha/static_src/src/sass/apply/components/_reviews-sidebar.scss
+++ b/hypha/static_src/src/sass/apply/components/_reviews-sidebar.scss
@@ -22,7 +22,7 @@
 
         @supports (display: grid) {
             display: grid;
-            grid-template-columns: 45% 15% 15% 25%;
+            grid-template-columns: 45% 20% 10% 25%;
             grid-gap: 5px;
         }
 

--- a/hypha/static_src/src/sass/apply/components/_reviews-sidebar.scss
+++ b/hypha/static_src/src/sass/apply/components/_reviews-sidebar.scss
@@ -22,7 +22,7 @@
 
         @supports (display: grid) {
             display: grid;
-            grid-template-columns: 45% 20% 10% 25%;
+            grid-template-columns: 45% 25% 15% 15%;
             grid-gap: 5px;
         }
 


### PR DESCRIPTION
Fixes #2729

This PR updates the widths of the "review items" sidebar so that the recommendation and score fields won't overlap.

**Before**
<img width="356" alt="image" src="https://user-images.githubusercontent.com/208884/154353049-fcde630c-4809-4f9a-8d0e-6b2051c10b19.png">


**After**
<img width="356" alt="image" src="https://user-images.githubusercontent.com/208884/154352895-c0af043a-82dd-45b6-a59b-3f39d4624876.png">

