### PR TITLE
#3404: Added Configuration settings for comment visibility.

### DIFF
--- a/docs/setup/administrators/configuration.md
+++ b/docs/setup/administrators/configuration.md
@@ -141,6 +141,12 @@ Possible values are: fund, round, status, lead, reviewers, screening_statuses, c
 
     SUBMISSIONS_TABLE_EXCLUDED_FIELDS = env.list('SUBMISSIONS_TABLE_EXCLUDED_FIELDS', [])
 
+### Comment visibility setting for admin, reviewer and partner.
+
+    COMMENT_VISIBILITY_ADMIN = env.list('COMMENT_VISIBITY_ADMIN', ['applicant', 'team', 'reviewers', 'partners', 'all'])
+    COMMENT_VISIBILITY_REVIEWER = env.list('COMMENT_VISIBILITY_REVIEWER', ['reviewers','all'])
+    COMMENT_VISIBILITY_PARTNER = env.list('COMMENT_VISIBILITY_PARTNER', ['partners','all'])
+
 ### Should submission automatically transition after all reviewer roles are assigned.
 
     TRANSITION_AFTER_ASSIGNED = env.bool('TRANSITION_AFTER_ASSIGNED', False)

--- a/docs/setup/administrators/configuration.md
+++ b/docs/setup/administrators/configuration.md
@@ -143,7 +143,7 @@ Possible values are: fund, round, status, lead, reviewers, screening_statuses, c
 
 ### Comment visibility setting for admin, reviewer and partner.
 
-    COMMENT_VISIBILITY_ADMIN = env.list('COMMENT_VISIBITY_ADMIN', ['applicant', 'team', 'reviewers', 'partners', 'all'])
+    COMMENT_VISIBILITY_STAFF = env.list('COMMENT_VISIBILITY_STAFF', ['applicant', 'team', 'reviewers', 'partners', 'all'])
     COMMENT_VISIBILITY_REVIEWER = env.list('COMMENT_VISIBILITY_REVIEWER', ['reviewers','all'])
     COMMENT_VISIBILITY_PARTNER = env.list('COMMENT_VISIBILITY_PARTNER', ['partners','all'])
 

--- a/hypha/apply/activity/models.py
+++ b/hypha/apply/activity/models.py
@@ -136,11 +136,11 @@ class Activity(models.Model):
     @classmethod
     def visibility_for(cls, user):
         if user.is_apply_staff:
-            return [APPLICANT, TEAM, REVIEWER, PARTNER, ALL]
+            return getattr(settings, "COMMENT_VISIBILITY_ADMIN", [])
         if user.is_reviewer:
-            return [REVIEWER, ALL]
+            return getattr(settings, "COMMENT_VISIBILITY_REVIEWER", [])
         if user.is_partner:
-            return [PARTNER, ALL]
+            return getattr(settings, "COMMENT_VISIBILITY_PARTNER", [])
 
         return [APPLICANT, ALL]
 

--- a/hypha/apply/activity/models.py
+++ b/hypha/apply/activity/models.py
@@ -136,11 +136,11 @@ class Activity(models.Model):
     @classmethod
     def visibility_for(cls, user):
         if user.is_apply_staff:
-            return getattr(settings, "COMMENT_VISIBILITY_ADMIN", [])
+            return settings.COMMENT_VISIBILITY_STAFF
         if user.is_reviewer:
-            return getattr(settings, "COMMENT_VISIBILITY_REVIEWER", [])
+            return settings.COMMENT_VISIBILITY_REVIEWER
         if user.is_partner:
-            return getattr(settings, "COMMENT_VISIBILITY_PARTNER", [])
+            return settings.COMMENT_VISIBILITY_PARTNER
 
         return [APPLICANT, ALL]
 

--- a/hypha/settings/base.py
+++ b/hypha/settings/base.py
@@ -480,6 +480,6 @@ if SENTRY_DSN:
     )
 
 # Comment Visibility setting
-COMMENT_VISIBILITY_ADMIN = env.list('COMMENT_VISIBITY_ADMIN', ['applicant', 'team', 'reviewers', 'partners', 'all'])
+COMMENT_VISIBILITY_STAFF = env.list('COMMENT_VISIBILITY_STAFF', ['applicant', 'team', 'reviewers', 'partners', 'all'])
 COMMENT_VISIBILITY_REVIEWER = env.list('COMMENT_VISIBILITY_REVIEWER', ['reviewers','all'])
 COMMENT_VISIBILITY_PARTNER = env.list('COMMENT_VISIBILITY_PARTNER', ['partners','all'])

--- a/hypha/settings/base.py
+++ b/hypha/settings/base.py
@@ -478,3 +478,8 @@ if SENTRY_DSN:
         debug=SENTRY_DEBUG,
         integrations=[DjangoIntegration()]
     )
+
+# Comment Visibility setting
+COMMENT_VISIBILITY_ADMIN = env.list('COMMENT_VISIBITY_ADMIN', ['applicant', 'team', 'reviewers', 'partners', 'all'])
+COMMENT_VISIBILITY_REVIEWER = env.list('COMMENT_VISIBILITY_REVIEWER', ['reviewers','all'])
+COMMENT_VISIBILITY_PARTNER = env.list('COMMENT_VISIBILITY_PARTNER', ['partners','all'])


### PR DESCRIPTION
Added a configuration setting that allows for the customization of the visibility of comments made by admins, reviewers, and partners. This feature provides flexibility and allows for easy modification without the need to manually adjust settings in the models.

Recently, ARDC required the removal of partner from comment visibility, which was easily accomplished by updating the new setting. 

**Settings to consider:**

- ``` COMMENT_VISIBILITY_ADMIN ```
- ``` COMMENT_VISIBILITY_REVIEWER ```
- ``` COMMENT_VISIBILITY_PARTNER ```

Closes #3404 