### PR TITLE
Restrict the html tags in mistune by setting escape as False

### DIFF
--- a/hypha/apply/api/v1/serializers.py
+++ b/hypha/apply/api/v1/serializers.py
@@ -21,7 +21,7 @@ from hypha.apply.users.groups import PARTNER_GROUP_NAME, STAFF_GROUP_NAME
 
 User = get_user_model()
 
-markdown = mistune.create_markdown()
+markdown = mistune.create_markdown(escape=False)
 
 
 class ActionSerializer(serializers.Field):

--- a/hypha/apply/funds/templatetags/markdown_tags.py
+++ b/hypha/apply/funds/templatetags/markdown_tags.py
@@ -4,7 +4,7 @@ from django import template
 
 register = template.Library()
 
-mistune_markdown = mistune.create_markdown()
+mistune_markdown = mistune.create_markdown(escape=False)
 
 
 @register.filter


### PR DESCRIPTION
Fixes #2777 

Without any change in mistune.
<img width="765" alt="image" src="https://user-images.githubusercontent.com/23638629/158593894-15f0c7b4-3ee9-431e-b648-a85b4cdc175d.png">

With `escape=False`
<img width="765" alt="image" src="https://user-images.githubusercontent.com/23638629/158594039-220c1ad5-c7d6-4c92-ab09-683d6287a448.png">
