### PR TITLE
fix: eliminate review creation integrity error

### DIFF
--- a/hypha/apply/funds/models/submissions.py
+++ b/hypha/apply/funds/models/submissions.py
@@ -1061,7 +1061,7 @@ class AssignedReviewersQuerySet(models.QuerySet):
 
         group = Group.objects.get(name=groups.pop())
 
-        return self.get_or_create(
+        return self.update_or_create(
             submission=submission,
             reviewer=reviewer,
             type=group,
@@ -1075,18 +1075,8 @@ class AssignedReviewersQuerySet(models.QuerySet):
         )
 
     def bulk_create_reviewers(self, reviewers, submission):
-        group = Group.objects.get(name=REVIEWER_GROUP_NAME)
-        self.bulk_create(
-            [
-                self.model(
-                    submission=submission,
-                    role=None,
-                    reviewer=reviewer,
-                    type=group,
-                ) for reviewer in reviewers
-            ],
-            ignore_conflicts=True
-        )
+        for reviewer in reviewers:
+            self.get_or_create_for_user(submission, reviewer)
 
     def update_role(self, role, reviewer, *submissions):
         # Remove role who didn't review

--- a/hypha/apply/funds/tests/test_forms.py
+++ b/hypha/apply/funds/tests/test_forms.py
@@ -92,12 +92,16 @@ class TestReviewerFormQueries(TestCase):
 
         # 1 - Submission
         # 1 - Select Review
-        # 2 - Cascase
+        # 2 - Cascade
         # 1 - Fetch data
         # 1 - Cache existing
-        # 1 - auth group
-        # 1 - Add new
-        with self.assertNumQueries(8):
+        # 18 - 9 per reviewer
+        #    2 - auth group
+        #    2 - savepoint
+        #    2 - release savepoint
+        #    1 - Select reviewer
+        #    1 - Add
+        with self.assertNumQueries(22):
             form.save()
 
     def test_queries_existing_reviews(self):
@@ -116,8 +120,11 @@ class TestReviewerFormQueries(TestCase):
         self.assertTrue(form.is_valid())
 
         # 1 - Submission
-        # 1 - Delete old
-        # 1 - Cache existing
-        # 1 - Add new
-        with self.assertNumQueries(5):
+        # 18 - 9 per reviewer
+        #    2 - auth group
+        #    2 - savepoint
+        #    2 - release savepoint
+        #    1 - Select reviewer
+        #    1 - Add
+        with self.assertNumQueries(19):
             form.save()


### PR DESCRIPTION
Fixes #3255

This fixes the error in #3255 by changing how the reviewers are added.  We know that the 500 does go away, and that reviews are able to be added, however we didn't have the fullest understanding of the change we made.  Some extra help looking at it to point out any edge cases that would be missed would be awesome!