### PR TITLE
Fix duplicate comments in in-app feed

### DIFF
--- a/hypha/apply/activity/context_processors.py
+++ b/hypha/apply/activity/context_processors.py
@@ -5,5 +5,5 @@ def notification_context(request):
     context_data = dict()
     if hasattr(request, 'user'):
         if request.user.is_authenticated and request.user.is_apply_staff:
-            context_data['latest_notifications'] = Activity.objects.latest().order_by('-timestamp')[:5]
+            context_data['latest_notifications'] = Activity.objects.filter(current=True).latest().order_by('-timestamp')[:5]
     return context_data

--- a/hypha/apply/activity/views.py
+++ b/hypha/apply/activity/views.py
@@ -70,7 +70,7 @@ class NotificationsView(ListView):
 
     def get_queryset(self):
         # List only last 30 days' activities
-        queryset = Activity.objects.latest()
+        queryset = Activity.objects.filter(current=True).latest()
         self.filterset = self.filterset_class(self.request.GET, queryset=queryset)
         return self.filterset.qs.distinct().order_by('-timestamp')
 

--- a/hypha/apply/projects/templates/application_projects/project_detail.html
+++ b/hypha/apply/projects/templates/application_projects/project_detail.html
@@ -243,6 +243,7 @@
 
 {% block extra_js %}
     <script src="{% static 'js/apply/tabs.js' %}"></script>
+    <script src="{% static 'js/apply/edit-comment.js' %}"></script>
     <script src="{% static 'js/apply/toggle-payment-block.js' %}"></script>
     <script src="{% static 'js/apply/past-reports-pagination.js' %}"></script>
     <script src="{% static 'js/apply/report-calculator.js' %}"></script>


### PR DESCRIPTION
Fixes #2929 

Fixed two issues:
1. Fixed in-app feed to show only current activities.
2. Add `edit-comment.js` file to the project detail page, to avail the comment edit feature on the project's communication tab.