### PR TITLE
Fix missing i18n tag in the fund template

### DIFF
--- a/hypha/templates/blocks/more_block.html
+++ b/hypha/templates/blocks/more_block.html
@@ -1,3 +1,4 @@
+{% load i18n %}
 <div class="more-content {{ value.more_class|slugify }}">
     <div class="wrapper wrapper--medium wrapper--bottom-space">
         {{ value.more_content }}


### PR DESCRIPTION
Fixes #3001

Adds missing `i18n` template library that has the `trans` block.
