### PR TITLE
#3414: Configured setting for displaying total review score on reviews page

### DIFF
--- a/docs/setup/administrators/configuration.md
+++ b/docs/setup/administrators/configuration.md
@@ -141,6 +141,12 @@ Possible values are: fund, round, status, lead, reviewers, screening_statuses, c
 
     SUBMISSIONS_TABLE_EXCLUDED_FIELDS = env.list('SUBMISSIONS_TABLE_EXCLUDED_FIELDS', [])
 
+### Score diplayed on reviews page.
+
+If True sum of scores will be displayed otherwise average of scores will be displayed
+
+    DISPLAY_TOTAL_REVIEW_SCORE = env.bool('DISPLAY_TOTAL_REVIEW_SCORE', default = False)
+
 ### Should submission automatically transition after all reviewer roles are assigned.
 
     TRANSITION_AFTER_ASSIGNED = env.bool('TRANSITION_AFTER_ASSIGNED', False)

--- a/docs/setup/administrators/configuration.md
+++ b/docs/setup/administrators/configuration.md
@@ -143,9 +143,9 @@ Possible values are: fund, round, status, lead, reviewers, screening_statuses, c
 
 ### Score diplayed on reviews page.
 
-If True sum of scores will be displayed otherwise average of scores will be displayed
+If 'sum' sum of score will be displayed, if 'avg' average of score will be displayed, empty string is for use-cases where no final summary is desired by any setup.
 
-    DISPLAY_TOTAL_REVIEW_SCORE = env.bool('DISPLAY_TOTAL_REVIEW_SCORE', default = False)
+    REVIEWS_FINAL_SCORE_METHOD: Literal['sum', 'avg', ''] = env.str('REVIEWS_FINAL_SCORE_METHOD', default='avg')
 
 ### Should submission automatically transition after all reviewer roles are assigned.
 

--- a/hypha/apply/review/forms.py
+++ b/hypha/apply/review/forms.py
@@ -99,13 +99,15 @@ class ReviewModelForm(StreamBaseForm, forms.ModelForm, metaclass=MixedMetaClass)
                 score = 0
             scores.append(int(score))
 
-        if settings.DISPLAY_TOTAL_REVIEW_SCORE:
+        if settings.REVIEWS_FINAL_SCORE_METHOD == 'sum':
             return sum(scores)
-        else:
+        elif settings.REVIEWS_FINAL_SCORE_METHOD == 'avg':
             try:
                 return sum(scores) / len(scores)
             except ZeroDivisionError:
                 return NA
+        else:
+            return NA
 
 
 class SubmitButtonWidget(forms.Widget):

--- a/hypha/apply/review/forms.py
+++ b/hypha/apply/review/forms.py
@@ -1,4 +1,5 @@
 from django import forms
+from django.conf import settings
 from django.core.exceptions import NON_FIELD_ERRORS
 from django.utils.html import escape
 
@@ -98,10 +99,13 @@ class ReviewModelForm(StreamBaseForm, forms.ModelForm, metaclass=MixedMetaClass)
                 score = 0
             scores.append(int(score))
 
-        try:
-            return sum(scores) / len(scores)
-        except ZeroDivisionError:
-            return NA
+        if settings.DISPLAY_TOTAL_REVIEW_SCORE:
+            return sum(scores)
+        else:
+            try:
+                return sum(scores) / len(scores)
+            except ZeroDivisionError:
+                return NA
 
 
 class SubmitButtonWidget(forms.Widget):

--- a/hypha/settings/base.py
+++ b/hypha/settings/base.py
@@ -3,6 +3,7 @@ Hypha project base settings.
 """
 
 import os
+from typing import Literal
 
 import dj_database_url
 from environs import Env
@@ -18,6 +19,7 @@ BASE_DIR = os.path.dirname(PROJECT_DIR)
 
 
 # Hypha custom settings
+REVIEWS_FINAL_SCORE_METHOD: Literal['sum', 'avg', ''] = env.str('REVIEWS_FINAL_SCORE_METHOD', default='avg')
 
 # Set the currency symbol to be used.
 CURRENCY_SYMBOL = env.str('CURRENCY_SYMBOL', '$')
@@ -479,4 +481,3 @@ if SENTRY_DSN:
         integrations=[DjangoIntegration()]
     )
 
-DISPLAY_TOTAL_REVIEW_SCORE = env.bool('DISPLAY_TOTAL_REVIEW_SCORE', default = False)

--- a/hypha/settings/base.py
+++ b/hypha/settings/base.py
@@ -478,3 +478,5 @@ if SENTRY_DSN:
         debug=SENTRY_DEBUG,
         integrations=[DjangoIntegration()]
     )
+
+DISPLAY_TOTAL_REVIEW_SCORE = env.bool('DISPLAY_TOTAL_REVIEW_SCORE', default = False)


### PR DESCRIPTION
Configured a setting for displaying total review score instead of average score. Each organization can customize it accordingly. 

**Setting to consider:** 

- ```DISPLAY_TOTAL_REVIEW_SCORE```

Closes #3414 