### PR TITLE
Add a extra sass file for easy variable override

### DIFF
--- a/hypha/static_src/src/sass/apply/custom/_extra.scss
+++ b/hypha/static_src/src/sass/apply/custom/_extra.scss
@@ -1,0 +1,1 @@
+// stylelint-disable no-empty-source

--- a/hypha/static_src/src/sass/apply/main.scss
+++ b/hypha/static_src/src/sass/apply/main.scss
@@ -3,6 +3,9 @@
 @import 'abstracts/mixins';
 @import 'abstracts/variables';
 
+// Custom overrides
+@import 'custom/extra';
+
 // Base
 @import 'base/base';
 @import 'base/typography';

--- a/hypha/static_src/src/sass/public/custom/_extra.scss
+++ b/hypha/static_src/src/sass/public/custom/_extra.scss
@@ -1,0 +1,1 @@
+// stylelint-disable no-empty-source

--- a/hypha/static_src/src/sass/public/main.scss
+++ b/hypha/static_src/src/sass/public/main.scss
@@ -3,6 +3,9 @@
 @import 'abstracts/mixins';
 @import 'abstracts/variables';
 
+// Custom overrides
+@import 'custom/extra';
+
 // Base
 @import 'base/base';
 @import 'base/typography';


### PR DESCRIPTION
The custom file is loaded last to allow for overriding styles. The new extra file is loaded right after variables allowing easy override of them.