### PR TITLE
Align invoice filters on project overview page

### DIFF
--- a/hypha/apply/projects/templates/application_projects/overview.html
+++ b/hypha/apply/projects/templates/application_projects/overview.html
@@ -44,7 +44,7 @@
     <div class="wrapper wrapper--bottom-space">
 
         {% trans "Project Invoices" as heading %}
-        {% include "funds/includes/table_filter_and_search.html" with filter=invoices.filterset filter_action=invoices.url heading=heading filter_classes="filters--dates" %}
+        {% include "funds/includes/table_filter_and_search.html" with filter=invoices.filterset filter_action=invoices.url heading=heading %}
 
         {% render_table invoices.table %}
 


### PR DESCRIPTION
Fixes #3139 

Remove 'filters-date' class for invoice filters on the overview page because there is no date field in InvoiceListFilter.