### PR TITLE
Add vscode launch config to start django debug server

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,19 @@
+{
+    // Use IntelliSense to learn about possible attributes.
+    // Hover to view descriptions of existing attributes.
+    // For more information, visit: https://go.microsoft.com/fwlink/?linkid=830387
+    "version": "0.2.0",
+    "configurations": [
+        {
+            "name": "Python: Django",
+            "type": "python",
+            "request": "launch",
+            "program": "${workspaceFolder}/manage.py",
+            "args": [
+                "runserver",
+                "0.0.0.0:8090"
+            ],
+            "django": true
+        }
+    ]
+}


### PR DESCRIPTION
This configuration allows running the Django server using `python manage.py runserver` and connects to the debugger.

This will be useful to other developers using VSCode to start the Django server and quickly debug the code.