### PR TITLE
Improve sample generator for help_text in factories

### DIFF
--- a/hypha/apply/stream_forms/testing/factories.py
+++ b/hypha/apply/stream_forms/testing/factories.py
@@ -94,7 +94,9 @@ class ParagraphBlockFactory(wagtail_factories.blocks.BlockFactory):
 class FormFieldBlockFactory(wagtail_factories.StructBlockFactory):
     default_value = factory.Faker('sentence')
     field_label = factory.Faker('sentence')
-    help_text = factory.LazyAttribute(lambda o: str(o._Resolver__step.builder.factory_meta.model))
+    help_text = factory.LazyAttribute(
+        lambda o: f"Help text for {o._Resolver__step.builder.factory_meta.model.__name__}"
+    )
 
     class Meta:
         model = stream_blocks.FormFieldBlock


### PR DESCRIPTION
Fixes: N/A

Right now, the help text generated is class representation
(e.g. “`<class 'hypha.apply.stream_forms.blocks.CharFieldBlock’>`”)

This is confusing while debugging, so replace it with a more familiar
format. `e.g. Help text for CharFieldBlock`.

See related closed issue: 
- https://github.com/HyphaApp/hypha/pull/2946