### PR TITLE
fix: allow editing review with old form

### DIFF
--- a/hypha/apply/review/forms.py
+++ b/hypha/apply/review/forms.py
@@ -64,7 +64,8 @@ class ReviewModelForm(StreamBaseForm, forms.ModelForm, metaclass=MixedMetaClass)
 
     def save(self, commit=True):
         self.instance.score = self.calculate_score(self.cleaned_data)
-        self.instance.recommendation = int(self.cleaned_data[self.instance.recommendation_field.id])
+        if self.instance.recommendation_field.id in self.cleaned_data:
+            self.instance.recommendation = int(self.cleaned_data[self.instance.recommendation_field.id])
         self.instance.is_draft = self.draft_button_name in self.data
         # Old review forms do not have the requred visability field.
         # This will set visibility to PRIVATE by default.
@@ -84,7 +85,10 @@ class ReviewModelForm(StreamBaseForm, forms.ModelForm, metaclass=MixedMetaClass)
     def calculate_score(self, data):
         scores = []
         for field in self.instance.score_fields:
-            score = data.get(field.id)[1]
+            score = data.get(field.id)
+            if score is None:
+                continue
+            score = score[1]
             # Include NA answers as 0.
             if score == NA:
                 score = 0
@@ -93,6 +97,8 @@ class ReviewModelForm(StreamBaseForm, forms.ModelForm, metaclass=MixedMetaClass)
         # append scores from them.
         for field in self.instance.score_fields_without_text:
             score = data.get(field.id)
+            if score is None:
+                continue
             # Include '' answers as 0.
             if score == '':
                 score = 0


### PR DESCRIPTION
Closes #3254

Checks for missing form fields, none types in review editing

Further note:

This only fixes the 500 error as it appears.  When doing some testing on it, I noticed that the following also failed when working with a review that had its scores deleted, and then was edited:

* View All reviews on the submission leads to a 500 error
* Viewing the review itself seems to be missing some information (like the new score if I added one)

Because this is issue/PR is us trying to move changes we made to our fork into upstream to align the two codebases, I am submitting it as is.  For the other issues, would it be better to hold off on this fix until we have time to address some of the other things that pop up, or just create issues for them?  I lean toward merging and creating issues just because this PR does remove a 500 error and iterates toward a bug free system.
