### PR TITLE
Fix search issue on submission list page with none archived value

### DIFF
--- a/hypha/apply/funds/templates/funds/includes/table_filter_and_search.html
+++ b/hypha/apply/funds/templates/funds/includes/table_filter_and_search.html
@@ -69,7 +69,7 @@
                 <button class="button button--search" type="submit" aria-label="{% trans 'Search' %}">
                     <svg class="icon icon--magnifying-glass icon--search"><use xlink:href="#magnifying-glass"></use></svg>
                 </button>
-                {% if show_archive %}
+                {% if show_archive and archived_param is not None %}
                 <input type="hidden" value="{{ archived_param }}" name="archived">
                 {% endif %}
                 {% trans "submissions" as submissions %}


### PR DESCRIPTION
Fixed sentry issue [3887915131](https://sentry.io/organizations/otf/issues/3887915131/?project=1268368)

#3123 has fixed it only for the users who can't see the archived feature and that's why we found it working in our testing but for staff admin, this issue is still there. 
The main issue is we have checked for empty and None archived values but with the search only it passes 'None' as the str type. I fix it by not passing the archived param to the URL if the archived param's value is None(not selected yet).

@frjo @theskumar Please test it once, and I think we might need a new release with this one as well.