### PR TITLE
Move report permissions to permission file

### DIFF
--- a/hypha/apply/projects/permissions.py
+++ b/hypha/apply/projects/permissions.py
@@ -52,9 +52,60 @@ def can_update_project_status(user, project):
     return False, 'Forbidden Error'
 
 
+def can_update_report(user, report):
+    if not user.is_authenticated:
+        return False, 'Login Required'
+    if report.project.status != IN_PROGRESS:
+        return False, 'Report can be updated only in In Progress state'
+    if report.skipped:
+        return False, 'Skipped reports are not editable'
+    if not report.can_submit:
+        return False, 'Future reports are not editable'
+
+    if user.is_apply_staff or user == report.project.user:
+        return True, 'Staff and Project Owner can edit the editable reports'
+
+    return False, 'Forbidden Error'
+
+
+def can_update_report_config(user, project):
+    if not user.is_authenticated:
+        return False, 'Login Required'
+    if project.status != IN_PROGRESS:
+        return False, 'Report Config can be changed only in In Progress state'
+    if user.is_apply_staff:
+        return True, 'Only Staff can update report config for In Progress projects'
+    return False, 'Forbidden Error'
+
+
+def can_update_project_reports(user, project):
+    if not user.is_authenticated:
+        return False, 'Login Required'
+    if project.status != IN_PROGRESS:
+        return False, 'Report Config can be changed only in In Progress state'
+    if user.is_apply_staff or user == project.user:
+        return True, 'Only Staff and project owner can update report config for In Progress projects'
+    return False, 'Forbidden Error'
+
+
+def can_view_report(user, report):
+    if not user.is_authenticated:
+        return False, 'Login Required'
+    if report.project.status not in [COMPLETE, CLOSING, IN_PROGRESS]:
+        return False, 'Report are not available at this state'
+    if report.skipped:
+        return False, 'Skipped reports are not available'
+    if user.is_apply_staff or user.is_finance or user == report.project.user:
+        return True, 'Staff, Finance, and Project owner can view the report'
+    return False, 'Forbidden Error'
+
 
 permissions_map = {
     'contract_approve': can_approve_contract,
     'contract_upload': can_upload_contract,
     'project_status_update': can_update_project_status,
+    'project_reports_update': can_update_project_reports,
+    'report_update': can_update_report,
+    'report_config_update': can_update_report_config,
+    'report_view': can_view_report,
 }

--- a/hypha/apply/projects/templates/application_projects/includes/reports.html
+++ b/hypha/apply/projects/templates/application_projects/includes/reports.html
@@ -1,26 +1,25 @@
 {% load i18n project_tags %}
 
-{% user_can_add_reports object user as can_add_reports %}
-{% user_can_edit_reports object user as can_edit_reports %}
-{% if can_add_reports %}
+{% user_can_update_project_reports object user as can_update_project_reports %}
+{% if can_update_project_reports %}
 <div class="wrapper wrapper--outer-space-large">
     <div class="data-block">
         <div class="data-block__header">
             <p class="data-block__title">{% trans "Reporting" %}</p>
         </div>
         <div class="data-block__body">
-            <div class="data-block__card">
-                <p class="data-block__card-title">{% trans "Report frequency" %}</p>
-                <p class="data-block__card-copy">{{ object.report_config.get_frequency_display }}</p>
-                {% if request.user.is_apply_staff %}
+            {% user_can_update_report_config object user as can_update_report_config %}
+            {% if can_update_report_config %}
+                <div class="data-block__card">
+                    <p class="data-block__card-title">{% trans "Report frequency" %}</p>
+                    <p class="data-block__card-copy">{{ object.report_config.get_frequency_display }}</p>
                     <p class="data-block__card-copy">
                         <a data-fancybox data-src="#change-frequency" href="#" class="data-block__action-link">{% if object.report_config.disable_reporting %}{% trans "Enable" %}{% else %}{% trans "Change" %}{% endif %}</a>
                     </p>
                     <!-- Change report frequency modal -->
                     {% include 'application_projects/includes/report_frequency_config.html' with form=update_frequency_form extra_classes="form--report-frequency" config=object.report_config %}
-
-                {% endif %}
-            </div>
+                </div>
+            {% endif %}
             <ul class="data-block__list">
                 {% for report in object.report_config.past_due_reports %}
                     {% include "application_projects/includes/report_line.html" with report=report %}
@@ -60,13 +59,17 @@
                             </td>
                             <td class="data-block__links">
                                 {% if not report.skipped %}
+                                    {% user_can_view_report report user as can_view_report %}
+                                    {% if can_view_report %}
                                     <a class="data-block__action-link" href="{% url "apply:projects:reports:detail" pk=report.pk %}">{% trans "View" %}</a>
+                                    {% endif %}
 
-                                    {% if request.user.is_apply_staff and can_edit_reports %}
+                                    {% user_can_update_report report user as can_update_report %}
+                                    {% if can_update_report %}
                                         <a class="data-block__action-link" href="{% url "apply:projects:reports:edit" pk=report.pk %}">{% trans "Edit" %}</a>
                                     {% endif %}
                                 {% else %}
-                                    {% if request.user.is_apply_staff %}
+                                    {% if can_update_project_reports %}
                                         <form action="{% url "apply:projects:reports:skip" pk=report.pk %}" method="post">
                                             {% csrf_token %}
                                             <button type="submit" class="btn data-block__action-link">{% trans "Unskip" %}</button>

