### PR TITLE
Improve number input field validation

### DIFF
--- a/hypha/static_src/src/sass/apply/components/_form.scss
+++ b/hypha/static_src/src/sass/apply/components/_form.scss
@@ -407,6 +407,11 @@
             color: $color--black-50;
             cursor: not-allowed;
         }
+
+        &.invalid {
+            border: 2px solid $color--error;
+            outline: none;
+        }
     }
 
     &__error {

--- a/hypha/static_src/src/sass/public/components/_form.scss
+++ b/hypha/static_src/src/sass/public/components/_form.scss
@@ -379,6 +379,11 @@
             color: $color--black-50;
             cursor: not-allowed;
         }
+
+        &.invalid {
+            border: 2px solid $color--error;
+            outline: none;
+        }
     }
 
     &__error {

--- a/hypha/templates/base-apply.html
+++ b/hypha/templates/base-apply.html
@@ -42,10 +42,10 @@
         <script src="{% static 'js/js.cookie.min.js' %}"></script>
         <script src="{% static 'js/main-top.js' %}"></script>
 
-        <!-- alphine js start-->
+        <!-- alpine js start -->
         <script defer src="{% static 'js/apply/vendor/alpine-3.11.1.min.js' %}"></script>
         <style> [x-cloak] {display: none !important} </style>
-        <!-- apline.js ends-->
+        <!-- alpine.js end -->
 
         {% if COOKIES_ACCEPTED and MATOMO_URL and MATOMO_SITEID %}
         {# we are only expecting strings, so make sure we escape the values #}

--- a/hypha/templates/base.html
+++ b/hypha/templates/base.html
@@ -55,6 +55,12 @@
         {% block extra_css %}{% endblock %}
         <link rel="stylesheet" href="{% static 'css/print.css' %}" media="print">
 
+        <!-- alpine js start -->
+        <script defer src="{% static 'js/apply/vendor/alpine-3.11.1.min.js' %}"></script>
+        <style> [x-cloak] {display: none !important} </style>
+        <!-- apline.js end -->
+
+
         <script src="{% static 'js/jquery.min.js' %}"></script>
         <script src="{% static 'js/main-top.js' %}"></script>
         {% if COOKIES_ACCEPTED and MATOMO_URL and MATOMO_SITEID %}

--- a/hypha/templates/django/forms/widgets/number.html
+++ b/hypha/templates/django/forms/widgets/number.html
@@ -1,0 +1,23 @@
+{% load i18n %}
+{% comment %}
+Update the number input to validate and display feedback if input is not a valid number.
+
+It upgrades default '<input type=number>' that doesn't allow user to enter any value if it's not a number.
+With this user can enter any text and get a feedback why it's wrong.
+{% endcomment %}
+<span x-data="{
+    value: '{% if widget.value != None %}{{ widget.value|stringformat:'s' }}{% endif %}',
+    get error() {
+        return this.value !== '' && isNaN(this.value) ? '{% trans "This must be a number" %}': ''
+    }
+}">
+    <input x-model='value'
+        :class="error ? 'invalid': ''"
+        type="text"
+        inputmode="numeric"
+        pattern="[0-9.]*"  {% comment %} Allow for digit with a decimal{% endcomment %}
+        name="{{ widget.name }}"
+        {% if widget.value != None %} value="{{ widget.value|stringformat:'s' }}"{% endif %}
+        {% include "django/forms/widgets/attrs.html" %}>
+        <span x-cloak x-show="error" x-text="error" class="form__error-text"></span>
+</span>


### PR DESCRIPTION
Fixes #3213 
Fixes #3194 

- Allow the user to enter any input
- Display instant feedback if the input is not a valid number.

It uses alpine and `isNaN` javascript function for validation
Also, move alpine to be included in both public and apply site; forms right now doesn't use `base_apply.html`

Checkout the video below for it's look and feel.

https://user-images.githubusercontent.com/236356/222098169-a0a57d65-eb8f-4851-9b11-29f1860317c6.mp4

