### PR TITLE
Use logger.warning/error instead of exception for slack errors

### DIFF
--- a/docs/setup/administrators/configuration.md
+++ b/docs/setup/administrators/configuration.md
@@ -127,6 +127,8 @@ Good for testing, might not be a good idea in production.
     SLACK_ENDPOINT_URL = env.str('SLACK_ENDPOINT_URL', 'https://slack.com/api/chat.postMessage')
     SLACK_BACKEND = 'django_slack.backends.CeleryBackend'  # UrllibBackend can be used for sync
 
+If `SLACK_DESTINATION_ROOM` is not correctly configured, it will fail silently only with the error log, without making any noise to sentry.
+
 ### Staff e-mail domain. Used for OAUTH2 whitelist default value and staff account creation.
 
     STAFF_EMAIL_DOMAINS = env.list('STAFF_EMAIL_DOMAINS', [])

--- a/hypha/apply/activity/adapters/slack.py
+++ b/hypha/apply/activity/adapters/slack.py
@@ -4,6 +4,7 @@ from django.conf import settings
 from django.contrib.auth import get_user_model
 from django.utils.translation import gettext as _
 from django_slack import slack_message
+from django_slack.exceptions import ChannelNotFound
 
 from hypha.apply.activity.adapters.base import AdapterBase
 from hypha.apply.activity.adapters.utils import link_to, reviewers_message
@@ -372,7 +373,10 @@ class SlackAdapter(AdapterBase):
         for room in target_rooms:
             try:
                 slack_message('messages/slack_message.html', data, channel=room)
+            except ChannelNotFound as e:
+                logger.warning(e)
+                return '400: Bad Request'
             except Exception as e:
-                logger.exception(e)
+                logger.error(e)
                 return '400: Bad Request'
         return '200: OK'


### PR DESCRIPTION
Fixes #3423 

Use logger.error/warning because exception making noise in sentry.
