### PR TITLE
Fix PAF admin's related forms issues

### DIFF
--- a/hypha/apply/projects/admin.py
+++ b/hypha/apply/projects/admin.py
@@ -1,8 +1,9 @@
 from wagtail.contrib.modeladmin.options import ModelAdmin, ModelAdminGroup
 
+from hypha.apply.utils.admin import ListRelatedMixin
+
 from .admin_views import CreateProjectApprovalFormView, EditProjectApprovalFormView
 from .models import DocumentCategory, ProjectApprovalForm
-from hypha.apply.utils.admin import ListRelatedMixin
 
 
 class DocumentCategoryAdmin(ModelAdmin):

--- a/hypha/apply/projects/admin.py
+++ b/hypha/apply/projects/admin.py
@@ -2,6 +2,7 @@ from wagtail.contrib.modeladmin.options import ModelAdmin, ModelAdminGroup
 
 from .admin_views import CreateProjectApprovalFormView, EditProjectApprovalFormView
 from .models import DocumentCategory, ProjectApprovalForm
+from hypha.apply.utils.admin import ListRelatedMixin
 
 
 class DocumentCategoryAdmin(ModelAdmin):
@@ -10,20 +11,17 @@ class DocumentCategoryAdmin(ModelAdmin):
     list_display = ('name', 'recommended_minimum',)
 
 
-class ProjectApprovalFormAdmin(ModelAdmin):
+class ProjectApprovalFormAdmin(ListRelatedMixin, ModelAdmin):
     model = ProjectApprovalForm
     menu_icon = 'form'
     list_display = ('name', 'used_by',)
     create_view_class = CreateProjectApprovalFormView
     edit_view_class = EditProjectApprovalFormView
 
-    def used_by(self, obj):
-        rows = list()
-        for field in ('funds', 'labs',):
-            related = ', '.join(getattr(obj, f'{field}').values_list('title', flat=True))
-            if related:
-                rows.append(related)
-        return ', '.join(rows)
+    related_models = [
+        ('applicationbaseprojectapprovalform', 'application'),
+        ('labbaseprojectapprovalform', 'lab'),
+    ]
 
 
 class ManageAdminGoup(ModelAdminGroup):


### PR DESCRIPTION
Reported in slack by @fourthletter.

Previously, we were using it as a foreign key so it was hard coded but we changed it in PR #2966 so it needs to be changed.
