### PR TITLE
Underline social media and footer links

### DIFF
--- a/hypha/static_src/src/sass/public/layout/_footer.scss
+++ b/hypha/static_src/src/sass/public/layout/_footer.scss
@@ -8,9 +8,11 @@
     a {
         color: inherit;
     }
-    a:hover{
+
+    a:hover {
         text-decoration: underline;
     }
+
     &__inner {
         padding: 20px;
 

--- a/hypha/static_src/src/sass/public/layout/_footer.scss
+++ b/hypha/static_src/src/sass/public/layout/_footer.scss
@@ -8,7 +8,9 @@
     a {
         color: inherit;
     }
-
+    a:hover{
+        text-decoration: underline;
+    }
     &__inner {
         padding: 20px;
 


### PR DESCRIPTION
Fixes #3281

Footer links are underlined on hover.

![Footer social link hovered](https://user-images.githubusercontent.com/111306331/225321843-2fc5c8e2-911a-499a-9890-748ca8861d9e.png)
![Footer menu link hovered](https://user-images.githubusercontent.com/111306331/225321850-270d3443-c4cc-43de-9a18-fca12f0874d2.png)

