### PR TITLE
Rename "Manage" to "Project" and move "Project Approval Forms" to "Project"

### DIFF
--- a/hypha/apply/funds/admin.py
+++ b/hypha/apply/funds/admin.py
@@ -6,7 +6,6 @@ from wagtail.contrib.modeladmin.options import ModelAdmin, ModelAdminGroup
 from hypha.apply.categories.admin import CategoryAdmin, MetaTermAdmin
 from hypha.apply.determinations.admin import DeterminationFormAdmin
 from hypha.apply.funds.models import ReviewerRole, ScreeningStatus
-from hypha.apply.projects.admin import ProjectApprovalFormAdmin
 from hypha.apply.review.admin import ReviewFormAdmin
 from hypha.apply.utils.admin import ListRelatedMixin, RelatedFormsMixin
 
@@ -170,7 +169,6 @@ class ApplyAdminGroup(ModelAdminGroup):
         ApplicationFormAdmin,
         ReviewFormAdmin,
         DeterminationFormAdmin,
-        ProjectApprovalFormAdmin,
         CategoryAdmin,
         ScreeningStatusAdmin,
         ReviewerRoleAdmin,

--- a/hypha/apply/projects/admin.py
+++ b/hypha/apply/projects/admin.py
@@ -14,6 +14,7 @@ class DocumentCategoryAdmin(ModelAdmin):
 
 class ProjectApprovalFormAdmin(ListRelatedMixin, ModelAdmin):
     model = ProjectApprovalForm
+    menu_label = 'Approval Forms'
     menu_icon = 'form'
     list_display = ('name', 'used_by',)
     create_view_class = CreateProjectApprovalFormView
@@ -25,9 +26,10 @@ class ProjectApprovalFormAdmin(ListRelatedMixin, ModelAdmin):
     ]
 
 
-class ManageAdminGoup(ModelAdminGroup):
-    menu_label = 'Manage'
-    menu_icon = 'folder-open-inverse'
+class ProjectAdminGroup(ModelAdminGroup):
+    menu_label = 'Projects'
+    menu_icon = 'duplicate'
     items = (
         DocumentCategoryAdmin,
+        ProjectApprovalFormAdmin
     )

--- a/hypha/apply/projects/wagtail_hooks.py
+++ b/hypha/apply/projects/wagtail_hooks.py
@@ -1,5 +1,5 @@
 from wagtail.contrib.modeladmin.options import modeladmin_register
 
-from .admin import ManageAdminGoup
+from .admin import ProjectAdminGroup
 
-modeladmin_register(ManageAdminGoup)
+modeladmin_register(ProjectAdminGroup)


### PR DESCRIPTION
Fixes #2981

Rename "Manage" to "Project" and move "Project Approval Forms" from "Apply" to "Project"

![image](https://user-images.githubusercontent.com/236356/196359755-eabf76d8-5e18-4d38-b34c-562507fce749.png)


cc: @aurum-linh for any documentation update.