### PR TITLE
Fix extra margin on the admin bar sub title

### DIFF
--- a/hypha/core/templates/components/admin_bar.html
+++ b/hypha/core/templates/components/admin_bar.html
@@ -4,7 +4,7 @@
     <div class="admin-bar__inner items-center md:flex md:justify-between">
         <div>
             <h1 class="text-2xl mb-0 font-bold md:text-3xl md:m-0">{% render_slot slots.header %}</h1>
-            {% if slots.sub_heading %}<p class="text-sm hidden md:block">{% render_slot slots.sub_heading %}</p>{% endif %}
+            {% if slots.sub_heading %}<p class="text-sm hidden md:block m-0">{% render_slot slots.sub_heading %}</p>{% endif %}
         </div>
 
         {% render_slot slots.inner_block %}


### PR DESCRIPTION
Regression bug:

Before:
![Screenshot 2023-04-30 at 07 11 20](https://user-images.githubusercontent.com/236356/235340635-cce898e9-ad3a-4914-b7b5-fdc350dbea55.jpg)

After the fix:

![Screenshot 2023-04-30 at 07 10 59](https://user-images.githubusercontent.com/236356/235340615-d25e10c4-ad5f-4052-a508-407d7a68023f.jpg)
