### PR TITLE
Show the per-page selection/display at the bottom of the table

### DIFF
--- a/hypha/apply/funds/templates/funds/includes/table_filter_and_search.html
+++ b/hypha/apply/funds/templates/funds/includes/table_filter_and_search.html
@@ -4,10 +4,6 @@
     <div class="actions-bar">
         {# Left #}
         <div class="actions-bar__inner actions-bar__inner--left">
-            {% if use_batch_actions %}
-                <div class="actions-bar__per-page">{% trans "Show" %} <a href="{% querystring "per_page"=25 %}">25</a> | <a href="{% querystring "per_page"=50 %}">50</a> | <a href="{% querystring "per_page"=100 %}">100</a> {% trans "items" %}</div>
-            {% endif %}
-
             {% if heading %}
                 <h4 class="heading heading--normal heading--no-margin">{{ heading }}</h4>
             {% endif %}

--- a/hypha/apply/funds/templates/funds/submissions_overview.html
+++ b/hypha/apply/funds/templates/funds/submissions_overview.html
@@ -43,7 +43,7 @@
     {% block table %}
         <div class="wrapper wrapper--bottom-space">
             {% trans "All Submissions" as all_submissions %}
-            {% include "funds/includes/table_filter_and_search.html" with filter_form=filter_form search_term=search_term use_search=True filter_action=filter_action use_batch_actions=False heading=all_submissions %}
+            {% include "funds/includes/table_filter_and_search.html" with filter_form=filter_form search_term=search_term use_search=True filter_action=filter_action search_action=search_action use_batch_actions=False heading=all_submissions %}
 
             {% render_table table %}
             <div class="all-submissions-table__more">

--- a/hypha/apply/funds/templates/funds/tables/table.html
+++ b/hypha/apply/funds/templates/funds/tables/table.html
@@ -121,40 +121,42 @@
 {% endblock table.tbody.empty_text %}
 
 {% block pagination %}
-    <div class="pagination--wrapper">
-        <div class='per-page'>
-            {% trans "Show" %}
-            <a href="{% querystring "per_page"=25 %}" {% if table.paginator.per_page == 25 %}class="current"{% endif %}>25</a> |
-            <a href="{% querystring "per_page"=50 %}" {% if table.paginator.per_page == 50 %}class="current"{% endif %}>50</a> |
-            <a href="{% querystring "per_page"=100 %}" {% if table.paginator.per_page == 100 %}class="current"{% endif %}>100</a> |
-            {% trans "items" %}
-        </div>
+    {% if table.page and table.paginator.num_pages > 0 %}
+        <div class="pagination--wrapper">
+            <div class='per-page'>
+                {% trans "Show" %}
+                <a href="{% querystring "per_page"=25 %}" {% if table.paginator.per_page == 25 %}class="current"{% endif %}>25</a> |
+                <a href="{% querystring "per_page"=50 %}" {% if table.paginator.per_page == 50 %}class="current"{% endif %}>50</a> |
+                <a href="{% querystring "per_page"=100 %}" {% if table.paginator.per_page == 100 %}class="current"{% endif %}>100</a> |
+                {% trans "items" %}
+            </div>
 
-        {% if table.page and table.paginator.num_pages > 1 %}
-            <ul class="pagination">
-                {% if table.page.has_previous %}
-                    <li class="previous">
-                        <a href="{% querystring table.prefixed_page_field=table.page.previous_page_number %}">
-                            {% trans 'previous' %}
-                        </a>
-                    </li>
-                {% endif %}
-                {% if table.page.has_previous or table.page.has_next %}
-                    {% total_num_of_pages table.rows|length table.paginator.per_page as total_pages %}
-                    <li class="cardinality">
-                        <p>
-                            {% trans "Page" %} {{ table.page.number }} / {{ total_pages }}
-                        </p>
-                    </li>
-                {% endif %}
-                {% if table.page.has_next %}
-                    <li class="next">
-                        <a href="{% querystring table.prefixed_page_field=table.page.next_page_number %}">
-                            {% trans 'next' %}
-                        </a>
-                    </li>
-                {% endif %}
-            </ul>
-        {% endif %}
-    </div>
+            {% if table.paginator.num_pages > 1 %}
+                <ul class="pagination">
+                    {% if table.page.has_previous %}
+                        <li class="previous">
+                            <a href="{% querystring table.prefixed_page_field=table.page.previous_page_number %}">
+                                {% trans 'previous' %}
+                            </a>
+                        </li>
+                    {% endif %}
+                    {% if table.page.has_previous or table.page.has_next %}
+                        {% total_num_of_pages table.rows|length table.paginator.per_page as total_pages %}
+                        <li class="cardinality">
+                            <p>
+                                {% trans "Page" %} {{ table.page.number }} / {{ total_pages }}
+                            </p>
+                        </li>
+                    {% endif %}
+                    {% if table.page.has_next %}
+                        <li class="next">
+                            <a href="{% querystring table.prefixed_page_field=table.page.next_page_number %}">
+                                {% trans 'next' %}
+                            </a>
+                        </li>
+                    {% endif %}
+                </ul>
+            {% endif %}
+        </div>
+    {% endif %}
 {% endblock pagination %}

--- a/hypha/apply/funds/templates/funds/tables/table.html
+++ b/hypha/apply/funds/templates/funds/tables/table.html
@@ -140,9 +140,10 @@
                     </li>
                 {% endif %}
                 {% if table.page.has_previous or table.page.has_next %}
+                    {% total_num_of_pages table.rows|length table.paginator.per_page as total_pages %}
                     <li class="cardinality">
                         <p>
-                            {% trans "Page" %} {{ table.page.number }}
+                            {% trans "Page" %} {{ table.page.number }} / {{ total_pages }}
                         </p>
                     </li>
                 {% endif %}

--- a/hypha/apply/funds/templates/funds/tables/table.html
+++ b/hypha/apply/funds/templates/funds/tables/table.html
@@ -121,29 +121,39 @@
 {% endblock table.tbody.empty_text %}
 
 {% block pagination %}
-    {% if table.page and table.paginator.num_pages > 1 %}
-    <ul class="pagination">
-        {% if table.page.has_previous %}
-            <li class="previous">
-                <a href="{% querystring table.prefixed_page_field=table.page.previous_page_number %}">
-                    {% trans 'previous' %}
-                </a>
-            </li>
+    <div class="pagination--wrapper">
+        <div class='per-page'>
+            {% trans "Show" %}
+            <a href="{% querystring "per_page"=25 %}" {% if table.paginator.per_page == 25 %}class="current"{% endif %}>25</a> |
+            <a href="{% querystring "per_page"=50 %}" {% if table.paginator.per_page == 50 %}class="current"{% endif %}>50</a> |
+            <a href="{% querystring "per_page"=100 %}" {% if table.paginator.per_page == 100 %}class="current"{% endif %}>100</a> |
+            {% trans "items" %}
+        </div>
+
+        {% if table.page and table.paginator.num_pages > 1 %}
+            <ul class="pagination">
+                {% if table.page.has_previous %}
+                    <li class="previous">
+                        <a href="{% querystring table.prefixed_page_field=table.page.previous_page_number %}">
+                            {% trans 'previous' %}
+                        </a>
+                    </li>
+                {% endif %}
+                {% if table.page.has_previous or table.page.has_next %}
+                    <li class="cardinality">
+                        <p>
+                            {% trans "Page" %} {{ table.page.number }}
+                        </p>
+                    </li>
+                {% endif %}
+                {% if table.page.has_next %}
+                    <li class="next">
+                        <a href="{% querystring table.prefixed_page_field=table.page.next_page_number %}">
+                            {% trans 'next' %}
+                        </a>
+                    </li>
+                {% endif %}
+            </ul>
         {% endif %}
-        {% if table.page.has_previous or table.page.has_next %}
-            <li class="cardinality">
-                <p>
-                    {% trans "Page" %} {{ table.page.number }}
-                </p>
-            </li>
-        {% endif %}
-        {% if table.page.has_next %}
-            <li class="next">
-                <a href="{% querystring table.prefixed_page_field=table.page.next_page_number %}">
-                    {% trans 'next' %}
-                </a>
-            </li>
-        {% endif %}
-    </ul>
-    {% endif %}
+    </div>
 {% endblock pagination %}

--- a/hypha/apply/funds/templatetags/table_tags.py
+++ b/hypha/apply/funds/templatetags/table_tags.py
@@ -1,4 +1,5 @@
 import copy
+import math
 
 from django import template
 
@@ -10,3 +11,9 @@ def row_from_record(row, record):
     row = copy.copy(row)
     row._record = record
     return row
+
+
+@register.simple_tag
+def total_num_of_pages(total_no_of_rows, per_page):
+    return math.ceil(total_no_of_rows/per_page)
+

--- a/hypha/apply/funds/views.py
+++ b/hypha/apply/funds/views.py
@@ -179,6 +179,7 @@ class BaseAdminSubmissionsTable(SingleTableMixin, FilterView):
     table_class = AdminSubmissionsTable
     filterset_class = SubmissionFilterAndSearch
     filter_action = ''
+    search_action = ''
     paginator_class = LazyPaginator
     table_pagination = {'per_page': 25}
 
@@ -214,6 +215,7 @@ class BaseAdminSubmissionsTable(SingleTableMixin, FilterView):
 
         return super().get_context_data(
             search_term=search_term,
+            search_action=self.search_action,
             filter_action=self.filter_action,
             **kwargs,
         )
@@ -431,6 +433,7 @@ class SubmissionOverviewView(BaseAdminSubmissionsTable):
     table_class = SummarySubmissionsTable
     table_pagination = False
     filter_action = reverse_lazy('funds:submissions:list')
+    search_action = reverse_lazy('funds:submissions:list')
 
     def get_table_data(self):
         limit = 5

--- a/hypha/apply/projects/tables.py
+++ b/hypha/apply/projects/tables.py
@@ -129,6 +129,7 @@ class ProjectsListTable(BaseProjectsTable):
         model = Project
         orderable = True
         order_by = ('-end_date',)
+        template_name = 'application_projects/tables/table.html'
         attrs = {'class': 'projects-table'}
 
     def order_fund_allocation(self, qs, is_descending):

--- a/hypha/apply/projects/templates/application_projects/project_list.html
+++ b/hypha/apply/projects/templates/application_projects/project_list.html
@@ -10,7 +10,7 @@
     <div class="admin-bar__inner wrapper--search">
         {% block page_header %}
             <div>
-                <h1 class="gamma heading heading--no-margin heading--bold">{% trans "All Projects" %}</h1>
+                <h1 class="gamma heading heading--no-margin heading--bold">{% trans "All Projects" %}<span class="submissions-count"> ({{ table.rows|length }})</span></h1>
             </div>
         {% endblock %}
     </div>

--- a/hypha/apply/projects/templates/application_projects/tables/table.html
+++ b/hypha/apply/projects/templates/application_projects/tables/table.html
@@ -2,29 +2,39 @@
 {% load django_tables2 table_tags review_tags wagtailimages_tags i18n %}
 
 {% block pagination %}
-    {% if table.page and table.paginator.num_pages > 1 %}
-    <ul class="pagination">
-        {% if table.page.has_previous %}
-            <li class="previous">
-                <a href="{% querystring table.prefixed_page_field=table.page.previous_page_number %}">
-                    {% trans 'previous' %}
-                </a>
-            </li>
+    <div class="pagination--wrapper">
+        <div class='per-page'>
+            {% trans "Show" %}
+            <a href="{% querystring "per_page"=25 %}" {% if table.paginator.per_page == 25 %}class="current"{% endif %}>25</a> |
+            <a href="{% querystring "per_page"=50 %}" {% if table.paginator.per_page == 50 %}class="current"{% endif %}>50</a> |
+            <a href="{% querystring "per_page"=100 %}" {% if table.paginator.per_page == 100 %}class="current"{% endif %}>100</a> |
+            {% trans "items" %}
+        </div>
+        {% if table.page and table.paginator.num_pages > 1 %}
+        <ul class="pagination">
+            {% if table.page.has_previous %}
+                <li class="previous">
+                    <a href="{% querystring table.prefixed_page_field=table.page.previous_page_number %}">
+                        {% trans 'previous' %}
+                    </a>
+                </li>
+            {% endif %}
+            {% if table.page.has_previous or table.page.has_next %}
+                {% total_num_of_pages table.rows|length table.paginator.per_page as total_pages %}
+                <li class="cardinality">
+                    <p>
+                        {% trans "Page" %} {{ table.page.number }} / {{ total_pages }}
+                    </p>
+                </li>
+            {% endif %}
+            {% if table.page.has_next %}
+                <li class="next">
+                    <a href="{% querystring table.prefixed_page_field=table.page.next_page_number %}">
+                        {% trans 'next' %}
+                    </a>
+                </li>
+            {% endif %}
+        </ul>
         {% endif %}
-        {% if table.page.has_previous or table.page.has_next %}
-            <li class="cardinality">
-                <p>
-                    {% trans "Page" %} {{ table.page.number }}
-                </p>
-            </li>
-        {% endif %}
-        {% if table.page.has_next %}
-            <li class="next">
-                <a href="{% querystring table.prefixed_page_field=table.page.next_page_number %}">
-                    {% trans 'next' %}
-                </a>
-            </li>
-        {% endif %}
-    </ul>
-    {% endif %}
+    </div>
 {% endblock pagination %}

--- a/hypha/apply/projects/templates/application_projects/tables/table.html
+++ b/hypha/apply/projects/templates/application_projects/tables/table.html
@@ -1,0 +1,30 @@
+{% extends 'django_tables2/table.html' %}
+{% load django_tables2 table_tags review_tags wagtailimages_tags i18n %}
+
+{% block pagination %}
+    {% if table.page and table.paginator.num_pages > 1 %}
+    <ul class="pagination">
+        {% if table.page.has_previous %}
+            <li class="previous">
+                <a href="{% querystring table.prefixed_page_field=table.page.previous_page_number %}">
+                    {% trans 'previous' %}
+                </a>
+            </li>
+        {% endif %}
+        {% if table.page.has_previous or table.page.has_next %}
+            <li class="cardinality">
+                <p>
+                    {% trans "Page" %} {{ table.page.number }}
+                </p>
+            </li>
+        {% endif %}
+        {% if table.page.has_next %}
+            <li class="next">
+                <a href="{% querystring table.prefixed_page_field=table.page.next_page_number %}">
+                    {% trans 'next' %}
+                </a>
+            </li>
+        {% endif %}
+    </ul>
+    {% endif %}
+{% endblock pagination %}

--- a/hypha/apply/projects/templates/application_projects/tables/table.html
+++ b/hypha/apply/projects/templates/application_projects/tables/table.html
@@ -2,39 +2,41 @@
 {% load django_tables2 table_tags review_tags wagtailimages_tags i18n %}
 
 {% block pagination %}
-    <div class="pagination--wrapper">
-        <div class='per-page'>
-            {% trans "Show" %}
-            <a href="{% querystring "per_page"=25 %}" {% if table.paginator.per_page == 25 %}class="current"{% endif %}>25</a> |
-            <a href="{% querystring "per_page"=50 %}" {% if table.paginator.per_page == 50 %}class="current"{% endif %}>50</a> |
-            <a href="{% querystring "per_page"=100 %}" {% if table.paginator.per_page == 100 %}class="current"{% endif %}>100</a> |
-            {% trans "items" %}
+    {% if table.page and table.paginator.num_pages > 0 %}
+        <div class="pagination--wrapper">
+            <div class='per-page'>
+                {% trans "Show" %}
+                <a href="{% querystring "per_page"=25 %}" {% if table.paginator.per_page == 25 %}class="current"{% endif %}>25</a> |
+                <a href="{% querystring "per_page"=50 %}" {% if table.paginator.per_page == 50 %}class="current"{% endif %}>50</a> |
+                <a href="{% querystring "per_page"=100 %}" {% if table.paginator.per_page == 100 %}class="current"{% endif %}>100</a> |
+                {% trans "items" %}
+            </div>
+            {% if table.paginator.num_pages > 1 %}
+                <ul class="pagination">
+                    {% if table.page.has_previous %}
+                        <li class="previous">
+                            <a href="{% querystring table.prefixed_page_field=table.page.previous_page_number %}">
+                                {% trans 'previous' %}
+                            </a>
+                        </li>
+                    {% endif %}
+                    {% if table.page.has_previous or table.page.has_next %}
+                        {% total_num_of_pages table.rows|length table.paginator.per_page as total_pages %}
+                        <li class="cardinality">
+                            <p>
+                                {% trans "Page" %} {{ table.page.number }} / {{ total_pages }}
+                            </p>
+                        </li>
+                    {% endif %}
+                    {% if table.page.has_next %}
+                        <li class="next">
+                            <a href="{% querystring table.prefixed_page_field=table.page.next_page_number %}">
+                                {% trans 'next' %}
+                            </a>
+                        </li>
+                    {% endif %}
+                </ul>
+            {% endif %}
         </div>
-        {% if table.page and table.paginator.num_pages > 1 %}
-        <ul class="pagination">
-            {% if table.page.has_previous %}
-                <li class="previous">
-                    <a href="{% querystring table.prefixed_page_field=table.page.previous_page_number %}">
-                        {% trans 'previous' %}
-                    </a>
-                </li>
-            {% endif %}
-            {% if table.page.has_previous or table.page.has_next %}
-                {% total_num_of_pages table.rows|length table.paginator.per_page as total_pages %}
-                <li class="cardinality">
-                    <p>
-                        {% trans "Page" %} {{ table.page.number }} / {{ total_pages }}
-                    </p>
-                </li>
-            {% endif %}
-            {% if table.page.has_next %}
-                <li class="next">
-                    <a href="{% querystring table.prefixed_page_field=table.page.next_page_number %}">
-                        {% trans 'next' %}
-                    </a>
-                </li>
-            {% endif %}
-        </ul>
-        {% endif %}
-    </div>
+    {% endif %}
 {% endblock pagination %}

--- a/hypha/static_src/src/sass/apply/components/_pagination.scss
+++ b/hypha/static_src/src/sass/apply/components/_pagination.scss
@@ -1,9 +1,28 @@
+.pagination--wrapper {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    margin-bottom: 60px;
+    margin-top: 30px;
+
+    .per-page {
+        a.current {
+            pointer-events: none;
+            cursor: default;
+            text-decoration: none;
+        }
+
+        a {
+            text-decoration: underline;
+        }
+    }
+}
+
 .pagination {
     @extend %h6;
     display: flex;
     align-items: center;
     justify-content: center;
-    margin-top: 30px;
 
     .cardinality {
         margin: 0 10px;


### PR DESCRIPTION
- This free up space at the top for batch actions.
- Also, add an indication of which per_page value is currently used.


![Screenshot 2023-01-17 at 08 35 41@2x](https://user-images.githubusercontent.com/236356/212854249-55fb2b2f-49af-4f77-8c15-24c0ec0815a0.jpg)

---

![Screenshot 2023-01-17 at 08 39 29@2x](https://user-images.githubusercontent.com/236356/212854266-d8010ba4-723a-4456-a362-cc515525fafe.jpg)


**Issues fixed in this PR**:

- [x] Move 'Show per-page' section to the bottom, left-hand side of the pagination.
- [x] Similar pagination for both the Submissions and Projects list page, using the submissions' custom one for both pages.
- [x] Add the total no of pages in pagination like Page 1/3.
- [x] Redirect the user to the submission list page on using the search on the submission overview page, similar flow like filters.
- [x]  Remove 'show per-page' section from submissions and projects overview pages. 

