### PR TITLE
Replace reviewer toggle label

### DIFF
--- a/hypha/apply/funds/templates/funds/includes/review_sidebar.html
+++ b/hypha/apply/funds/templates/funds/includes/review_sidebar.html
@@ -24,7 +24,7 @@
             {% if reviewer_type.name in hidden_types %}
                 {% include 'funds/includes/review_sidebar_item.html' with reviewer=reviewer hidden=True %}
                 {% if forloop.last %}
-                    <li><a class="link link--bold link--underlined js-toggle-reviewers" href="#">{% trans "All Assigned Advisors" %}</a></li>
+                    <li><a class="link link--bold link--underlined js-toggle-reviewers" href="#">{% trans "All Assigned Reviewers" %}</a></li>
                 {% endif %}
              {% else %}
                 {% include 'funds/includes/review_sidebar_item.html' with reviewer=reviewer %}

--- a/hypha/locale/django.pot
+++ b/hypha/locale/django.pot
@@ -2193,7 +2193,7 @@ msgid "No staff reviewers yet"
 msgstr ""
 
 #: hypha/apply/funds/templates/funds/includes/review_sidebar.html:27
-msgid "All Assigned Advisors"
+msgid "All Assigned Reviewers"
 msgstr ""
 
 #: hypha/apply/funds/templates/funds/includes/round-block-listing.html:33

--- a/hypha/locale/en/LC_MESSAGES/django.po
+++ b/hypha/locale/en/LC_MESSAGES/django.po
@@ -2193,7 +2193,7 @@ msgid "No staff reviewers yet"
 msgstr ""
 
 #: hypha/apply/funds/templates/funds/includes/review_sidebar.html:27
-msgid "All Assigned Advisors"
+msgid "All Assigned Reviewers"
 msgstr ""
 
 #: hypha/apply/funds/templates/funds/includes/round-block-listing.html:33

--- a/hypha/static_src/src/javascript/apply/toggle-reviewers.js
+++ b/hypha/static_src/src/javascript/apply/toggle-reviewers.js
@@ -11,10 +11,10 @@
         // toggle class and update text
         $(this).toggleClass('is-open');
         if ($(this).hasClass('is-open')) {
-            $(this).html('Hide All Assigned Advisors');
+            $(this).html('Hide All Assigned Reviewers');
         }
         else {
-            $(this).html('All Assigned Advisors');
+            $(this).html('All Assigned Reviewers');
         }
 
         // toggle the reviewers


### PR DESCRIPTION
Related to  #2736

This PR changes the default text for the "Show all {reviewers}" interface to reference reviewers instead of advisors.

This does NOT change the way the label is applied in order to use the django templating system / allow for localization.  That change will happen in a future PR.