### PR TITLE
#3401: Configured Submissions table columns and their order

### DIFF
--- a/docs/setup/administrators/configuration.md
+++ b/docs/setup/administrators/configuration.md
@@ -135,11 +135,14 @@ Good for testing, might not be a good idea in production.
 
     SUBMISSIONS_DRAFT_ACCESS_STAFF = env.bool('SUBMISSIONS_DRAFT_ACCESS_STAFF', False)
 
-### Columns to exclude from the submission tables.
+### Columns to include in submission tables and their ordering.
 
-Possible values are: fund, round, status, lead, reviewers, screening_statuses, category_options, meta_terms
+Possible values are: title, submit_time, screening_status, phase, stage, fund, round, lead, last_update, reviews_stats
 
-    SUBMISSIONS_TABLE_EXCLUDED_FIELDS = env.list('SUBMISSIONS_TABLE_EXCLUDED_FIELDS', [])
+    BASE_SUBMISSION_TABLE_FIELDS = env.list('BASE_SUBMISSION_TABLE_FIELDS', ['title', 'submit_time', 'screening_status', 'phase', 'stage', 'fund', 'round', 'lead', 'last_update', 'reviews_stats'])
+
+    SUBMISSION_TABLE_FIELDS = env.list('SUBMISSION_TABLE_FIELDS', ['title', 'submit_time', 'phase', 'stage', 'fund', 'round', 'last_update'])
+
 
 ### Should submission automatically transition after all reviewer roles are assigned.
 

--- a/hypha/apply/funds/tables.py
+++ b/hypha/apply/funds/tables.py
@@ -4,6 +4,7 @@ import textwrap
 import django_filters as filters
 import django_tables2 as tables
 from django import forms
+from django.conf import settings
 from django.contrib.auth import get_user_model
 from django.db.models import F, Q
 from django.urls import reverse
@@ -78,8 +79,8 @@ class SubmissionsTable(tables.Table):
     class Meta:
         model = ApplicationSubmission
         order_by = ('-last_update',)
-        fields = ('title', 'phase', 'stage', 'fund', 'round', 'submit_time', 'last_update')
-        sequence = fields + ('comments',)
+        fields = getattr(settings, "SUBMISSION_TABLE_FIELDS", ())
+        sequence = tuple(fields) + ('comments',)
         template_name = 'funds/tables/table.html'
         row_attrs = {
             'class': make_row_class,
@@ -136,8 +137,8 @@ class BaseAdminSubmissionsTable(SubmissionsTable):
     screening_status = tables.Column(verbose_name=_('Screening'), accessor='screening_statuses')
 
     class Meta(SubmissionsTable.Meta):
-        fields = ('title', 'phase', 'stage', 'fund', 'round', 'lead', 'submit_time', 'last_update', 'screening_status', 'reviews_stats')  # type: ignore
-        sequence = fields + ('comments',)
+        fields = getattr(settings, "BASE_SUBMISSION_TABLE_FIELDS", ())  # type: ignore
+        sequence = tuple(fields) + ('comments',)
 
     def render_lead(self, value):
         return format_html('<span>{}</span>', value)
@@ -170,7 +171,7 @@ class SummarySubmissionsTableWithRole(BaseAdminSubmissionsTable):
     role_icon = tables.Column(verbose_name=_('Role'))
 
     class Meta(BaseAdminSubmissionsTable.Meta):
-        sequence = BaseAdminSubmissionsTable.Meta.fields + ('role_icon', 'comments')
+        sequence = tuple(BaseAdminSubmissionsTable.Meta.fields) + ('role_icon', 'comments')
         orderable = False
 
     def render_role_icon(self, value):

--- a/hypha/apply/funds/views.py
+++ b/hypha/apply/funds/views.py
@@ -185,20 +185,8 @@ class BaseAdminSubmissionsTable(SingleTableMixin, FilterView):
     paginator_class = LazyPaginator
     table_pagination = {'per_page': 25}
 
-    excluded_fields = settings.SUBMISSIONS_TABLE_EXCLUDED_FIELDS
-
-    @property
-    def excluded(self):
-        return {
-            'exclude': self.excluded_fields
-        }
-
-    def get_table_kwargs(self, **kwargs):
-        return {**self.excluded, **kwargs}
-
     def get_filterset_kwargs(self, filterset_class, **kwargs):
         new_kwargs = super().get_filterset_kwargs(filterset_class)
-        new_kwargs.update(self.excluded)
         new_kwargs.update(kwargs)
         return new_kwargs
 
@@ -413,17 +401,6 @@ class AwaitingReviewSubmissionsListView(SingleTableMixin, ListView):
     paginator_class = LazyPaginator
     table_pagination = {'per_page': 25}
 
-    excluded_fields = settings.SUBMISSIONS_TABLE_EXCLUDED_FIELDS
-
-    @property
-    def excluded(self):
-        return {
-            'exclude': self.excluded_fields
-        }
-
-    def get_table_kwargs(self, **kwargs):
-        return {**self.excluded, **kwargs}
-
     def get_queryset(self):
         submissions = ApplicationSubmission.objects.in_review_for(self.request.user).order_by('-submit_time')
         return submissions.for_table(self.request.user)
@@ -625,7 +602,16 @@ class SubmissionsByRound(BaseAdminSubmissionsTable, DelegateableListView):
         BatchArchiveSubmissionView,
     ]
 
