### PR TITLE
Fix function call `AnonymousUser` performed in argument defaults

### DIFF
--- a/hypha/apply/funds/tests/test_models.py
+++ b/hypha/apply/funds/tests/test_models.py
@@ -203,7 +203,8 @@ class TestFormSubmission(TestCase):
         self.round_page = RoundFactory(parent=fund, now=True)
         self.lab_page = LabFactory(lead=self.round_page.lead)
 
-    def submit_form(self, page=None, email=None, name=None, draft=None, user=AnonymousUser(), ignore_errors=False):
+    def submit_form(self, page=None, email=None, name=None, draft=None, user=None, ignore_errors=False):
+        user = user or AnonymousUser()
         page = page or self.round_page
 
         fields = page.forms.first().fields

--- a/hypha/apply/utils/testing/tests.py
+++ b/hypha/apply/utils/testing/tests.py
@@ -6,7 +6,8 @@ from django.urls import reverse
 request_factory = RequestFactory()
 
 
-def make_request(user=AnonymousUser(), data={}, method='get', site=None):
+def make_request(user=None, data={}, method='get', site=None):
+    user = user or AnonymousUser()
     method = getattr(request_factory, method)
     request = method('', data)
     request.user = user


### PR DESCRIPTION
It is generally not a good idea to perform function calls in argument defaults in Python because the function will be called at the time the default value is defined, not when the function is called. This means that if the function has side effects, they will be executed every time the default value is used, which can lead to unexpected behavior.

