### PR TITLE
Fix editing of review after review form is updated

### DIFF
--- a/hypha/apply/review/models.py
+++ b/hypha/apply/review/models.py
@@ -204,7 +204,7 @@ class Review(ReviewFormFieldsMixin, BaseStreamForm, AccessFormData, models.Model
 
     @cached_property
     def is_updated(self):
-        # Only compear dates, not time.
+        # Only compare dates, not time.
         return self.created_at.date() < self.updated_at.date()
 
 

--- a/hypha/apply/review/templates/review/review_detail.html
+++ b/hypha/apply/review/templates/review/review_detail.html
@@ -14,7 +14,7 @@
     </div>
 </div>
 
-<div class="grid">
+<div style="display: flex; gap: 2rem; padding-top: 2rem;">
     <div>
         <h5>{% trans "Recommendation" %}</h5>
         <p>{{ review.get_recommendation_display }}</p>
@@ -23,6 +23,7 @@
         <h5>{% trans "Score" %}</h5>
         <p>{{ review.get_score_display }}</p>
     </div>
+    <div style="flex-grow: 1"></div>
     <div>
         <svg class="icon icon--eye"><use xlink:href="#eye"></use></svg>
         {{ review.get_visibility_display }}

--- a/hypha/apply/review/views.py
+++ b/hypha/apply/review/views.py
@@ -91,7 +91,7 @@ class ReviewEditView(UserPassesTestMixin, BaseStreamForm, UpdateView):
         """Retrieve currently stored form_fields, if it exists, else retrieve it from the form configured
         in the rounds/lab of the submission.
 
-        This ensures submitted reviews are affected by the changes to the original review forms.
+        This ensures editing of submitted review is not affected by the changes to the original review forms.
         """
         review = self.get_object()
         return review.form_fields or get_fields_for_stage(review.submission, user=self.request.user)

--- a/hypha/apply/review/views.py
+++ b/hypha/apply/review/views.py
@@ -88,8 +88,13 @@ class ReviewEditView(UserPassesTestMixin, BaseStreamForm, UpdateView):
         )
 
     def get_defined_fields(self):
+        """Retrieve currently stored form_fields, if it exists, else retrieve it from the form configured
+        in the rounds/lab of the submission.
+
+        This ensures submitted reviews are affected by the changes to the original review forms.
+        """
         review = self.get_object()
-        return get_fields_for_stage(review.submission, user=self.request.user)
+        return review.form_fields or get_fields_for_stage(review.submission, user=self.request.user)
 
     def get_form_kwargs(self):
         review = self.get_object()


### PR DESCRIPTION
While editing a form, do not use the form assigned to the 
Round/lab, instead, use the form used while writing the review
for the first time

This PR also tweaks the look of the view review page; see the screenshot below.

![Screenshot 2023-03-10 at 11 05 34@2x](https://user-images.githubusercontent.com/236356/224300352-31786759-83ab-4a1d-94c0-173f177cf4a5.jpg)



Fixes #3254 
Closes #3263