### PR TITLE
Fix ruff bugbear issues

### DIFF
--- a/hypha/apply/api/v1/determination/serializers.py
+++ b/hypha/apply/api/v1/determination/serializers.py
@@ -13,10 +13,7 @@ class SubmissionDeterminationSerializer(serializers.ModelSerializer):
 
     def validate(self, data):
         validated_data = super().validate(data)
-        validated_data['form_data'] = {
-            key: value
-            for key, value in validated_data.items()
-        }
+        validated_data['form_data'] = dict(validated_data.items())
         return validated_data
 
     def update(self, instance, validated_data):

--- a/hypha/apply/api/v1/review/serializers.py
+++ b/hypha/apply/api/v1/review/serializers.py
@@ -42,10 +42,7 @@ class SubmissionReviewSerializer(serializers.ModelSerializer):
 
     def validate(self, data):
         validated_data = super().validate(data)
-        validated_data['form_data'] = {
-            key: value
-            for key, value in validated_data.items()
-        }
+        validated_data['form_data'] = dict(validated_data.items())
         return validated_data
 
     def update(self, instance, validated_data):

--- a/hypha/apply/funds/tests/test_views.py
+++ b/hypha/apply/funds/tests/test_views.py
@@ -238,7 +238,7 @@ class TestStaffSubmissionView(BaseSubmissionViewTestCase):
     def test_can_create_project(self):
         # check submission doesn't already have a Project
         with self.assertRaisesMessage(Project.DoesNotExist, 'ApplicationSubmission has no project.'):
-            self.submission.project
+            self.submission.project  # noqa: B018
 
         self.post_page(self.submission, {
             'form-submitted-project_form': '',

--- a/hypha/apply/projects/services/sageintacct/wrapper/api_base.py
+++ b/hypha/apply/projects/services/sageintacct/wrapper/api_base.py
@@ -445,8 +445,11 @@ class ApiBase:
             if paginated_data['@numremaining'] == '0':
                 break
         if filtered_total != len(complete_data):
-            warn(message='Your data may not be complete. Records returned do not equal total query record count',
-                 category=DataIntegrityWarning)
+            warn(
+                message='Your data may not be complete. Records returned do not equal total query record count',
+                category=DataIntegrityWarning,
+                stacklevel=2
+            )
         return complete_data
 
     def get_lookup(self):

--- a/hypha/public/people/management/commands/migrate_people.py
+++ b/hypha/public/people/management/commands/migrate_people.py
@@ -46,13 +46,13 @@ VALID_IMAGE_MIMETYPES = [
 
 
 def valid_url_extension(url, extension_list=VALID_IMAGE_EXTENSIONS):
-    return any([url.endswith(e) for e in extension_list])
+    return any(url.endswith(e) for e in extension_list)
 
 
 def valid_url_mimetype(url, mimetype_list=VALID_IMAGE_MIMETYPES):
     mimetype, encoding = mimetypes.guess_type(url)
     if mimetype:
-        return any([mimetype.startswith(m) for m in mimetype_list])
+        return any(mimetype.startswith(m) for m in mimetype_list)
     else:
         return False
 

--- a/hypha/public/projects/management/commands/migrate_projects.py
+++ b/hypha/public/projects/management/commands/migrate_projects.py
@@ -42,13 +42,13 @@ VALID_IMAGE_MIMETYPES = [
 
 
 def valid_url_extension(url, extension_list=VALID_IMAGE_EXTENSIONS):
-    return any([url.endswith(e) for e in extension_list])
+    return any(url.endswith(e) for e in extension_list)
 
 
 def valid_url_mimetype(url, mimetype_list=VALID_IMAGE_MIMETYPES):
     mimetype, encoding = mimetypes.guess_type(url)
     if mimetype:
-        return any([mimetype.startswith(m) for m in mimetype_list])
+        return any(mimetype.startswith(m) for m in mimetype_list)
     else:
         return False
 


### PR DESCRIPTION
On main branch, running`make lint` shows these issues with python 3.11

```shell
❯ make lint
Checking python code style with ruff
ruff .
hypha/apply/api/v1/determination/serializers.py:16:39: C416 [*] Unnecessary `dict` comprehension (rewrite using `dict()`)
hypha/apply/api/v1/review/serializers.py:45:39: C416 [*] Unnecessary `dict` comprehension (rewrite using `dict()`)
hypha/apply/funds/tests/test_views.py:241:13: B018 Found useless expression. Either assign it to a variable or remove it.
hypha/apply/projects/services/sageintacct/wrapper/api_base.py:448:13: B028 No explicit `stacklevel` keyword argument found
hypha/public/people/management/commands/migrate_people.py:49:16: C419 [*] Unnecessary list comprehension.
hypha/public/people/management/commands/migrate_people.py:55:20: C419 [*] Unnecessary list comprehension.
hypha/public/projects/management/commands/migrate_projects.py:45:16: C419 [*] Unnecessary list comprehension.
hypha/public/projects/management/commands/migrate_projects.py:51:20: C419 [*] Unnecessary list comprehension.
Found 8 errors.
```