### PR TITLE
Set margin-block on p-tags since TailWind resets margins.

### DIFF
--- a/hypha/static_src/src/sass/apply/base/_base.scss
+++ b/hypha/static_src/src/sass/apply/base/_base.scss
@@ -55,6 +55,10 @@ a {
     }
 }
 
+p {
+    margin-block: 1rem;
+}
+
 ul,
 ol {
     padding: 0;


### PR DESCRIPTION
Fixes #3364
