### PR TITLE
Reviewers sorted according to recommendation types.

### DIFF
--- a/hypha/apply/funds/templates/funds/includes/review_sidebar.html
+++ b/hypha/apply/funds/templates/funds/includes/review_sidebar.html
@@ -24,7 +24,7 @@
             {% endifchanged %}
         {% endif %}
 
-        {% for reviewer in reviewers %}
+        {% for reviewer in reviewers|order_by %}
             {% if reviewer_type.name in hidden_types %}
                 {% include 'funds/includes/review_sidebar_item.html' with reviewer=reviewer hidden=True %}
 

--- a/hypha/apply/funds/templates/funds/tables/table.html
+++ b/hypha/apply/funds/templates/funds/tables/table.html
@@ -45,7 +45,7 @@
 
                         <td>
                             <ul class="list list--no-margin">
-                                {% for reviewer in submission.has_reviewed %}
+                                {% for reviewer in submission.has_reviewed|order_by %}
                                     <li class="list__item list__item--has-reviewed ">
                                         <span class="list__item--reviewer-name truncate">
                                             {{ reviewer }}

--- a/hypha/apply/review/templatetags/review_tags.py
+++ b/hypha/apply/review/templatetags/review_tags.py
@@ -57,3 +57,8 @@ def average_review_score(reviewers):
             return 0
     else:
         return reviewers
+
+@register.filter_function
+def order_by(reviewers):
+    reviewers.sort(key=lambda reviewer: reviewer.review.recommendation if not reviewer.has_review else -1,reverse=True)
+    return reviewers


### PR DESCRIPTION
Reviewers sorted according to recommendation types.

In submission list under **Review outcomes** all reviewers are sorted. 

![image](https://user-images.githubusercontent.com/111306331/235220653-2066264b-81d1-4029-a734-7eb580d7a816.png)

In **Reviews and assignee's box,** reviewers are first grouped according to their roles and than these groups are sorted.

![image](https://user-images.githubusercontent.com/111306331/235220884-04ec1e39-0553-46e2-9d43-71cdc54362ef.png)


Closes #3381 
