### PR TITLE
Accessibility  improvements to form fields

### DIFF
--- a/hypha/apply/templates/forms/includes/field.html
+++ b/hypha/apply/templates/forms/includes/field.html
@@ -10,6 +10,14 @@
                 <span class="form__required">*</span>
             {% endif %}
         </label>
+    {% elif widget_type == 'checkbox_select_multiple' or widget_type == 'radio_select' %}
+        <fieldset>
+            <legend class="form__question form__question--{{ field_type }} {{ widget_type }}" {% if field.field.required %}required{% endif %}>
+                <span>{{ field.label }}</span>
+                {% if field.field.required %}
+                    <span class="form__required">*</span>
+                {% endif %}
+            </legend>
     {% else %}
         <label for="{{ field.id_for_label }}" class="form__question form__question--{{ field_type }} {{ widget_type }}" {% if field.field.required %}required{% endif %}>
             <span>{{ field.label }}</span>
@@ -47,5 +55,8 @@
             </div>
         {% endif %}
     </div>
+    {% if widget_type == 'checkbox_select_multiple' or widget_type == 'radio_select' %}
+        </fieldset>
+    {% endif %}
 </div>
 {% endwith %}

--- a/hypha/static_src/src/javascript/apply/application-form.js
+++ b/hypha/static_src/src/javascript/apply/application-form.js
@@ -6,6 +6,19 @@
         var $application_form = $(this);
         var $application_form_button = $application_form.find('button[type="submit"]');
 
+        // set aria-required attribute true for required fields
+        $application_form.find('input[required]').each(function(index, input_field) {
+            input_field.setAttribute('aria-required', true)
+        })
+
+        // add label_id as aria-describedby to help texts
+        $application_form.find('.form__group').each(function(index, form_group){
+            var label_id = form_group.querySelector('label').getAttribute('for')
+            if (form_group.querySelector('.form__help')){
+                form_group.querySelector('.form__help').setAttribute('aria-describedby', label_id)
+            }
+        })
+
         // Remove the "no javascript" messages
         $('.message-no-js').detach();
 

--- a/hypha/static_src/src/javascript/apply/application-form.js
+++ b/hypha/static_src/src/javascript/apply/application-form.js
@@ -19,6 +19,17 @@
             }
         })
 
+        // set aria-invalid for field with errors
+        var $error_fields = $application_form.find('.form__error')
+        if ($error_fields.length){
+            //set focus to the first error field
+            $error_fields[0].querySelector('input').focus()
+
+            $error_fields.each(function(index, error_field){
+                error_field.querySelector('input').setAttribute('aria-invalid', true)
+            })
+        }
+
         // Remove the "no javascript" messages
         $('.message-no-js').detach();
 

--- a/hypha/static_src/src/javascript/apply/application-form.js
+++ b/hypha/static_src/src/javascript/apply/application-form.js
@@ -7,27 +7,27 @@
         var $application_form_button = $application_form.find('button[type="submit"]');
 
         // set aria-required attribute true for required fields
-        $application_form.find('input[required]').each(function(index, input_field) {
-            input_field.setAttribute('aria-required', true)
-        })
+        $application_form.find('input[required]').each(function (index, input_field) {
+            input_field.setAttribute('aria-required', true);
+        });
 
         // add label_id as aria-describedby to help texts
