### PR TITLE
Update 'getattr' calls that use constants with normal property access

### DIFF
--- a/hypha/apply/api/v1/reminder/views.py
+++ b/hypha/apply/api/v1/reminder/views.py
@@ -63,7 +63,7 @@ class SubmissionReminderViewSet(
             },
             {
                 "id": "action",
-                "kwargs": {"label": "Action", "required": True, "choices": getattr(Reminder, 'ACTIONS').items(), "initial": getattr(Reminder, 'REVIEW')},
+                "kwargs": {"label": "Action", "required": True, "choices": Reminder.ACTIONS.items(), "initial": Reminder.REVIEW},
                 "type": "Select"
             }
         ]

--- a/hypha/apply/api/v1/stream_serializers.py
+++ b/hypha/apply/api/v1/stream_serializers.py
@@ -128,11 +128,11 @@ class WagtailSerializer:
         respective classes. But for now this works.
         """
         if isinstance(field, BlockFieldWrapper):
-            return getattr(serializers, 'CharField')
+            return serializers.CharField
         if isinstance(field, ScoredAnswerField):
             return ScoredAnswerListField
         if isinstance(field, TypedChoiceField):
-            return getattr(serializers, 'ChoiceField')
+            return serializers.ChoiceField
         class_name = field.__class__.__name__
         return getattr(serializers, class_name)
 

--- a/hypha/apply/categories/admin_helpers.py
+++ b/hypha/apply/categories/admin_helpers.py
@@ -42,7 +42,7 @@ class MetaTermButtonHelper(ButtonHelper):
 
         add_child_button = self.add_child_button(
             pk=getattr(obj, self.opts.pk.attname),
-            child_verbose_name=getattr(obj, 'node_child_verbose_name'),
+            child_verbose_name=obj.node_child_verbose_name,
             **kwargs
         )
         buttons.append(add_child_button)

--- a/hypha/apply/funds/admin_helpers.py
+++ b/hypha/apply/funds/admin_helpers.py
@@ -122,7 +122,7 @@ class ApplicationFormButtonHelper(ButtonHelper):
 
         copy_form_button = self.copy_form_button(
             pk=getattr(obj, self.opts.pk.attname),
-            form_name=getattr(obj, 'name'),
+            form_name=obj.name,
             **kwargs
         )
         buttons.append(copy_form_button)

--- a/hypha/apply/projects/views/vendor.py
+++ b/hypha/apply/projects/views/vendor.py
@@ -249,45 +249,45 @@ class VendorDetailView(DetailVendorAccessMixin, DetailView):
         group = 0
         data.setdefault(group, {'title': str(_('Contracting Information')), 'questions': list()})
         data[group]['questions'] = [
-            (getattr(vendor_form_settings, 'name_label'), vendor.name),
-            (getattr(vendor_form_settings, 'contractor_name_label'), vendor.contractor_name),
-            (getattr(vendor_form_settings, 'type_label'), vendor.type),
-            (getattr(vendor_form_settings, 'required_to_pay_taxes_label'), vendor.required_to_pay_taxes),
+            (vendor_form_settings.name_label, vendor.name),
+            (vendor_form_settings.contractor_name_label, vendor.contractor_name),
+            (vendor_form_settings.type_label, vendor.type),
+            (vendor_form_settings.required_to_pay_taxes_label, vendor.required_to_pay_taxes),
             ('Due Diligence Documents', ''),
         ]
         group = group + 1
         data.setdefault(group, {'title': str(_('Bank Account Information')), 'questions': list()})
         bank_info = vendor.bank_info
         data[group]['questions'] = [
-            (getattr(vendor_form_settings, 'account_holder_name_label'), bank_info.account_holder_name if bank_info else ''),
-            (getattr(vendor_form_settings, 'account_routing_number_label'), bank_info.account_routing_number if bank_info else ''),
-            (getattr(vendor_form_settings, 'account_number_label'), bank_info.account_number if bank_info else ''),
-            (getattr(vendor_form_settings, 'account_currency_label'), bank_info.account_currency if bank_info else ''),
+            (vendor_form_settings.account_holder_name_label, bank_info.account_holder_name if bank_info else ''),
+            (vendor_form_settings.account_routing_number_label, bank_info.account_routing_number if bank_info else ''),
+            (vendor_form_settings.account_number_label, bank_info.account_number if bank_info else ''),
+            (vendor_form_settings.account_currency_label, bank_info.account_currency if bank_info else ''),
         ]
         group = group + 1
         data.setdefault(group, {'title': str(_('(Optional) Extra Information for Accepting Payments')), 'questions': list()})
         data[group]['questions'] = [
-            (getattr(vendor_form_settings, 'branch_address_label'), self.get_address_display(bank_info.branch_address) if bank_info else ''),
+            (vendor_form_settings.branch_address_label, self.get_address_display(bank_info.branch_address) if bank_info else ''),
         ]
         group = group + 1
         data.setdefault(group, {'title': str(_('Intermediary Bank Account Information')), 'questions': list()})
         iba_info = bank_info.iba_info if bank_info else None
         data[group]['questions'] = [
-            (getattr(vendor_form_settings, 'ib_account_routing_number_label'), iba_info.account_routing_number if iba_info else ''),
-            (getattr(vendor_form_settings, 'ib_account_number_label'), iba_info.account_number if iba_info else ''),
-            (getattr(vendor_form_settings, 'ib_account_currency_label'), iba_info.account_currency if iba_info else ''),
-            (getattr(vendor_form_settings, 'ib_branch_address_label'), self.get_address_display(iba_info.branch_address) if iba_info else ''),
+            (vendor_form_settings.ib_account_routing_number_label, iba_info.account_routing_number if iba_info else ''),
+            (vendor_form_settings.ib_account_number_label, iba_info.account_number if iba_info else ''),
+            (vendor_form_settings.ib_account_currency_label, iba_info.account_currency if iba_info else ''),
+            (vendor_form_settings.ib_branch_address_label, self.get_address_display(iba_info.branch_address) if iba_info else ''),
         ]
         group = group + 1
         data.setdefault(group, {'title': str(_('Account Holder National Identity Document Information')), 'questions': list()})
         data[group]['questions'] = [
-            (getattr(vendor_form_settings, 'nid_type_label'), bank_info.nid_type if bank_info else ''),
-            (getattr(vendor_form_settings, 'nid_number_label'), bank_info.nid_number if bank_info else ''),
+            (vendor_form_settings.nid_type_label, bank_info.nid_type if bank_info else ''),
+            (vendor_form_settings.nid_number_label, bank_info.nid_number if bank_info else ''),
         ]
         group = group + 1
         data.setdefault(group, {'title': None, 'questions': list()})
         data[group]['questions'] = [
-            (getattr(vendor_form_settings, 'other_info_label'), vendor.other_info),
+            (vendor_form_settings.other_info_label, vendor.other_info),
         ]
         return data
 


### PR DESCRIPTION
Do not call `getattr` with a constant attribute value. It is not any safer than normal property access.

