### PR TITLE
Remove reviewers from list who opinionated but didn't submit review

### DIFF
--- a/hypha/apply/funds/models/submissions.py
+++ b/hypha/apply/funds/models/submissions.py
@@ -964,9 +964,9 @@ class AssignedReviewersQuerySet(models.QuerySet):
         ]
         return self.exclude(
             # Remove people from the list who are opinionated but
-            # didn't review, they appear elsewhere
-            opinions__isnull=False,
-            review__isnull=True,
+            # didn't submit a review, they appear elsewhere
+            Q(opinions__isnull=False) &
+            Q(Q(review__isnull=True) | Q(review__is_draft=True))
         ).annotate(
             type_order=models.Case(
                 *ordering,

--- a/hypha/apply/funds/tests/test_models.py
+++ b/hypha/apply/funds/tests/test_models.py
@@ -11,9 +11,9 @@ from django.test import TestCase, override_settings
 from django.urls import reverse
 
 from hypha.apply.funds.blocks import EmailBlock, FullNameBlock
-from hypha.apply.funds.models import ApplicationSubmission, Reminder
+from hypha.apply.funds.models import ApplicationSubmission, AssignedReviewers, Reminder
 from hypha.apply.funds.workflow import DRAFT_STATE, Request
-from hypha.apply.review.options import MAYBE, NO
+from hypha.apply.review.options import AGREE, MAYBE, NO
 from hypha.apply.review.tests.factories import ReviewFactory, ReviewOpinionFactory
 from hypha.apply.users.tests.factories import StaffFactory
 from hypha.apply.utils.testing import make_request
@@ -699,3 +699,30 @@ class TestReminderModel(TestCase):
     def test_reminder_action_message(self):
         reminder = ReminderFactory()
         self.assertEqual(reminder.action_message, Reminder.ACTION_MESSAGE[f'{reminder.action}-{reminder.medium}'])
+
+
+class TestAssignedReviewersQuerySet(TestCase):
+    def test_reviewed(self):
+        staff1 = StaffFactory()
+        staff2 = StaffFactory()
+        submission = ApplicationSubmissionFactory()
+        reviewer1 = AssignedReviewersFactory(submission=submission, reviewer=staff1)
+        reviewer2 = AssignedReviewersFactory(submission=submission, reviewer=staff2)
+        ReviewFactory(submission=submission, author=reviewer1)
+        ReviewFactory(submission=submission, is_draft=True, author=reviewer2)
+        self.assertEqual(AssignedReviewers.objects.reviewed().count(), 1)
+
+    def test_reviewed_with_review_order(self):
+        # testing the assigned reviewers count only(review_order's exclude condition)
+        staff1 = StaffFactory()
+        staff2 = StaffFactory()
+        submission = ApplicationSubmissionFactory()
+        reviewer1 = AssignedReviewersFactory(submission=submission, reviewer=staff1)
+        reviewer2 = AssignedReviewersFactory(submission=submission, reviewer=staff2)
+        review1 = ReviewFactory(submission=submission, author=reviewer1)
+        review2 = ReviewFactory(submission=submission, is_draft=True, author=reviewer2)
+        ReviewOpinionFactory(review=review1, author=reviewer2, opinion=AGREE)
+        self.assertEqual(AssignedReviewers.objects.reviewed().count(), 2)
+        self.assertEqual(AssignedReviewers.objects.reviewed().review_order().count(), 1)
+
+

--- a/hypha/apply/funds/tests/test_models.py
+++ b/hypha/apply/funds/tests/test_models.py
@@ -720,9 +720,7 @@ class TestAssignedReviewersQuerySet(TestCase):
         reviewer1 = AssignedReviewersFactory(submission=submission, reviewer=staff1)
         reviewer2 = AssignedReviewersFactory(submission=submission, reviewer=staff2)
         review1 = ReviewFactory(submission=submission, author=reviewer1)
-        review2 = ReviewFactory(submission=submission, is_draft=True, author=reviewer2)
+        ReviewFactory(submission=submission, is_draft=True, author=reviewer2)
         ReviewOpinionFactory(review=review1, author=reviewer2, opinion=AGREE)
         self.assertEqual(AssignedReviewers.objects.reviewed().count(), 2)
         self.assertEqual(AssignedReviewers.objects.reviewed().review_order().count(), 1)
-
-


### PR DESCRIPTION
Fixes #2973 

We already had a check for if a reviewer is opinionated but there is no review(null) added by the reviewer. But there is an edge case that if the reviewer has a draft review (that means not null) and opinionated another review as well, it is getting passed and causing an error. 
Now we have put the check for the draft as well.