### PR TITLE
Fix link to documentation on how to contribute

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -2,6 +2,6 @@
 
 First off, thanks for taking the time to contribute! Hypha is improved by a small community of developers, designers and users. We welcome your contributions. 
 
-There are [many ways to contribute](https://docs.hypha.app/contributors) to Hypha - code, design, documentation and translation.
+There are [many ways to contribute](https://docs.hypha.app/getting-started/contributing/code-contributions/) to Hypha - code, design, documentation and translation.
 
-Before you start working however, please [read our guide which covers all the ways you can contribute](https://docs.hypha.app/contributors).
+Before you start working however, please [read our guide which covers all the ways you can contribute](https://docs.hypha.app/getting-started/contributing/code-contributions/).


### PR DESCRIPTION
The previous link was broken (404 error), so this is an improvement. However, an even better fix would be to have a general documentation landing page for all types of contributions, and it would refer out to the type-specific sections (e.g., translations, code contributions, doc contributions).

Currently, because there is no such page, we have to instead point to https://docs.hypha.app/getting-started/contributing/code-contributions/ (i.e., https://docs.hypha.app/getting-started/contributing/ does not exist -- that URL also gets a 404 error).  I think a better fix here would be to first make the latter exist in the documentation, and then re-update the links in CONTRIBUTING.md here to point to the new place. But let not the perfect be the enemy of the good.  This fix is still a great improvement, as it at least gets the user to contribution docs.