### PR TITLE
Similar UI for Upload contract as supporting documents

### DIFF
--- a/hypha/apply/projects/forms/project.py
+++ b/hypha/apply/projects/forms/project.py
@@ -156,13 +156,17 @@ class SetPendingForm(forms.ModelForm):
         super().clean()
 
 
-class UploadContractForm(forms.ModelForm):
+class UploadContractForm(FileFormMixin, forms.ModelForm):
+    file = SingleFileField(label=_('Contract'), required=True)
+
     class Meta:
         fields = ['file']
         model = Contract
 
 
-class StaffUploadContractForm(forms.ModelForm):
+class StaffUploadContractForm(FileFormMixin, forms.ModelForm):
+    file = SingleFileField(label=_('Contract'), required=True)
+
     class Meta:
         fields = ['file', 'is_signed']
         model = Contract

--- a/hypha/apply/projects/tests/test_forms.py
+++ b/hypha/apply/projects/tests/test_forms.py
@@ -1,6 +1,5 @@
 import json
 from io import BytesIO
-from unittest import mock
 
 from django.core.files.uploadedfile import SimpleUploadedFile
 from django.test import TestCase, override_settings

--- a/hypha/apply/projects/tests/test_forms.py
+++ b/hypha/apply/projects/tests/test_forms.py
@@ -494,8 +494,7 @@ class TestSelectDocumentForm(TestCase):
 
 
 class TestStaffContractUploadForm(TestCase):
-    mock_file = mock.MagicMock(spec=SimpleUploadedFile)
-    mock_file.read.return_value = b"fake file contents"
+    mock_file = SimpleUploadedFile('contract.pdf', BytesIO(b'somebinarydata').read())
 
     def test_staff_can_upload_unsigned(self):
         form = StaffUploadContractForm(data={}, files={'file': self.mock_file})
@@ -509,8 +508,7 @@ class TestStaffContractUploadForm(TestCase):
 
 
 class TestContractUploadForm(TestCase):
-    mock_file = mock.MagicMock(spec=SimpleUploadedFile)
-    mock_file.read.return_value = b"fake file contents"
+    mock_file = SimpleUploadedFile('contract.pdf', BytesIO(b'somebinarydata').read())
 
     def test_applicant_cant_upload_unsigned(self):
         form = UploadContractForm(data={}, files={'file': self.mock_file})


### PR DESCRIPTION
Fixes #3166 

Shows the uploaded file title and also provides the flexibility to drag and drop.