### PR TITLE
Fix adaptors * imports, make values of __all__ string

### DIFF
--- a/hypha/apply/activity/adapters/__init__.py
+++ b/hypha/apply/activity/adapters/__init__.py
@@ -5,9 +5,9 @@ from .emails import EmailAdapter
 from .slack import SlackAdapter
 
 __all__ = [
-    AdapterBase,
-    ActivityAdapter,
-    DjangoMessagesAdapter,
-    EmailAdapter,
-    SlackAdapter,
+    "AdapterBase",
+    "ActivityAdapter",
+    "DjangoMessagesAdapter",
+    "EmailAdapter",
+    "SlackAdapter",
 ]


### PR DESCRIPTION
Fixes - N/A

The imports in `__all__` should be in string format.
