### PR TITLE
Fix email whitespaces and allow email translations

### DIFF
--- a/hypha/apply/activity/adapters/emails.py
+++ b/hypha/apply/activity/adapters/emails.py
@@ -14,6 +14,10 @@ from hypha.apply.users.groups import (
     STAFF_GROUP_NAME,
 )
 from hypha.apply.users.models import User
+from hypha.core.mail import (
+    language,
+    remove_extra_empty_lines,
+)
 
 from ..options import MESSAGES
 from ..tasks import send_mail
@@ -350,7 +354,11 @@ class EmailAdapter(AdapterBase):
             )
 
     def render_message(self, template, **kwargs):
-        return render_to_string(template, kwargs, kwargs['request'])
+
+        with language(settings.LANGUAGE_CODE):
+            text = render_to_string(template, kwargs, kwargs['request'])
+
+        return remove_extra_empty_lines(text)
 
     def send_message(self, message, source, subject, recipient, logs, **kwargs):
         try:

--- a/hypha/apply/activity/templates/messages/email/contract_uploaded.html
+++ b/hypha/apply/activity/templates/messages/email/contract_uploaded.html
@@ -3,34 +3,33 @@
 {% load i18n %}
 
 {% block salutation %}
-    {% if request.user != source.user %}
-        {% blocktrans with name=source.user.get_full_name|default:"applicant" %}Dear {{ name }},{% endblocktrans %}
-    {% endif %}
+{% if request.user != source.user %}
+{% blocktrans with name=source.user.get_full_name|default:"applicant" %}Dear {{ name }},{% endblocktrans %}
+{% endif %}
 {% endblock %}
 
 {% block content %}
 
-        {% trans "A new contract has been added to your Project" %}:
+{% trans "A new contract has been added to your Project" %}:
 
-        {% trans "Title" %}: {{ source.title }}
-        {% trans "Link" %}: {{ request.scheme }}://{{ request.get_host }}{{ source.get_absolute_url }}
+{% trans "Title" %}: {{ source.title }}
+{% trans "Link" %}: {{ request.scheme }}://{{ request.get_host }}{{ source.get_absolute_url }}
 
-        {% if contract.is_signed %}
-        {% trans "This contract has already been signed and there is no action for you to take." %}
-        {% else %}
-        {% blocktrans %}Please review the contract and sign it before reuploading it to your Project page for the {{ ORG_SHORT_NAME }} Team to approve.{% endblocktrans %}
-        {% endif %}
+{% if contract.is_signed %}
+{% trans "This contract has already been signed and there is no action for you to take." %}
+{% else %}
+{% blocktrans %}Please review the contract and sign it before reuploading it to your Project page for the {{ ORG_SHORT_NAME }} Team to approve.{% endblocktrans %}
+{% endif %}
 {% endblock %}
 
 
 {% block more_info %}
-    {% if request.user != source.user %}
-        {% trans "Link to your application" %}: {{ request.scheme }}://{{ request.get_host }}{{ source.get_absolute_url }}
-        {% trans "If you have any questions, please submit them here" %}: {{ request.scheme }}://{{ request.get_host }}{{ source.get_absolute_url }}#communications
+{% if request.user != source.user %}
+{% trans "Link to your application" %}: {{ request.scheme }}://{{ request.get_host }}{{ source.get_absolute_url }}
+{% trans "If you have any questions, please submit them here" %}: {{ request.scheme }}://{{ request.get_host }}{{ source.get_absolute_url }}#communications
 
-        {% trans "See our guide for more information" %}: {{ ORG_GUIDE_URL }}
+{% trans "See our guide for more information" %}: {{ ORG_GUIDE_URL }}
 
-        {% blocktrans %}If you have any issues accessing the submission system or other general inquiries, please email us at {{ ORG_EMAIL }}{% endblocktrans %}
-    {% endif %}
+{% blocktrans %}If you have any issues accessing the submission system or other general inquiries, please email us at {{ ORG_EMAIL }}{% endblocktrans %}
+{% endif %}
 {% endblock %}
-

--- a/hypha/apply/activity/templates/messages/email/invoice_status_updated.html
+++ b/hypha/apply/activity/templates/messages/email/invoice_status_updated.html
@@ -7,7 +7,7 @@
 {% blocktrans with status=invoice.get_status_display %}It is now {{ status }}.{% endblocktrans %}
 
 {% if has_changes_requested and invoice.comment %}
-    {% trans "The staff member left this comment" %}:
+{% trans "The staff member left this comment" %}:
 
     {{ invoice.comment }}
 {% endif %}

--- a/hypha/apply/activity/templates/messages/email/submit_contract_documents.html
+++ b/hypha/apply/activity/templates/messages/email/submit_contract_documents.html
@@ -6,10 +6,10 @@
 {% endblock %}
 
 {% block content %}
-    {% trans "A Project's contract is awaiting your review." %}
+{% trans "A Project's contract is awaiting your review." %}
 
-    {% trans "Title" %}: {{ source.title }}
-    {% trans "Link" %}: {{ request.scheme }}://{{ request.get_host }}{{ source.get_absolute_url }}
+{% trans "Title" %}: {{ source.title }}
+{% trans "Link" %}: {{ request.scheme }}://{{ request.get_host }}{{ source.get_absolute_url }}
 
-    {% blocktrans with lead=source.lead email=source.lead.email %}Please contact {{ lead }} - {{ email }} if you have any questions.{% endblocktrans %}
+{% blocktrans with lead=source.lead email=source.lead.email %}Please contact {{ lead }} - {{ email }} if you have any questions.{% endblocktrans %}
 {% endblock %}

--- a/hypha/core/mail.py
+++ b/hypha/core/mail.py
@@ -13,7 +13,7 @@ from hypha.core.utils import markdown_to_html
 logger = logging.getLogger(__name__)
 
 
-def cleanup_markdown(text):
+def remove_extra_empty_lines(text: str) -> str:
     """Removes extra blank lines and spaces from markdown generated
     using Django templates. Do this for readably of markdown itself.
     """
@@ -65,7 +65,7 @@ class MarkdownMail(object):
 
         with language(lang):
             rendered_template = self._render_template(context)
-            body_txt = cleanup_markdown(rendered_template)
+            body_txt = remove_extra_empty_lines(rendered_template)
             body_html = markdown_to_html(rendered_template)
 
         email = EmailMultiAlternatives(**kwargs)


### PR DESCRIPTION
Due the way the `AdapterBase` for messages is structured, there is not easy to send markdown emails. Right now, it fixes few templates that had horizontal whitespaces issues.

We also use translations while rendering template as string and then remove extra lines introduced due to Django template tags.

Fixes #3173 #3243