### PR TITLE
Fix .editorconfig for Makefile & markdown

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,3 +1,5 @@
+# EditorConfig helps developers define and maintain consistent coding styles between different editors and IDEs.
+# See: http://editorconfig.org
 root = true
 
 [*]
@@ -7,3 +9,9 @@ indent_size = 4
 indent_style = space
 insert_final_newline = true
 trim_trailing_whitespace = true
+
+[*.md]
+trim_trailing_whitespace = false
+
+[Makefile]
+indent_style = tab


### PR DESCRIPTION
Fixes None

Makefile must have tab used for indentation, while in Markdown files two trailing spaces means a linebreak.

