### PR TITLE
Fix usages of dict() and list() with literal keywords

### DIFF
--- a/addressfield/fields.py
+++ b/addressfield/fields.py
@@ -19,7 +19,7 @@ ADDRESS_FIELDS_ORDER = [
 
 
 def flatten_data(data):
-    flattened = dict()
+    flattened = {}
     for d in data:
         for k, v in d.items():
             if isinstance(v, list):
@@ -47,7 +47,7 @@ class AddressField(forms.CharField):
 
         fields = flatten_data(country_data['fields'])
 
-        missing_fields = set(country_data['required']) - set(field for field, value in value.items() if value)
+        missing_fields = set(country_data['required']) - {field for field, value in value.items() if value}
         if missing_fields:
             missing_field_name = [fields[field]['label'] for field in missing_fields]
             raise ValidationError('Please provide data for: {}'.format(', '.join(missing_field_name)))

--- a/addressfield/widgets.py
+++ b/addressfield/widgets.py
@@ -45,7 +45,7 @@ class NestedMultiWidget(KeepOwnAttrsWidget, forms.MultiWidget):
 
     def decompress(self, value):
         if value:
-            decompressed = list()
+            decompressed = []
             for i, widget in enumerate(self.widgets):
                 if hasattr(widget, 'components'):
                     decompressed.append(widget.decompress(value))
@@ -55,7 +55,7 @@ class NestedMultiWidget(KeepOwnAttrsWidget, forms.MultiWidget):
         return [None] * len(self.components)
 
     def value_from_datadict(self, data, files, name):
-        value = dict()
+        value = {}
         for i, widget in enumerate(self.widgets):
             widget_value = widget.value_from_datadict(data, files, name + '_%s' % i)
             # flatten the data structure to a single dict
@@ -89,7 +89,7 @@ class AddressWidget(NestedMultiWidget):
         )
 
     def __init__(self, *args, **kwargs):
-        attrs = kwargs.get('attrs', dict())
+        attrs = kwargs.get('attrs', {})
         attrs['class'] = 'address'
         kwargs['attrs'] = attrs
         super().__init__(*args, **kwargs)

--- a/hypha/apply/activity/adapters/activity_feed.py
+++ b/hypha/apply/activity/adapters/activity_feed.py
@@ -74,7 +74,7 @@ class ActivityAdapter(AdapterBase):
             return {'visibility': TEAM}
         return {}
 
-    def reviewers_updated(self, added=list(), removed=list(), **kwargs):
+    def reviewers_updated(self, added=None, removed=None, **kwargs):
         message = [_('Reviewers updated.')]
         if added:
             message.append(_('Added:'))

--- a/hypha/apply/activity/adapters/base.py
+++ b/hypha/apply/activity/adapters/base.py
@@ -139,7 +139,7 @@ class AdapterBase:
         request,
         user,
         source,
-        sources=list(),
+        sources=[],
         related=None,
         **kwargs,
     ):

--- a/hypha/apply/activity/adapters/slack.py
+++ b/hypha/apply/activity/adapters/slack.py
@@ -169,7 +169,7 @@ class SlackAdapter(AdapterBase):
         ]
 
     def reviewers_updated(
-        self, source, link, user, added=list(), removed=list(), **kwargs
+        self, source, link, user, added=[], removed=[], **kwargs
     ):
         submission = source
         message = [
@@ -350,7 +350,7 @@ class SlackAdapter(AdapterBase):
         target_rooms = self.slack_channels(source, **kwargs)
 
         if not any(target_rooms) or not settings.SLACK_TOKEN:
-            errors = list()
+            errors = []
             if not target_rooms:
                 errors.append('Room ID')
             if not settings.SLACK_TOKEN:

--- a/hypha/apply/activity/context_processors.py
+++ b/hypha/apply/activity/context_processors.py
@@ -2,7 +2,7 @@ from .models import Activity
 
 
 def notification_context(request):
-    context_data = dict()
+    context_data = {}
     if hasattr(request, 'user'):
         if request.user.is_authenticated and request.user.is_apply_staff:
             context_data['latest_notifications'] = Activity.objects.filter(current=True).latest().order_by('-timestamp')[:5]

--- a/hypha/apply/activity/messaging.py
+++ b/hypha/apply/activity/messaging.py
@@ -24,7 +24,7 @@ class MessengerBackend:
         user,
         related,
         source=None,
-        sources=list(),
+        sources=[],
         **kwargs
     ):
         from .models import Event

