### PR TITLE
Hide section header for section showing status summary

### DIFF
--- a/hypha/apply/funds/templates/funds/includes/status-block.html
+++ b/hypha/apply/funds/templates/funds/includes/status-block.html
@@ -1,7 +1,6 @@
 {% load i18n %}
 <div class="wrapper wrapper--bottom-space">
     <section class="section">
-        <h4 class="heading heading--normal">{% trans "By status" %}</h4>
         <ul class="status-block">
             {% for status, data in status_counts.items %}
                 <li class="status-block__item">


### PR DESCRIPTION
The "By Status" feels unnecessary here, and the UI on the "submissions" and "projects" is made similar to how the info in displayed on the "Dashboard" page. 

![Screenshot 2023-02-20 at 06 48 04@2x](https://user-images.githubusercontent.com/236356/220033526-97767cff-4603-4a35-b8b3-e010318f8157.jpg)


Dashboard page: 
![Screenshot 2023-02-20 at 06 52 23@2x](https://user-images.githubusercontent.com/236356/220033883-bb8bd8d6-7e53-4a2c-8c2e-e0dc87db70d9.jpg)
