### PR TITLE
Fix change email error

### DIFF
--- a/hypha/apply/users/forms.py
+++ b/hypha/apply/users/forms.py
@@ -105,7 +105,8 @@ class EmailChangePasswordForm(forms.Form):
 
     def save(self, updated_email, name, slack, commit=True):
         self.user.full_name = name
-        self.user.slack = slack
+        if slack is not None:
+            self.user.slack = slack
         if commit:
             self.user.save()
         return self.user

--- a/hypha/apply/users/tests/test_forms.py
+++ b/hypha/apply/users/tests/test_forms.py
@@ -1,7 +1,7 @@
 from django.forms.models import model_to_dict
 from django.test import TestCase
 
-from ..forms import ProfileForm
+from ..forms import EmailChangePasswordForm, ProfileForm
 from .factories import StaffFactory, UserFactory
 
 
@@ -89,3 +89,18 @@ class TestStaffProfileForm(BaseTestProfileForm):
 
         self.staff.refresh_from_db()
         self.assertEqual(self.staff.slack, slack_name)
+
+
+class TestEmailChangePasswordForm(TestCase):
+    def setUp(self):
+        self.user = UserFactory()
+
+    def test_doesnt_error_on_null_slack_field(self):
+        form = EmailChangePasswordForm(self.user)
+        form.save('', '', None)
+
+    def test_can_update_slack(self):
+        slack_name = 'foobar'
+        form = EmailChangePasswordForm(self.user)
+        form.save('', '', slack_name)
+        self.assertEqual(self.user.slack, slack_name)


### PR DESCRIPTION
Fixes #2784

This PR fixes an issue where non-staff users could not change their email address.