### PR TITLE
Fix user objects not linked in slack and email messages

### DIFF
--- a/hypha/apply/activity/tests/test_messaging.py
+++ b/hypha/apply/activity/tests/test_messaging.py
@@ -302,12 +302,12 @@ class TestActivityAdapter(TestCase):
         self.assertIn(submission.phase.display_name, message)
         self.assertIn(old_phase.display_name, message)
 
-    def test_lead_not_saved_on_activity(self):
+    def test_lead_saved_on_activity(self):
         submission = ApplicationSubmissionFactory()
         user = UserFactory()
         self.adapter.send_message('a message', user=user, source=submission, sources=[], related=user)
         activity = Activity.objects.first()
-        self.assertEqual(activity.related_object, None)
+        self.assertEqual(activity.related_object, user)
 
     def test_review_saved_on_activity(self):
         review = ReviewFactory()

--- a/hypha/apply/users/models.py
+++ b/hypha/apply/users/models.py
@@ -6,6 +6,7 @@ from django.db import IntegrityError, models
 from django.db.models import Q
 from django.db.models.constants import LOOKUP_SEP
 from django.db.models.utils import resolve_callables
+from django.urls import reverse
 from django.utils.functional import cached_property
 from django.utils.translation import gettext_lazy as _
 from wagtail.admin.panels import FieldPanel, MultiFieldPanel
@@ -269,6 +270,14 @@ class User(AbstractUser):
     @cached_property
     def is_contracting_approver(self):
         return self.groups.filter(name=CONTRACTING_GROUP_NAME).exists() and self.groups.filter(name=APPROVER_GROUP_NAME).exists()
+
+    def get_absolute_url(self):
+        """Used in the activities messages to generate URL for user instances.
+
+        Returns:
+           url pointing to the wagtail admin, as there are no public urls for user.
+        """
+        return reverse('wagtailusers_users:edit', args=[self.id])
 
     class Meta:
         ordering = ('full_name', 'email')


### PR DESCRIPTION
Fixes #3172

The messaging module use model's `get_absolute_url` method
to determine and link a model object to its page.

The user model is linked in the slack messagge template but
didn't have `get_absolute_url()`.
