### PR TITLE
#3417: Configured default visibility for review

### DIFF
--- a/docs/setup/administrators/configuration.md
+++ b/docs/setup/administrators/configuration.md
@@ -160,6 +160,14 @@ Possible values are: fund, round, status, lead, reviewers, screening_statuses, c
 
     SUBMISSIONS_TABLE_EXCLUDED_FIELDS = env.list('SUBMISSIONS_TABLE_EXCLUDED_FIELDS', [])
 
+### Default visibility for reviews.
+
+Possible values are: 'reviewers' or 'private'. 
+Private: Visible only to staff.
+Reviewers: Visible to other reviewers and staff.
+
+    DEFAULT_REVIEW_VISIBILITY = env.str('DEFAULT_REVIEW_VISIBILITY', 'private')
+
 ### Should submission automatically transition after all reviewer roles are assigned.
 
     TRANSITION_AFTER_ASSIGNED = env.bool('TRANSITION_AFTER_ASSIGNED', False)

--- a/docs/setup/administrators/configuration.md
+++ b/docs/setup/administrators/configuration.md
@@ -166,7 +166,7 @@ Possible values are: 'reviewers' or 'private'.
 Private: Visible only to staff.
 Reviewers: Visible to other reviewers and staff.
 
-    DEFAULT_REVIEW_VISIBILITY = env.str('DEFAULT_REVIEW_VISIBILITY', 'private')
+    REVIEW_VISIBILITY_DEFAULT = env.str('REVIEW_VISIBILITY_DEFAULT', 'private')
 
 ### Should submission automatically transition after all reviewer roles are assigned.
 

--- a/hypha/apply/review/blocks.py
+++ b/hypha/apply/review/blocks.py
@@ -1,6 +1,7 @@
 import json
 
 from django import forms
+from django.conf import settings
 from django.utils.safestring import mark_safe
 from django.utils.translation import gettext_lazy as _
 from wagtail.blocks import RichTextBlock
@@ -8,7 +9,6 @@ from wagtail.blocks import RichTextBlock
 from hypha.apply.review.fields import ScoredAnswerField
 from hypha.apply.review.options import (
     NA,
-    PRIVATE,
     RATE_CHOICE_NA,
     RATE_CHOICES,
     RATE_CHOICES_DICT,
@@ -152,7 +152,7 @@ class VisibilityBlock(ReviewMustIncludeFieldBlock):
     def get_field_kwargs(self, struct_value):
         kwargs = super(VisibilityBlock, self).get_field_kwargs(struct_value)
         kwargs["choices"] = VISIBILITY.items()
-        kwargs["initial"] = PRIVATE
+        kwargs["initial"] = settings.DEFAULT_REVIEW_VISIBILITY
         kwargs["help_text"] = mark_safe(
             "<br>".join(
                 [

--- a/hypha/apply/review/blocks.py
+++ b/hypha/apply/review/blocks.py
@@ -152,7 +152,7 @@ class VisibilityBlock(ReviewMustIncludeFieldBlock):
     def get_field_kwargs(self, struct_value):
         kwargs = super(VisibilityBlock, self).get_field_kwargs(struct_value)
         kwargs["choices"] = VISIBILITY.items()
-        kwargs["initial"] = settings.DEFAULT_REVIEW_VISIBILITY
+        kwargs["initial"] = settings.REVIEW_VISIBILITY_DEFAULT
         kwargs["help_text"] = mark_safe(
             "<br>".join(
                 [

--- a/hypha/settings/base.py
+++ b/hypha/settings/base.py
@@ -18,7 +18,6 @@ BASE_DIR = os.path.dirname(PROJECT_DIR)
 
 
 # Hypha custom settings
-REVIEW_VISIBILITY_DEFAULT = env.str('REVIEW_VISIBILITY_DEFAULT', 'private')
 
 # Set the currency symbol to be used.
 CURRENCY_CODE = env.str("CURRENCY_CODE", "USD")
@@ -144,6 +143,9 @@ TRANSITION_AFTER_ASSIGNED = env.bool("TRANSITION_AFTER_ASSIGNED", False)
 # Should submission automatically transition after n number of reviews.
 # Possible values are: False, 1,2,3,…
 TRANSITION_AFTER_REVIEWS = env.bool("TRANSITION_AFTER_REVIEWS", False)
+
+# Default visibility for reviews.
+REVIEW_VISIBILITY_DEFAULT = env.str("REVIEW_VISIBILITY_DEFAULT", "private")
 
 
 # Project settings.

--- a/hypha/settings/base.py
+++ b/hypha/settings/base.py
@@ -18,6 +18,7 @@ BASE_DIR = os.path.dirname(PROJECT_DIR)
 
 
 # Hypha custom settings
+REVIEW_VISIBILITY_DEFAULT = env.str('REVIEW_VISIBILITY_DEFAULT', 'private')
 
 # Set the currency symbol to be used.
 CURRENCY_CODE = env.str("CURRENCY_CODE", "USD")
@@ -611,5 +612,3 @@ if SENTRY_DSN:
         debug=SENTRY_DEBUG,
         integrations=[DjangoIntegration()],
     )
-
-DEFAULT_REVIEW_VISIBILITY = env.str('DEFAULT_REVIEW_VISIBILITY', 'private')

--- a/hypha/settings/base.py
+++ b/hypha/settings/base.py
@@ -611,3 +611,5 @@ if SENTRY_DSN:
         debug=SENTRY_DEBUG,
         integrations=[DjangoIntegration()],
     )
+
+DEFAULT_REVIEW_VISIBILITY = env.str('DEFAULT_REVIEW_VISIBILITY', 'private')


### PR DESCRIPTION
Configured setting for default visibility of review. It can be set as **private** or **reviewers**. 

- Private: Visible only to staff.
- Reviewers: Visible to other reviewers and staff.

**Setting to consider:**

- ```REVIEW_VISIBILITY_DEFAULT ```

Closes #3417 
