### PR TITLE
Allow reviewer to delete review in review phase

### DIFF
--- a/hypha/apply/review/views.py
+++ b/hypha/apply/review/views.py
@@ -420,7 +420,7 @@ class ReviewDeleteView(UserPassesTestMixin, DeleteView):
 
     def test_func(self):
         review = self.get_object()
-        return self.request.user.has_perm('review.delete_review') or self.request.user == review.author
+        return self.request.user.has_perm('review.delete_review') or self.request.user == review.author.reviewer
 
     def delete(self, request, *args, **kwargs):
         review = self.get_object()


### PR DESCRIPTION
Reviewers can now delete their review when application is in review phase. 

![image](https://user-images.githubusercontent.com/111306331/231749971-d5800a7a-7e42-4fde-bc38-f77522b7b152.png)

Closes #3353 
