### PR TITLE
Send email when saving a submission as a draft for the first time

### DIFF
--- a/hypha/apply/activity/messaging.py
+++ b/hypha/apply/activity/messaging.py
@@ -11,8 +11,8 @@ from .options import MESSAGES  # noqa
 
 
 class MessengerBackend:
-    def __init__(self, *adpaters):
-        self.adapters = adpaters
+    def __init__(self, *adapters):
+        self.adapters = adapters
 
     def __call__(self, *args, related=None, **kwargs):
         return self.send(*args, related=related, **kwargs)

--- a/hypha/apply/activity/templates/messages/email/submission_confirmation.html
+++ b/hypha/apply/activity/templates/messages/email/submission_confirmation.html
@@ -1,7 +1,9 @@
 {% extends "messages/email/base.html" %}
 
 {% load i18n %}
-{% block content %}{% blocktrans with title=source.title %}We appreciate your {{ title }} application submission to the {{ ORG_LONG_NAME }}. We will review and reply to your submission as quickly as possible.{% endblocktrans %}
+{% block content %}{% blocktrans with title=source.title %}We appreciate your {{ title }} application submission to the {{ ORG_LONG_NAME }}.{% endblocktrans %}
+
+{% if source.is_draft %}{% trans "Please note that it is not submitted for review because it's still in draft." %} {% trans "You can access the draft at" %}: {{ request.scheme }}://{{ request.get_host }}{{ source.get_absolute_url }}{% else %}{% trans "We will review and reply to your submission as quickly as possible." %}{% endif %}
 
 {% trans "If you have any questions, please submit them here" %}: {{ request.scheme }}://{{ request.get_host }}{{ source.get_absolute_url }}#communications
 

--- a/hypha/apply/funds/models/submissions.py
+++ b/hypha/apply/funds/models/submissions.py
@@ -484,7 +484,7 @@ class ApplicationSubmission(
 
     submit_time = models.DateTimeField(verbose_name=_('submit time'), auto_now_add=False)
 
-    is_draft = False
+    _is_draft = False
 
     live_revision = models.OneToOneField(
         'ApplicationRevision',
@@ -505,6 +505,10 @@ class ApplicationSubmission(
     drupal_id = models.IntegerField(null=True, blank=True, editable=False)
 
     objects = ApplicationSubmissionQueryset.as_manager()
+
+    @property
+    def is_draft(self):
+        return self.status == DRAFT_STATE
 
     def not_progressed(self):
         return not self.next
@@ -613,12 +617,12 @@ class ApplicationSubmission(
         submission_in_db.save()
 
     def new_data(self, data):
-        self.is_draft = False
+        self._is_draft = False
         self.form_data = data
         return self
 
     def from_draft(self):
-        self.is_draft = True
+        self._is_draft = True
         self.form_data = self.deserialised_data(self, self.draft_revision.form_data, self.form_fields)
         return self
 
@@ -665,7 +669,7 @@ class ApplicationSubmission(
         elif skip_custom:
             return super().save(*args, **kwargs)
 
-        if self.is_draft:
+        if self._is_draft:
             raise ValueError('Cannot save with draft data')
 
         creating = not self.id

--- a/hypha/apply/funds/models/utils.py
+++ b/hypha/apply/funds/models/utils.py
@@ -10,7 +10,8 @@ from wagtail.admin.panels import (
 )
 from wagtail.contrib.forms.models import AbstractEmailForm
 
-from hypha.apply.activity.messaging import MESSAGES, messenger
+from hypha.apply.activity.messaging import messenger
+from hypha.apply.activity.options import MESSAGES
 from hypha.apply.stream_forms.models import AbstractStreamForm
 from hypha.apply.users.groups import (
     COMMUNITY_REVIEWER_GROUP_NAME,
@@ -104,13 +105,13 @@ class WorkflowStreamForm(WorkflowHelpers, AbstractStreamForm):  # type: ignore
     def render_landing_page(self, request, form_submission=None, *args, **kwargs):
         # We only reach this page after creation of a new submission
         # Hook in to notify about new applications
-        if not form_submission.status == DRAFT_STATE:
-            messenger(
-                MESSAGES.NEW_SUBMISSION,
-                request=request,
-                user=form_submission.user,
-                source=form_submission,
-            )
+        messenger(
+            MESSAGES.NEW_SUBMISSION,
+            request=request,
+            user=form_submission.user,
+            source=form_submission,
+        )
+
         return super().render_landing_page(request, form_submission, *args, **kwargs)
 
     content_panels = AbstractStreamForm.content_panels + [

--- a/hypha/apply/funds/tests/test_models.py
+++ b/hypha/apply/funds/tests/test_models.py
@@ -12,7 +12,7 @@ from django.urls import reverse
 
 from hypha.apply.funds.blocks import EmailBlock, FullNameBlock
 from hypha.apply.funds.models import ApplicationSubmission, Reminder
-from hypha.apply.funds.workflow import Request
+from hypha.apply.funds.workflow import DRAFT_STATE, Request
 from hypha.apply.review.options import MAYBE, NO
 from hypha.apply.review.tests.factories import ReviewFactory, ReviewOpinionFactory
 from hypha.apply.users.tests.factories import StaffFactory
@@ -464,6 +464,10 @@ class TestApplicationSubmission(TestCase):
         self.assertEqual(submission.revisions.count(), 1)
         self.assertDictEqual(submission.live_revision.form_data, submission.form_data)
 
+    def test_is_draft_property(self):
+        submission = ApplicationSubmissionFactory(status=DRAFT_STATE)
+        self.assertTrue(submission.is_draft, True)
+
     def test_can_get_draft_data(self):
         submission = ApplicationSubmissionFactory()
         title = 'My new title'
@@ -474,7 +478,7 @@ class TestApplicationSubmission(TestCase):
         draft_submission = submission.from_draft()
         self.assertDictEqual(draft_submission.form_data, submission.form_data)
         self.assertEqual(draft_submission.title, title)
-        self.assertTrue(draft_submission.is_draft, True)
+        self.assertTrue(draft_submission._is_draft, True)
 
         with self.assertRaises(ValueError):
             draft_submission.save()


### PR DESCRIPTION
Fixes: #2940

**User Story**
I submitted a draft submission as an applicant, but received no further instructions on how to access this draft.

**Suggested Solution**
Applicants will be sent an automated email notification similar to when an applicant submits an application with a url to their draft
