### PR TITLE
Add proposal form field to concept determination

### DIFF
--- a/hypha/apply/determinations/forms.py
+++ b/hypha/apply/determinations/forms.py
@@ -350,7 +350,7 @@ class ConceptDeterminationForm(BaseConceptDeterminationForm, BaseNormalDetermina
         action = kwargs.get('action')
         stages_num = len(submission.workflow.stages)
 
-        if stages_num > 1 and action == 'invited_to_proposal':
+        if stages_num > 1:
             second_stage_forms = submission.get_from_parent('forms').filter(stage=2)
             if second_stage_forms.count() > 1:
                 proposal_form_choices = [
@@ -358,10 +358,15 @@ class ConceptDeterminationForm(BaseConceptDeterminationForm, BaseNormalDetermina
                     for index, form in enumerate(second_stage_forms)
                 ]
                 proposal_form_choices.insert(0, ('', _('-- No proposal form selected -- ')))
+                proposal_form_help_text = _('Select the proposal form only for determination approval')
+                if action == 'invited_to_proposal':
+                    proposal_form_help_text = _('Select the proposal form to use for proposal stage.')
                 self.fields['proposal_form'] = forms.ChoiceField(
                     label=_('Proposal Form'),
                     choices=proposal_form_choices,
-                    help_text=_('Select the proposal form to use for proposal stage.'),
+                    help_text=proposal_form_help_text,
+                    required=True if action == 'invited_to_proposal' else False,
+                    disabled=False if action == 'invited_to_proposal' else True,
                 )
                 self.fields['proposal_form'].group = 1
                 self.fields.move_to_end('proposal_form', last=False)

--- a/hypha/apply/determinations/views.py
+++ b/hypha/apply/determinations/views.py
@@ -342,8 +342,9 @@ class DeterminationCreateOrUpdateView(BaseStreamForm, CreateOrUpdateView):
                 )
                 # Outcome field choices need to be set according to the phase.
                 form_fields[field_block.id].choices = outcome_choices
-                # Set initial outcome based on action.
-                form_fields[field_block.id].initial = TRANSITION_DETERMINATION[action]
+                if action:
+                    # Set initial outcome based on action.
+                    form_fields[field_block.id].initial = TRANSITION_DETERMINATION[action]
         form_fields = self.add_proposal_form_field(form_fields, action)
         return type('WagtailStreamForm', (self.submission_form_class,), form_fields)
 
@@ -365,7 +366,7 @@ class DeterminationCreateOrUpdateView(BaseStreamForm, CreateOrUpdateView):
                     choices=proposal_form_choices,
                     help_text=proposal_form_help_text,
                     required=True if action == 'invited_to_proposal' else False,
-                    disabled=True,
+                    disabled=False if action == 'invited_to_proposal' else True,
                 )
                 fields.move_to_end('proposal_form', last=False)
         return fields

--- a/hypha/static_src/src/javascript/apply/determination-template.js
+++ b/hypha/static_src/src/javascript/apply/determination-template.js
@@ -22,12 +22,27 @@
         getMatchingCopy(value) {
             if (value === '0') {
                 this.text = document.querySelector('div[data-type="rejected"]').textContent;
+                var proposal_form = document.querySelector('#id_proposal_form');
+                if (proposal_form) {
+                    proposal_form.disabled = true;
+                    proposal_form.required = false;
+                }
             }
             else if (value === '1') {
                 this.text = document.querySelector('div[data-type="more_info"]').textContent;
+                var proposal_form = document.querySelector('#id_proposal_form');
+                if (proposal_form) {
+                    proposal_form.disabled = true;
+                    proposal_form.required = false;
+                }
             }
             else {
                 this.text = document.querySelector('div[data-type="accepted"]').textContent;
+                var proposal_form = document.querySelector('#id_proposal_form');
+                if (proposal_form) {
+                    proposal_form.disabled = false;
+                    proposal_form.required = true;
+                }
             }
             this.updateTextArea(this.text);
         }

--- a/hypha/static_src/src/javascript/apply/determination-template.js
+++ b/hypha/static_src/src/javascript/apply/determination-template.js
@@ -1,4 +1,4 @@
-(function ($) {
+(function () {
 
     'use strict';
     const field_blocks_ids = JSON.parse(document.getElementById('block-ids').textContent);
@@ -9,7 +9,7 @@
         }
 
         constructor(node) {
-            this.node = node[0];
+            this.node = node;
             this.bindEventListeners();
         }
 
@@ -20,7 +20,7 @@
         }
 
         getMatchingCopy(value) {
-            var proposal_form = document.querySelector('#id_proposal_form');
+            const proposal_form = document.querySelector('#id_proposal_form');
             if (value === '0') {
                 this.text = document.querySelector('div[data-type="rejected"]').textContent;
                 if (proposal_form) {
@@ -51,8 +51,8 @@
         }
     };
 
-    $(DeterminationCopy.selector()).each((index, el) => {
-        new DeterminationCopy($(el));
+    document.querySelectorAll(DeterminationCopy.selector()).forEach(el => {
+        new DeterminationCopy(el)
     });
 
-})(jQuery);
+})();

--- a/hypha/static_src/src/javascript/apply/determination-template.js
+++ b/hypha/static_src/src/javascript/apply/determination-template.js
@@ -52,7 +52,7 @@
     };
 
     document.querySelectorAll(DeterminationCopy.selector()).forEach(el => {
-        new DeterminationCopy(el)
+        new DeterminationCopy(el);
     });
 
 })();

--- a/hypha/static_src/src/javascript/apply/determination-template.js
+++ b/hypha/static_src/src/javascript/apply/determination-template.js
@@ -20,9 +20,9 @@
         }
 
         getMatchingCopy(value) {
+            var proposal_form = document.querySelector('#id_proposal_form');
             if (value === '0') {
                 this.text = document.querySelector('div[data-type="rejected"]').textContent;
-                var proposal_form = document.querySelector('#id_proposal_form');
                 if (proposal_form) {
                     proposal_form.disabled = true;
                     proposal_form.required = false;
@@ -30,7 +30,6 @@
             }
             else if (value === '1') {
                 this.text = document.querySelector('div[data-type="more_info"]').textContent;
-                var proposal_form = document.querySelector('#id_proposal_form');
                 if (proposal_form) {
                     proposal_form.disabled = true;
                     proposal_form.required = false;
@@ -38,7 +37,6 @@
             }
             else {
                 this.text = document.querySelector('div[data-type="accepted"]').textContent;
-                var proposal_form = document.querySelector('#id_proposal_form');
                 if (proposal_form) {
                     proposal_form.disabled = false;
                     proposal_form.required = true;


### PR DESCRIPTION
Fixes #3049 

1. Add a disabled proposal form field to concept determination.
2. It gets enabled only if the user selects 'Approved' in the determination field.
3. If it is enabled, it is required, else optional.

Update Status is working in the same way as it was working. We have only changed the behavior for the concept's Add Determination.