### PR TITLE
Fix loop control variable overriding iterable it iterates

### DIFF
--- a/hypha/apply/activity/adapters/utils.py
+++ b/hypha/apply/activity/adapters/utils.py
@@ -19,8 +19,8 @@ def group_reviewers(reviewers):
 
 def reviewers_message(reviewers):
     messages = []
-    for role, reviewers in group_reviewers(reviewers).items():
-        message = ', '.join(str(reviewer) for reviewer in reviewers)
+    for role, reviewers_ in group_reviewers(reviewers).items():
+        message = ', '.join(str(reviewer) for reviewer in reviewers_)
         if role:
             message += _(' as {role}').format(role=str(role))
         message += '.'

--- a/hypha/public/home/models.py
+++ b/hypha/public/home/models.py
@@ -160,9 +160,9 @@ class HomePage(BasePage):
         yield from sorted(qs, key=sort_by_deadline)
 
     def pages_from_related(self, related):
-        for related in related.all():
-            if related.page.live and related.page.public:
-                yield related.page.specific
+        for related_obj in related.all():
+            if related_obj.page.live and related_obj.page.public:
+                yield related_obj.page.specific
 
     def get_context(self, *args, **kwargs):
         context = super().get_context(*args, **kwargs)


### PR DESCRIPTION
The variables `reviewer` and `related` has the same as the iterable it
iterates on. This can lead to unexpected results.