-    excluded_fields = ['round', 'fund'] + settings.SUBMISSIONS_TABLE_EXCLUDED_FIELDS
+    excluded_fields = ['round', 'fund']
+
+    @property
+    def excluded(self):
+        return {
+            'exclude': self.excluded_fields
+        }
+
+    def get_table_kwargs(self, **kwargs):
+        return {**self.excluded, **kwargs}
 
     def get_form_kwargs(self):
         kwargs = super().get_form_kwargs()
@@ -1532,17 +1518,8 @@ class SubmissionResultView(SubmissionStatsMixin, FilterView):
     filterset_class = SubmissionFilterAndSearch
     filter_action = ''
 
-    excluded_fields = settings.SUBMISSIONS_TABLE_EXCLUDED_FIELDS
-
-    @property
-    def excluded(self):
-        return {
-            'exclude': self.excluded_fields
-        }
-
     def get_filterset_kwargs(self, filterset_class, **kwargs):
         new_kwargs = super().get_filterset_kwargs(filterset_class)
-        new_kwargs.update(self.excluded)
         new_kwargs.update(kwargs)
         return new_kwargs
 

--- a/hypha/settings/base.py
+++ b/hypha/settings/base.py
@@ -88,10 +88,6 @@ SUBMISSIONS_DRAFT_ACCESS_STAFF = env.bool('SUBMISSIONS_DRAFT_ACCESS_STAFF', Fals
 # Should staff admins be able to access/see draft submissions.
 SUBMISSIONS_DRAFT_ACCESS_STAFF_ADMIN = env.bool('SUBMISSIONS_DRAFT_ACCESS_STAFF_ADMIN', False)
 
-# Columns to exclude from the submission tables.
-# Possible values are: fund, round, status, lead, reviewers, screening_statuses, category_options, meta_terms
-SUBMISSIONS_TABLE_EXCLUDED_FIELDS = env.list('SUBMISSIONS_TABLE_EXCLUDED_FIELDS', [])
-
 # Should submission automatically transition after all reviewer roles are assigned.
 TRANSITION_AFTER_ASSIGNED = env.bool('TRANSITION_AFTER_ASSIGNED', False)
 

--- a/hypha/settings/base.py
+++ b/hypha/settings/base.py
@@ -479,5 +479,5 @@ if SENTRY_DSN:
         integrations=[DjangoIntegration()]
     )
 
-BASE_SUBMISSION_TABLE_FIELDS = env.list('TABLE_FIELDS', ['title', 'submit_time', 'screening_status', 'phase', 'stage', 'fund', 'round', 'lead', 'last_update', 'reviews_stats'])
+BASE_SUBMISSION_TABLE_FIELDS = env.list('BASE_SUBMISSION_TABLE_FIELDS', ['title', 'submit_time', 'screening_status', 'phase', 'stage', 'fund', 'round', 'lead', 'last_update', 'reviews_stats'])
 SUBMISSION_TABLE_FIELDS = env.list('SUBMISSION_TABLE_FIELDS', ['title', 'submit_time', 'phase', 'stage', 'fund', 'round', 'last_update'])

--- a/hypha/settings/base.py
+++ b/hypha/settings/base.py
@@ -478,3 +478,6 @@ if SENTRY_DSN:
         debug=SENTRY_DEBUG,
         integrations=[DjangoIntegration()]
     )
+
+BASE_SUBMISSION_TABLE_FIELDS = env.list('TABLE_FIELDS', ['title', 'submit_time', 'screening_status', 'phase', 'stage', 'fund', 'round', 'lead', 'last_update', 'reviews_stats'])
+SUBMISSION_TABLE_FIELDS = env.list('SUBMISSION_TABLE_FIELDS', ['title', 'submit_time', 'phase', 'stage', 'fund', 'round', 'last_update'])


### PR DESCRIPTION
Added a configuration setting to decide which columns to include and their order for Submission table.

![image](https://github.com/HyphaApp/hypha/assets/111306331/f2952949-db0e-47ae-b3ec-38299f3154ef)

![image](https://github.com/HyphaApp/hypha/assets/111306331/6f2478cc-9152-49eb-b0c4-f641623fe681)


Closes #3401 