### PR TITLE
Links in tables changed to blue color with underline

### DIFF
--- a/hypha/static_src/src/sass/apply/components/_all-submissions-table.scss
+++ b/hypha/static_src/src/sass/apply/components/_all-submissions-table.scss
@@ -112,8 +112,6 @@
                         }
                     }
                 }
-
-
             }
 
             // project status label

--- a/hypha/static_src/src/sass/apply/components/_all-submissions-table.scss
+++ b/hypha/static_src/src/sass/apply/components/_all-submissions-table.scss
@@ -113,13 +113,7 @@
                     }
                 }
 
-                a {
-                    color: $color--primary;
 
-                    @include media-query($table-breakpoint) {
-                        color: $color--dark-grey;
-                    }
-                }
             }
 
             // project status label

--- a/hypha/static_src/src/sass/apply/components/_table.scss
+++ b/hypha/static_src/src/sass/apply/components/_table.scss
@@ -95,6 +95,7 @@ table {
             &.title {
                 a {
                     font-weight: $weight--bold;
+                    text-decoration: underline;
                 }
             }
         }


### PR DESCRIPTION
Fixes #3283

Titles are formatted as links.

![image](https://user-images.githubusercontent.com/111306331/225386540-d5ed450c-c3bc-4999-9273-372374eac493.png)