-        $application_form.find('.form__group').each(function(index, form_group){
-            var label_id = form_group.querySelector('label').getAttribute('for')
-            if (form_group.querySelector('.form__help')){
-                form_group.querySelector('.form__help').setAttribute('aria-describedby', label_id)
+        $application_form.find('.form__group').each(function (index, form_group) {
+            var label_id = form_group.querySelector('label').getAttribute('for');
+            if (form_group.querySelector('.form__help')) {
+                form_group.querySelector('.form__help').setAttribute('aria-describedby', label_id);
             }
-        })
+        });
 
         // set aria-invalid for field with errors
-        var $error_fields = $application_form.find('.form__error')
-        if ($error_fields.length){
-            //set focus to the first error field
-            $error_fields[0].querySelector('input').focus()
+        var $error_fields = $application_form.find('.form__error');
+        if ($error_fields.length) {
+            // set focus to the first error field
+            $error_fields[0].querySelector('input').focus();
 
-            $error_fields.each(function(index, error_field){
-                error_field.querySelector('input').setAttribute('aria-invalid', true)
-            })
+            $error_fields.each(function (index, error_field) {
+                error_field.querySelector('input').setAttribute('aria-invalid', true);
+            });
         }
 
         // Remove the "no javascript" messages

--- a/hypha/static_src/src/sass/apply/components/_form.scss
+++ b/hypha/static_src/src/sass/apply/components/_form.scss
@@ -107,7 +107,7 @@
         &--multi_file_field,
         &--single_file_field,
         &--file_field {
-            @include button($color--light-blue, $color--dark-blue);
+            @include button($color--light-blue, $color--darkest-blue);
             max-width: 290px;
             text-align: center;
             background: url('./../../images/upload.svg') $color--light-blue no-repeat 40px center;
@@ -118,7 +118,7 @@
             }
 
             &:hover {
-                background: url('./../../images/upload.svg') $color--dark-blue no-repeat 40px center;
+                background: url('./../../images/upload.svg') $color--darkest-blue no-repeat 40px center;
 
                 .no-js & {
                     background: none;
@@ -283,6 +283,12 @@
     }
 
     &__help-link {
+        a{
+            &:hover {
+                    cursor: pointer;
+                    color: $color--darkest-blue;
+            }
+        }
     }
 
     &__open-icon {

--- a/hypha/static_src/src/sass/apply/components/_form.scss
+++ b/hypha/static_src/src/sass/apply/components/_form.scss
@@ -283,10 +283,10 @@
     }
 
     &__help-link {
-        a{
+        a {
             &:hover {
-                    cursor: pointer;
-                    color: $color--darkest-blue;
+                cursor: pointer;
+                color: $color--darkest-blue;
             }
         }
     }

--- a/hypha/static_src/src/sass/normalize.scss
+++ b/hypha/static_src/src/sass/normalize.scss
@@ -229,6 +229,9 @@ button:-moz-focusring,
 
 fieldset {
   padding: 0.35em 0.75em 0.625em;
+  border-width: 1px;
+  border-style: solid;
+  border-color: #cfcfcf;
 }
 
 /**

--- a/hypha/static_src/src/sass/normalize.scss
+++ b/hypha/static_src/src/sass/normalize.scss
@@ -4,6 +4,8 @@
 /* Document
    ========================================================================== */
 
+@import 'apply/abstracts/variables';
+
 /**
  * 1. Correct the line height in all browsers.
  * 2. Prevent adjustments of font size after orientation changes in iOS.
@@ -231,7 +233,7 @@ fieldset {
   padding: 0.35em 0.75em 0.625em;
   border-width: 1px;
   border-style: solid;
-  border-color: #cfcfcf;
+  border-color: $color--mid-grey;
 }
 
 /**

--- a/hypha/static_src/src/sass/public/components/_form.scss
+++ b/hypha/static_src/src/sass/public/components/_form.scss
@@ -125,7 +125,7 @@
         &--multi_file_field,
         &--single_file_field,
         &--file_field {
-            @include button($color--light-blue, $color--dark-blue);
+            @include button($color--light-blue, $color--darkest-blue);
             max-width: 290px;
             text-align: center;
             background: url('./../../images/upload.svg') $color--light-blue no-repeat 50px center;
@@ -136,7 +136,7 @@
             }
 
             &:hover {
-                background: url('./../../images/upload.svg') $color--dark-blue no-repeat 50px center;
+                background: url('./../../images/upload.svg') $color--darkest-blue no-repeat 50px center;
 
                 .no-js & {
                     background: none;
@@ -292,6 +292,12 @@
     }
 
     &__help-link {
+        a{
+            &:hover {
+                    cursor: pointer;
+                    color: $color--darkest-blue;
+            }
+        }
     }
 
     &__open-icon {

--- a/hypha/static_src/src/sass/public/components/_form.scss
+++ b/hypha/static_src/src/sass/public/components/_form.scss
@@ -462,6 +462,10 @@
         position: relative;
         padding-left: 30px;
         cursor: pointer;
+
+        &:hover {
+            font-weight: bold;
+        }
     }
 
     [type='radio'] + label::before,

--- a/hypha/static_src/src/sass/public/components/_form.scss
+++ b/hypha/static_src/src/sass/public/components/_form.scss
@@ -292,10 +292,10 @@
     }
 
     &__help-link {
-        a{
+        a {
             &:hover {
-                    cursor: pointer;
-                    color: $color--darkest-blue;
+                cursor: pointer;
+                color: $color--darkest-blue;
             }
         }
     }

--- a/hypha/static_src/src/sass/public/components/_link.scss
+++ b/hypha/static_src/src/sass/public/components/_link.scss
@@ -6,7 +6,7 @@
     }
 
     &--button {
-        @include button($color--light-blue, $color--dark-blue);
+        @include button($color--light-blue, $color--darkest-blue);
         display: inline-block;
 
         &--narrow {


### PR DESCRIPTION
Fixes #2895 
Add description here.

Improvement areas:
- [x]  Wrap multiple radio and checkbox input fields in fieldsets. Replace use of label with legend as section header.
- [ ] Remove the extra label used for single checkboxes. It is used to easy styling but is bad for accessibility.
- [x] Make button hover states easily visible. Upload button e.g. has a hard to see hover state.
- [x] Make hover and focus state the same for all buttons and links.
- [x] Add aria-required="true" to all required fields.
- [x] Link help text form__help with field with help of aria-describedby="id-of-help-text".
- [x] Mark invalid fields with aria-invalid="true".
- [x] Set focus to first field with error.
- [x] Add a subtle highlight to label plus checkbox/radio on hover/focus. Make it easy for users to see what they are about to click on.
- [x] Add hover/foucs state to all link on forms. E.g the "See help guide…"