--- a/hypha/apply/projects/templates/application_projects/project_detail.html
+++ b/hypha/apply/projects/templates/application_projects/project_detail.html
@@ -106,8 +106,8 @@
                 </div>
                 {% endif %}
 
-                {% user_can_view_reports object user as can_view_reports %}
-                {% if can_view_reports %}
+                {% project_can_have_report object as can_have_reports %}
+                {% if can_have_reports %}
                     <div class="wrapper wrapper--outer-space-large">
                         {% include "application_projects/includes/reports.html" %}
                     </div>

--- a/hypha/apply/projects/templatetags/project_tags.py
+++ b/hypha/apply/projects/templatetags/project_tags.py
@@ -7,24 +7,34 @@ register = template.Library()
 
 
 @register.simple_tag
-def user_can_view_reports(project, user):
+def project_can_have_report(project):
     if project.status in [COMPLETE, CLOSING, IN_PROGRESS]:
         return True
     return False
 
 
 @register.simple_tag
-def user_can_add_reports(project, user):
-    if project.status == IN_PROGRESS:
-        return True
-    return False
+def user_can_update_project_reports(project, user):
+    permission, _ = has_permission('project_reports_update', user, object=project, raise_exception=False)
+    return permission
 
 
 @register.simple_tag
-def user_can_edit_reports(project, user):
-    if project.status == IN_PROGRESS:
-        return True
-    return False
+def user_can_update_report_config(project, user):
+    permission, _ = has_permission('report_config_update', user, object=project, raise_exception=False)
+    return permission
+
+
+@register.simple_tag
+def user_can_update_report(report, user):
+    permission, _ = has_permission('report_update', user, object=report, raise_exception=False)
+    return permission
+
+
+@register.simple_tag
+def user_can_view_report(report, user):
+    permission, _ = has_permission('report_view', user, object=report, raise_exception=False)
+    return permission
 
 
 @register.simple_tag

--- a/hypha/apply/projects/views/report.py
+++ b/hypha/apply/projects/views/report.py
@@ -1,6 +1,5 @@
 from django.contrib.auth.decorators import login_required
 from django.contrib.auth.mixins import UserPassesTestMixin
-from django.core.exceptions import PermissionDenied
 from django.shortcuts import get_object_or_404, redirect
 from django.utils.decorators import method_decorator
 from django.views import View
@@ -55,8 +54,7 @@ class ReportDetailView(DetailView):
     def dispatch(self, *args, **kwargs):
         report = self.get_object()
         permission, _ = has_permission('report_view', self.request.user, object=report, raise_exception=True)
-        if permission:
-            return super().dispatch(*args, **kwargs)
+        return super().dispatch(*args, **kwargs)
 
 
 @method_decorator(login_required, name='dispatch')
@@ -67,8 +65,7 @@ class ReportUpdateView(UpdateView):
     def dispatch(self, *args, **kwargs):
         report = self.get_object()
         permission, _ = has_permission('report_update', self.request.user, object=report, raise_exception=True)
-        if permission:
-            return super().dispatch(*args, **kwargs)
+        return super().dispatch(*args, **kwargs)
 
     def get_initial(self):
         if self.object.draft:

--- a/hypha/apply/projects/views/report.py
+++ b/hypha/apply/projects/views/report.py
@@ -17,6 +17,7 @@ from hypha.apply.utils.views import DelegatedViewMixin
 from ..filters import ReportListFilter
 from ..forms import ReportEditForm, ReportFrequencyForm
 from ..models import Report, ReportConfig, ReportPrivateFiles
+from ..permissions import has_permission
 from ..tables import ReportListTable
 
 
@@ -47,27 +48,27 @@ class ReportAccessMixin(UserPassesTestMixin):
         return False
 
 
-class ReportDetailView(ReportAccessMixin, DetailView):
+@method_decorator(login_required, name='dispatch')
+class ReportDetailView(DetailView):
     model = Report
 
     def dispatch(self, *args, **kwargs):
         report = self.get_object()
-        if not report.current or report.skipped:
-            raise PermissionDenied
-        return super().dispatch(*args, **kwargs)
+        permission, _ = has_permission('report_view', self.request.user, object=report, raise_exception=True)
+        if permission:
+            return super().dispatch(*args, **kwargs)
 
 
-class ReportUpdateView(ReportAccessMixin, UpdateView):
+@method_decorator(login_required, name='dispatch')
+class ReportUpdateView(UpdateView):
     form_class = ReportEditForm
     model = Report
 
     def dispatch(self, *args, **kwargs):
         report = self.get_object()
-        if not report.can_submit:
-            raise PermissionDenied
-        if report.current and self.request.user.is_applicant:
-            raise PermissionDenied
-        return super().dispatch(*args, **kwargs)
+        permission, _ = has_permission('report_update', self.request.user, object=report, raise_exception=True)
+        if permission:
+            return super().dispatch(*args, **kwargs)
 
     def get_initial(self):
         if self.object.draft:


### PR DESCRIPTION
Fixes #3159 

Permissions to test:

When Project is in IN PROGRESS state, these actions should be restricted to 'CLOSING' and 'COMPLETE' states.

- [ ] staff can update the report config 
- [ ] applicants/staff can update/add reports

Similarly, when project is in IN PROGRESS, CLOSING, and COMPLETE state.

- [ ] applicants/staff/finance can see 'view' the reports 