### PR TITLE
Add link for dashboard/log in after application submission

### DIFF
--- a/hypha/apply/funds/templates/funds/application_base_landing.html
+++ b/hypha/apply/funds/templates/funds/application_base_landing.html
@@ -17,6 +17,15 @@
         {% endif %}
         <p>{% blocktrans with email=ORG_EMAIL|urlize %}If you do not receive an e-mail within 15 minutes please check your
 spam folder and contact {{ email }} for further assistance.{% endblocktrans %}</p>
+
+		<p>
+		{% if request.user.is_authenticated %}
+			<a href="/dashboard/">{% blocktrans %}Return to my dashboard.{% endblocktrans %}</a>
+		{% else %}
+			{% blocktrans %}Once you've activated an account, you can track your submissions after {% endblocktrans %}<a href="/login/">{% blocktrans %}logging in{% endblocktrans %}</a>.
+		{% endif %}
+		</p>
+
         {% with email_context=page.specific %}<p>{{ email_context.confirmation_text_extra|urlize }}</p>{% endwith %}
 
         {% block extra_text %}{{ settings.funds.ApplicationSettings.extra_text_round|richtext }}{% endblock %}

--- a/hypha/apply/funds/templates/funds/application_base_landing.html
+++ b/hypha/apply/funds/templates/funds/application_base_landing.html
@@ -23,7 +23,7 @@
 
 		<p>
 		{% if request.user.is_authenticated %}
-			<a href="{% url 'dashboard:dashboard' %}"><button class="button button--primary">{% blocktrans %}Return to my dashboard.{% endblocktrans %}</button></a>
+			<a href="{% url 'dashboard:dashboard' %}"><button class="button button--primary">{% blocktrans %}Go to my dashboard.{% endblocktrans %}</button></a>
 		{% else %}
 			<a href="{% url 'users_public:login' %}"><button class="button button--primary">{% blocktrans %}Log in{% endblocktrans %}</button></a>
 		{% endif %}

--- a/hypha/apply/funds/templates/funds/application_base_landing.html
+++ b/hypha/apply/funds/templates/funds/application_base_landing.html
@@ -20,9 +20,9 @@ spam folder and contact {{ email }} for further assistance.{% endblocktrans %}</
 
 		<p>
 		{% if request.user.is_authenticated %}
-			<a href="/dashboard/">{% blocktrans %}Return to my dashboard.{% endblocktrans %}</a>
+			<a href="{% url 'dashboard:dashboard' %}"><button class="button button--primary">{% blocktrans %}Return to my dashboard.{% endblocktrans %}</button></a>
 		{% else %}
-			{% blocktrans %}Once you've activated an account, you can track your submissions after {% endblocktrans %}<a href="/login/">{% blocktrans %}logging in{% endblocktrans %}</a>.
+			<a href="{% url 'users_public:login' %}"><button class="button button--primary">{% blocktrans %}Log in{% endblocktrans %}</button></a>.
 		{% endif %}
 		</p>
 

--- a/hypha/apply/funds/templates/funds/application_base_landing.html
+++ b/hypha/apply/funds/templates/funds/application_base_landing.html
@@ -15,20 +15,19 @@
     	{% else %}
         	<p>{% trans "An e-mail with more information has been sent to the address you entered." %}</p>
         {% endif %}
-        <p>{% blocktrans with email=ORG_EMAIL|urlize %}If you do not receive an e-mail within 15 minutes please check your
-spam folder and contact {{ email }} for further assistance.{% endblocktrans %}</p>
+        <p>{% blocktrans with email=ORG_EMAIL|urlize %}If you do not receive an e-mail within 15 minutes please check your spam folder and contact {{ email }} for further assistance.{% endblocktrans %}</p>
+
+        {% with email_context=page.specific %}<p>{{ email_context.confirmation_text_extra|urlize }}</p>{% endwith %}
+
+        {% block extra_text %}{{ settings.funds.ApplicationSettings.extra_text_round|richtext }}{% endblock %}
 
 		<p>
 		{% if request.user.is_authenticated %}
 			<a href="{% url 'dashboard:dashboard' %}"><button class="button button--primary">{% blocktrans %}Return to my dashboard.{% endblocktrans %}</button></a>
 		{% else %}
-			<a href="{% url 'users_public:login' %}"><button class="button button--primary">{% blocktrans %}Log in{% endblocktrans %}</button></a>.
+			<a href="{% url 'users_public:login' %}"><button class="button button--primary">{% blocktrans %}Log in{% endblocktrans %}</button></a>
 		{% endif %}
 		</p>
-
-        {% with email_context=page.specific %}<p>{{ email_context.confirmation_text_extra|urlize }}</p>{% endwith %}
-
-        {% block extra_text %}{{ settings.funds.ApplicationSettings.extra_text_round|richtext }}{% endblock %}
     </div>
 </div>
 {% endblock %}


### PR DESCRIPTION
After submitting application user, if the user is authenticated they will be presented with a link to go to back to dashbaord.

![image](https://github.com/HyphaApp/hypha/assets/111306331/a441f4a2-3f3a-44b8-9ee7-b0d124cc467b)

If user is not authenticated, they will be presented with a link to go to login page.

![image](https://github.com/HyphaApp/hypha/assets/111306331/bfdc27ff-a497-4a5f-a970-0a950bfad314)

Closes #3410 
