### PR TITLE
Fix max recursion error on vendor setup page

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -16,6 +16,7 @@ django-countries==7.5
 django-extensions==3.2.1
 django-file-form==3.4.3
 django-filter==2.4.0
+django-formtools==2.4.1
 django-fsm==2.8.1
 django-heroku==0.3.1
 django-hijack==3.2.6


### PR DESCRIPTION
Fixes #3395 

It was a package(django-formtools) issue, they have also mentioned it in [latest version](https://django-formtools.readthedocs.io/en/latest/changelog.html#id1). 