--- a/hypha/apply/activity/templatetags/activity_tags.py
+++ b/hypha/apply/activity/templatetags/activity_tags.py
@@ -45,7 +45,7 @@ def display_for(activity, user):
 
     visibile_for_user = activity.visibility_for(user)
 
-    if set(visibile_for_user) & set([TEAM, REVIEWER]):
+    if set(visibile_for_user) & {TEAM, REVIEWER}:
         return message_data[TEAM]
 
     return message_data[ALL]

--- a/hypha/apply/api/v1/filters.py
+++ b/hypha/apply/api/v1/filters.py
@@ -53,7 +53,7 @@ class SubmissionsFilter(filters.FilterSet):
         model = ApplicationSubmission
         fields = ('id', 'status', 'round', 'active', 'submit_date', 'fund', 'screening_statuses', 'reviewers', 'lead')
 
-    def __init__(self, *args, exclude=list(), limit_statuses=None, **kwargs):
+    def __init__(self, *args, exclude=[], limit_statuses=None, **kwargs):
         super().__init__(*args, **kwargs)
         self.filters['category_options'].extra['choices'] = [
             (option.id, option.value)
@@ -89,7 +89,7 @@ class SubmissionsFilter(filters.FilterSet):
                     else:
                         if isinstance(category_options, str):
                             category_options = [category_options]
-                        include_in_filter = set(list(category_options)) & set(value)
+                        include_in_filter = set(category_options) & set(value)
                     # Check if filter options has any value in category options
                     # If yes then those submissions should be filtered in the list
                     if include_in_filter:
@@ -102,7 +102,7 @@ class SubmissionsFilter(filters.FilterSet):
     def filter_id(self, qs, name, value):
         if not value:
             return qs
-        return qs.filter(id__in=map(lambda x: x.id, value))
+        return qs.filter(id__in=[x.id for x in value])
 
 
 class NewerThanFilter(filters.ModelChoiceFilter):

--- a/hypha/apply/api/v1/review/serializers.py
+++ b/hypha/apply/api/v1/review/serializers.py
@@ -72,7 +72,7 @@ class SubmissionReviewSerializer(serializers.ModelSerializer):
         return instance
 
     def calculate_score(self, instance, data):
-        scores = list()
+        scores = []
         for field in instance.score_fields:
             score = data.get(field.id, ['', NA])
             # Include NA answers as 0.

--- a/hypha/apply/determinations/forms.py
+++ b/hypha/apply/determinations/forms.py
@@ -60,7 +60,7 @@ class BaseDeterminationForm:
     def get_detailed_response(cls, saved_data):
         data = {}
         for group, title in cls.titles.items():
-            data.setdefault(group, {'title': title, 'questions': list()})
+            data.setdefault(group, {'title': title, 'questions': []})
 
         for name, field in cls.base_fields.items():
             try:
@@ -321,7 +321,8 @@ class BaseProposalDeterminationForm(forms.Form):
 
 
 class ConceptDeterminationForm(BaseConceptDeterminationForm, BaseNormalDeterminationForm):
-    def __init__(self, *args, submission, user, edit=False, initial={}, instance=None, **kwargs):
+    def __init__(self, *args, submission, user, edit=False, initial=None, instance=None, **kwargs):
+        initial = initial or {}
         initial.update(submission=submission.id)
 
         if instance:

--- a/hypha/apply/determinations/models.py
+++ b/hypha/apply/determinations/models.py
@@ -65,7 +65,7 @@ class DeterminationFormFieldsMixin(models.Model):
         return self._get_field_type(SendNoticeBlock)
 
     def _get_field_type(self, block_type, many=False):
-        fields = list()
+        fields = []
         for field in self.form_fields:
             try:
                 if isinstance(field.block, block_type):
@@ -165,7 +165,7 @@ class Determination(DeterminationFormFieldsMixin, AccessFormData, models.Model):
     def get_detailed_response(self):
         data = {}
         group = 0
-        data.setdefault(group, {'title': None, 'questions': list()})
+        data.setdefault(group, {'title': None, 'questions': []})
         for field in self.form_fields:
             if issubclass(
                 field.block.__class__, DeterminationMustIncludeFieldBlock
@@ -175,7 +175,7 @@ class Determination(DeterminationFormFieldsMixin, AccessFormData, models.Model):
                 value = self.form_data[field.id]
             except KeyError:
                 group = group + 1
-                data.setdefault(group, {'title': field.value.source, 'questions': list()})
+                data.setdefault(group, {'title': field.value.source, 'questions': []})
             else:
                 data[group]['questions'].append(
                     (field.value.get('field_label'), value)

--- a/hypha/apply/determinations/tests/factories.py
+++ b/hypha/apply/determinations/tests/factories.py
@@ -61,7 +61,7 @@ class DeterminationBlockFactory(FormFieldBlockFactory):
         model = DeterminationBlock
 
     @classmethod
-    def make_answer(cls, params=dict()):
+    def make_answer(cls, params={}):
         return random.choices([ACCEPTED, NEEDS_MORE_INFO, REJECTED])
 
 

--- a/hypha/apply/determinations/views.py
+++ b/hypha/apply/determinations/views.py
@@ -149,12 +149,7 @@ class BatchDeterminationCreateView(BaseStreamForm, CreateView):
         We can not create batch determination with submissions using two different
         type of forms.
         """
-        return len(set(
-            [
-                submission.is_determination_form_attached
-                for submission in submissions
-            ]
-        )) == 1
+        return len({submission.is_determination_form_attached for submission in submissions}) == 1
 
     def get_form_class(self):
         submissions = self.get_submissions()

--- a/hypha/apply/funds/admin_helpers.py
+++ b/hypha/apply/funds/admin_helpers.py
@@ -48,8 +48,8 @@ class ButtonsWithPreview(PageButtonHelper):
             'title': 'Preview this %s' % self.verbose_name,
         }
 
-    def get_buttons_for_obj(self, obj, exclude=list(), classnames_add=list(),
-                            classnames_exclude=list()):
+    def get_buttons_for_obj(self, obj, exclude=[], classnames_add=[],
+                            classnames_exclude=[]):
         btns = super().get_buttons_for_obj(obj, exclude, classnames_add, classnames_exclude)
 
         # Put preview before delete

--- a/hypha/apply/funds/edit_handlers.py
+++ b/hypha/apply/funds/edit_handlers.py
@@ -88,7 +88,7 @@ class ReadOnlyPanel(Panel):
 
 
 class FilteredFieldPanel(FieldPanel):
-    def __init__(self, *args, filter_query=dict(), **kwargs):
+    def __init__(self, *args, filter_query={}, **kwargs):
         self.filter_query = filter_query
         super().__init__(*args, **kwargs)
 

--- a/hypha/apply/funds/forms.py
+++ b/hypha/apply/funds/forms.py
@@ -407,7 +407,7 @@ class BatchUpdateReviewersForm(forms.Form):
 
         for submission in submissions:
             AssignedReviewers.objects.bulk_create_reviewers(
-                [reviewer for reviewer in external_reviewers],
+                list(external_reviewers),
                 submission,
             )
 

--- a/hypha/apply/funds/models/submissions.py
+++ b/hypha/apply/funds/models/submissions.py
@@ -662,7 +662,7 @@ class ApplicationSubmission(
             if response:
                 self.form_data[field_name] = response
 
-    def save(self, *args, update_fields=list(), skip_custom=False, **kwargs):
+    def save(self, *args, update_fields=[], skip_custom=False, **kwargs):
         if update_fields and 'form_data' not in update_fields:
             # We don't want to use this approach if the user is sending data
             return super().save(*args, update_fields=update_fields, **kwargs)

--- a/hypha/apply/funds/tables.py
+++ b/hypha/apply/funds/tables.py
@@ -268,7 +268,7 @@ class SubmissionFilter(filters.FilterSet):
         model = ApplicationSubmission
         fields = ('status', 'fund', 'round')
 
-    def __init__(self, *args, exclude=list(), limit_statuses=None, **kwargs):
+    def __init__(self, *args, exclude=[], limit_statuses=None, **kwargs):
         super().__init__(*args, **kwargs)
 
         self.filters['status'] = StatusMultipleChoiceFilter(limit_to=limit_statuses)
@@ -302,7 +302,7 @@ class SubmissionFilter(filters.FilterSet):
                     else:
                         if isinstance(category_options, str):
                             category_options = [category_options]
-                        include_in_filter = set(list(category_options)) & set(value)
+                        include_in_filter = set(category_options) & set(value)
                     # Check if filter options has any value in category options
                     # If yes then those submissions should be filtered in the list
                     if include_in_filter:
@@ -325,7 +325,7 @@ class SubmissionDashboardFilter(filters.FilterSet):
         model = ApplicationSubmission
         fields = ('fund', 'round')
 
-    def __init__(self, *args, exclude=list(), limit_statuses=None, **kwargs):
+    def __init__(self, *args, exclude=[], limit_statuses=None, **kwargs):
         super().__init__(*args, **kwargs)
 
         self.filters = {

--- a/hypha/apply/funds/tests/factories/blocks.py
+++ b/hypha/apply/funds/tests/factories/blocks.py
@@ -41,7 +41,7 @@ class DurationBlockFactory(FormFieldBlockFactory):
         model = blocks.DurationBlock
 
     @classmethod
-    def make_answer(cls, params=dict()):
+    def make_answer(cls, params={}):
         choices = list(blocks.DurationBlock.DURATION_MONTH_OPTIONS.keys())
         return random.choice(choices)
 
@@ -51,7 +51,7 @@ class ValueFieldBlockFactory(FormFieldBlockFactory):
         model = blocks.ValueBlock
 
     @classmethod
-    def make_answer(cls, params=dict(), form=False):
+    def make_answer(cls, params={}, form=False):
         return random.randint(0, 1_000_000)
 
 
@@ -60,7 +60,7 @@ class AddressFieldBlockFactory(FormFieldBlockFactory):
         model = blocks.AddressFieldBlock
 
     @classmethod
-    def make_answer(cls, params=dict()):
+    def make_answer(cls, params={}):
         if not params:
             params = {}
         return json.dumps({
@@ -73,7 +73,7 @@ class AddressFieldBlockFactory(FormFieldBlockFactory):
         })
 
     @classmethod
-    def make_form_answer(cls, params=dict()):
+    def make_form_answer(cls, params={}):
         try:
             address = json.loads(params)
         except TypeError:

--- a/hypha/apply/funds/tests/test_admin_views.py
+++ b/hypha/apply/funds/tests/test_admin_views.py
@@ -16,7 +16,7 @@ from .test_admin_form import form_data
 
 def create_form_fields_data(blocks):
     parent_field = 'form_fields'
-    form_fields_dict = dict()
+    form_fields_dict = {}
     form_fields_dict[f'{parent_field}-count'] = [str(len(blocks))]
     for index, block_name in enumerate(blocks):
         form_fields_dict[f'{parent_field}-{index}-deleted'] = ['']

--- a/hypha/apply/funds/tests/test_views.py
+++ b/hypha/apply/funds/tests/test_views.py
@@ -510,7 +510,7 @@ class TestReviewersUpdateView(BaseSubmissionViewTestCase):
         cls.reviewers = ReviewerFactory.create_batch(4)
         cls.roles = ReviewerRoleFactory.create_batch(2)
 
-    def post_form(self, submission, reviewer_roles=list(), reviewers=list()):
+    def post_form(self, submission, reviewer_roles=[], reviewers=[]):
         data = {
             'form-submitted-reviewer_form': '',
             'reviewer_reviewers': [r.id for r in reviewers]
@@ -1442,7 +1442,7 @@ class TestUpdateReviewersMixin(BaseSubmissionViewTestCase):
         cls.reviewers = ReviewerFactory.create_batch(4)
         cls.roles = ReviewerRoleFactory.create_batch(2)
 
-    def post_form(self, submission, reviewer_roles=list(), reviewers=list()):
+    def post_form(self, submission, reviewer_roles=[], reviewers=[]):
         data = {
             'form-submitted-reviewer_form': '',
             'reviewer_reviewers': [r.id for r in reviewers]

--- a/hypha/apply/funds/views.py
+++ b/hypha/apply/funds/views.py
@@ -647,10 +647,10 @@ class UpdateReviewersView(UpdateReviewersMixin, DelegatedViewMixin, UpdateView):
     context_name = 'reviewer_form'
 
     def form_valid(self, form):
-        old_reviewers = set(
+        old_reviewers = {
             copy(reviewer)
             for reviewer in form.instance.assigned.all()
-        )
+        }
         response = super().form_valid(form)
 
         new_reviewers = set(form.instance.assigned.all())

--- a/hypha/apply/funds/workflow.py
+++ b/hypha/apply/funds/workflow.py
@@ -75,7 +75,7 @@ class Phase:
     future_name = phase_name displayed to applicants if they haven't passed this stage
     """
 
-    def __init__(self, name, display, stage, permissions, step, public=None, future=None, transitions=dict()):
+    def __init__(self, name, display, stage, permissions, step, public=None, future=None, transitions={}):
         self.name = name
         self.display_name = display
         if public and future:
@@ -94,7 +94,7 @@ class Phase:
         default_permissions = {UserPermissions.STAFF, UserPermissions.LEAD, UserPermissions.ADMIN}
 
         for transition_target, action in transitions.items():
-            transition = dict()
+            transition = {}
             try:
                 transition['display'] = action.get('display')
             except AttributeError:
@@ -131,7 +131,7 @@ class Permissions:
         self.permissions = permissions
 
     def can_do(self, user, action):
-        checks = self.permissions.get(action, list())
+        checks = self.permissions.get(action, [])
         return any(check(user) for check in checks)
 
     def can_edit(self, user):
@@ -155,7 +155,7 @@ partner_can = lambda user: user.is_partner  # NOQA
 community_can = lambda user: user.is_community_reviewer  # NOQA
 
 
-def make_permissions(edit=list(), review=list(), view=[staff_can, applicant_can, reviewer_can, partner_can, ]):
+def make_permissions(edit=[], review=[], view=[staff_can, applicant_can, reviewer_can, partner_can, ]):
     return {
         'edit': edit,
         'review': review,
@@ -1016,7 +1016,7 @@ def get_review_statuses(user=None):
 def get_ext_review_statuses():
     reviews = set()
 
-    for phase_name, phase in PHASES:
+    for phase_name, _phase in PHASES:
         if phase_name.endswith('external_review'):
             reviews.add(phase_name)
     return reviews
@@ -1065,7 +1065,7 @@ ext_or_higher_statuses = get_ext_or_higher_statuses()
 accepted_statuses = get_accepted_statuses()
 dismissed_statuses = get_dismissed_statuses()
 
-DETERMINATION_PHASES = list(phase_name for phase_name, _ in PHASES if '_discussion' in phase_name)
+DETERMINATION_PHASES = [phase_name for phase_name, _ in PHASES if '_discussion' in phase_name]
 DETERMINATION_RESPONSE_PHASES = [
     'post_review_discussion',
     'concept_review_discussion',
@@ -1077,7 +1077,7 @@ DETERMINATION_RESPONSE_PHASES = [
 
 def get_determination_transitions():
     transitions = {}
-    for phase_name, phase in PHASES:
+    for _phase_name, phase in PHASES:
         for transition_name in phase.transitions:
             if 'accepted' in transition_name:
                 transitions[transition_name] = 'accepted'
@@ -1098,7 +1098,7 @@ def get_action_mapping(workflow):
         phases = workflow.items()
     else:
         phases = PHASES
-    for phase_name, phase in phases:
+    for _phase_name, phase in phases:
         for transition_name, transition in phase.transitions.items():
             transition_display = transition['display']
             transition_key = slugify(transition_display)
@@ -1111,7 +1111,7 @@ def get_action_mapping(workflow):
 DETERMINATION_OUTCOMES = get_determination_transitions()
 
 
-def phases_matching(phrase, exclude=list()):
+def phases_matching(phrase, exclude=[]):
     return [
         status for status, _ in PHASES
         if status.endswith(phrase) and status not in exclude

--- a/hypha/apply/projects/views/project.py
+++ b/hypha/apply/projects/views/project.py
@@ -736,7 +736,7 @@ class ProjectDetailDownloadView(SingleObjectMixin, View):
         return f"{datetime.date.today().strftime('%Y%m%d')}-{slugify(self.object.title)}.{export_type}"
 
     def get_paf_download_context(self):
-        context = dict()
+        context = {}
         context['id'] = self.object.id
         context['title'] = self.object.title
         context['project_link'] = self.request.build_absolute_uri(

--- a/hypha/apply/projects/views/vendor.py
+++ b/hypha/apply/projects/views/vendor.py
@@ -247,7 +247,7 @@ class VendorDetailView(DetailVendorAccessMixin, DetailView):
         vendor_form_settings = VendorFormSettings.for_request(self.request)
         data = {}
         group = 0
-        data.setdefault(group, {'title': str(_('Contracting Information')), 'questions': list()})
+        data.setdefault(group, {'title': str(_('Contracting Information')), 'questions': []})
         data[group]['questions'] = [
             (getattr(vendor_form_settings, 'name_label'), vendor.name),
             (getattr(vendor_form_settings, 'contractor_name_label'), vendor.contractor_name),
@@ -256,7 +256,7 @@ class VendorDetailView(DetailVendorAccessMixin, DetailView):
             ('Due Diligence Documents', ''),
         ]
         group = group + 1
-        data.setdefault(group, {'title': str(_('Bank Account Information')), 'questions': list()})
+        data.setdefault(group, {'title': str(_('Bank Account Information')), 'questions': []})
         bank_info = vendor.bank_info
         data[group]['questions'] = [
             (getattr(vendor_form_settings, 'account_holder_name_label'), bank_info.account_holder_name if bank_info else ''),
@@ -265,12 +265,12 @@ class VendorDetailView(DetailVendorAccessMixin, DetailView):
             (getattr(vendor_form_settings, 'account_currency_label'), bank_info.account_currency if bank_info else ''),
         ]
         group = group + 1
-        data.setdefault(group, {'title': str(_('(Optional) Extra Information for Accepting Payments')), 'questions': list()})
+        data.setdefault(group, {'title': str(_('(Optional) Extra Information for Accepting Payments')), 'questions': []})
         data[group]['questions'] = [
             (getattr(vendor_form_settings, 'branch_address_label'), self.get_address_display(bank_info.branch_address) if bank_info else ''),
         ]
         group = group + 1
-        data.setdefault(group, {'title': str(_('Intermediary Bank Account Information')), 'questions': list()})
+        data.setdefault(group, {'title': str(_('Intermediary Bank Account Information')), 'questions': []})
         iba_info = bank_info.iba_info if bank_info else None
         data[group]['questions'] = [
             (getattr(vendor_form_settings, 'ib_account_routing_number_label'), iba_info.account_routing_number if iba_info else ''),
@@ -279,13 +279,13 @@ class VendorDetailView(DetailVendorAccessMixin, DetailView):
             (getattr(vendor_form_settings, 'ib_branch_address_label'), self.get_address_display(iba_info.branch_address) if iba_info else ''),
         ]
         group = group + 1
-        data.setdefault(group, {'title': str(_('Account Holder National Identity Document Information')), 'questions': list()})
+        data.setdefault(group, {'title': str(_('Account Holder National Identity Document Information')), 'questions': []})
         data[group]['questions'] = [
             (getattr(vendor_form_settings, 'nid_type_label'), bank_info.nid_type if bank_info else ''),
             (getattr(vendor_form_settings, 'nid_number_label'), bank_info.nid_number if bank_info else ''),
         ]
         group = group + 1
-        data.setdefault(group, {'title': None, 'questions': list()})
+        data.setdefault(group, {'title': None, 'questions': []})
         data[group]['questions'] = [
             (getattr(vendor_form_settings, 'other_info_label'), vendor.other_info),
         ]

--- a/hypha/apply/review/admin_helpers.py
+++ b/hypha/apply/review/admin_helpers.py
@@ -12,8 +12,8 @@ class ButtonsWithClone(PageButtonHelper):
             'title': 'Clone this %s' % self.verbose_name,
         }
 
-    def get_buttons_for_obj(self, obj, exclude=list(), classnames_add=list(),
-                            classnames_exclude=list()):
+    def get_buttons_for_obj(self, obj, exclude=[], classnames_add=[],
+                            classnames_exclude=[]):
         btns = super().get_buttons_for_obj(obj, exclude, classnames_add, classnames_exclude)
 
         # Put preview before delete

--- a/hypha/apply/review/fields.py
+++ b/hypha/apply/review/fields.py
@@ -31,7 +31,7 @@ class ScoredAnswerWidget(forms.MultiWidget):
             value = kwargs['value']
             attrs = kwargs['attrs']
             rendered.append(widget.render(name, value, attrs, renderer))
-        return mark_safe(''.join([widget for widget in rendered]))
+        return mark_safe(''.join(list(rendered)))
 
 
 class ScoredAnswerField(forms.MultiValueField):

--- a/hypha/apply/review/forms.py
+++ b/hypha/apply/review/forms.py
@@ -79,7 +79,7 @@ class ReviewModelForm(StreamBaseForm, forms.ModelForm, metaclass=MixedMetaClass)
         return super().save(commit)
 
     def calculate_score(self, data):
-        scores = list()
+        scores = []
         for field in self.instance.score_fields:
             score = data.get(field.id)[1]
             # Include NA answers as 0.

--- a/hypha/apply/review/models.py
+++ b/hypha/apply/review/models.py
@@ -63,7 +63,7 @@ class ReviewFormFieldsMixin(models.Model):
         return self._get_field_type(RecommendationCommentsBlock)
 
     def _get_field_type(self, block_type, many=False):
-        fields = list()
+        fields = []
         for field in self.form_fields:
             try:
                 if isinstance(field.block, block_type):

--- a/hypha/apply/review/tests/factories/blocks.py
+++ b/hypha/apply/review/tests/factories/blocks.py
@@ -20,7 +20,7 @@ class RecommendationBlockFactory(FormFieldBlockFactory):
         model = blocks.RecommendationBlock
 
     @classmethod
-    def make_answer(cls, params=dict()):
+    def make_answer(cls, params={}):
         return random.choices([NO, MAYBE, YES])
 
 
@@ -34,7 +34,7 @@ class VisibilityBlockFactory(FormFieldBlockFactory):
         model = blocks.VisibilityBlock
 
     @classmethod
-    def make_answer(cls, params=dict()):
+    def make_answer(cls, params={}):
         return random.choices([PRIVATE, REVIEWER])
 
 
@@ -43,7 +43,7 @@ class ScoreFieldWithoutTextBlockFactory(FormFieldBlockFactory):
         model = blocks.ScoreFieldWithoutTextBlock
 
     @classmethod
-    def make_answer(cls, params=dict()):
+    def make_answer(cls, params={}):
         return random.randint(1, 5)
 
 
@@ -52,11 +52,11 @@ class ScoreFieldBlockFactory(FormFieldBlockFactory):
         model = blocks.ScoreFieldBlock
 
     @classmethod
-    def make_answer(cls, params=dict()):
+    def make_answer(cls, params={}):
         return json.dumps([factory.Faker('paragraph').evaluate(None, None, dict(params, locale=None)), random.randint(1, 5)])
 
     @classmethod
-    def make_form_answer(cls, params=dict()):
+    def make_form_answer(cls, params={}):
         defaults = {
             'description': factory.Faker('paragraph').evaluate(None, None, {'locale': None}),
             'score': random.randint(1, 5),

--- a/hypha/apply/review/views.py
+++ b/hypha/apply/review/views.py
@@ -362,12 +362,12 @@ class ReviewListView(ListView):
         review_data = {}
 
         # Add the header rows
-        review_data['title'] = {'question': '', 'answers': list()}
-        review_data['opinions'] = {'question': 'Opinions', 'answers': list()}
-        review_data['score'] = {'question': 'Overall Score', 'answers': list()}
-        review_data['recommendation'] = {'question': 'Recommendation', 'answers': list()}
-        review_data['revision'] = {'question': 'Revision', 'answers': list()}
-        review_data['comments'] = {'question': 'Comments', 'answers': list()}
+        review_data['title'] = {'question': '', 'answers': []}
+        review_data['opinions'] = {'question': 'Opinions', 'answers': []}
+        review_data['score'] = {'question': 'Overall Score', 'answers': []}
+        review_data['recommendation'] = {'question': 'Recommendation', 'answers': []}
+        review_data['revision'] = {'question': 'Revision', 'answers': []}
+        review_data['comments'] = {'question': 'Comments', 'answers': []}
 
         responses = self.object_list.count()
         ordered_reviewers = AssignedReviewers.objects.filter(submission=self.submission).reviewed().review_order()

--- a/hypha/apply/stream_forms/forms.py
+++ b/hypha/apply/stream_forms/forms.py
@@ -91,11 +91,11 @@ class BlockFieldWrapper:
         return self
 
     def css_classes(self):
-        return list()
+        return []
 
     @property
     def errors(self):
-        return list()
+        return []
 
     @property
     def html_name(self):

--- a/hypha/apply/stream_forms/models.py
+++ b/hypha/apply/stream_forms/models.py
@@ -37,7 +37,7 @@ class BaseStreamForm:
         # PERFORMANCE NOTE:
         # Do not attempt to iterate over form_fields - that will fully instantiate the form_fields
         # including any sub queries that they do
-        for i, field_data in enumerate(form_fields.raw_data):
+        for _i, field_data in enumerate(form_fields.raw_data):
             block = form_fields.stream_block.child_blocks[field_data['type']]
             field_id = field_data.get('id')
             try:

--- a/hypha/apply/stream_forms/testing/factories.py
+++ b/hypha/apply/stream_forms/testing/factories.py
@@ -102,7 +102,7 @@ class FormFieldBlockFactory(wagtail_factories.StructBlockFactory):
         model = stream_blocks.FormFieldBlock
 
     @classmethod
-    def make_answer(cls, params=dict()):
+    def make_answer(cls, params={}):
         return cls.default_value.evaluate(None, None, dict(params, locale=None))
 
     @classmethod
@@ -251,7 +251,7 @@ class StreamFieldUUIDFactory(wagtail_factories.StreamFieldFactory):
     def generate(self, step, params):
         params = self.build_form(params)
         blocks = super().generate(step, params)
-        ret_val = list()
+        ret_val = []
         # Convert to JSON so we can add id before create
         for block_name, value in blocks:
             block = self.factories[block_name]._meta.model()
@@ -262,7 +262,7 @@ class StreamFieldUUIDFactory(wagtail_factories.StreamFieldFactory):
     def build_form(self, data):
         extras = defaultdict(dict)
         exclusions = []
-        multiples = dict()
+        multiples = {}
         for field, value in data.items():
             # we dont care about position
             name, attr = field.split('__')

--- a/hypha/apply/users/models.py
+++ b/hypha/apply/users/models.py
@@ -123,7 +123,7 @@ class UserManager(BaseUserManager.from_queryset(UserQuerySet)):
                 ))
         return params
 
-    def get_or_create_and_notify(self, defaults=dict(), site=None, **kwargs):
+    def get_or_create_and_notify(self, defaults={}, site=None, **kwargs):
         """Create or get an account for applicant.and send activation email to applicant.
 
         Args:

--- a/hypha/apply/utils/admin.py
+++ b/hypha/apply/utils/admin.py
@@ -22,7 +22,7 @@ class ListRelatedMixin:
         return ', '.join(getattr(obj, f'{form}_set').values_list(f'{field}__title', flat=True))
 
     def used_by(self, obj):
-        rows = list()
+        rows = []
         for form, field in self.related_models:
             related = self._list_related(obj, form, field)
             if related:

--- a/hypha/apply/utils/blocks.py
+++ b/hypha/apply/utils/blocks.py
@@ -93,7 +93,7 @@ class CustomFormFieldsBlock(StreamBlock):
         except ValidationError as e:
             error_dict = e.params
         else:
-            error_dict = dict()
+            error_dict = {}
 
         block_types = [block.block_type for block in value]
         missing = set(self.required_block_names) - set(block_types)
@@ -103,7 +103,7 @@ class CustomFormFieldsBlock(StreamBlock):
             if name in self.single_block_names
         ]
 
-        all_errors = list()
+        all_errors = []
         if missing:
             all_errors.append(
                 'You are missing the following required fields: {}'.format(', '.join(prettify_names(missing)))

--- a/hypha/public/projects/widgets.py
+++ b/hypha/public/projects/widgets.py
@@ -42,14 +42,14 @@ class CategoriesWidget(forms.MultiWidget):
     template_name = 'projects/widgets/categories_widget.html'
 
     def __init__(self, *args, **kwargs):
-        kwargs['widgets'] = list()
+        kwargs['widgets'] = []
         super().__init__(*args, **kwargs)
         self.widgets = LazyWidgets(OptionsWidget, Category)
 
     def decompress(self, value):
         data = json.loads(value)
         return [
-            data.get(str(widget.attrs['id']), list()) for widget in self.widgets
+            data.get(str(widget.attrs['id']), []) for widget in self.widgets
         ]
 
     def value_from_datadict(self, data, files, name):


### PR DESCRIPTION
Replace their usages with the literal versions, [] for lists, {} for dicts, etc. It's easier for others to read, looks nicer, and the interpreter will convert it into bytecode that is executed faster (special opcodes for the containers, instead of performing function calls).

