### PR TITLE
Delete submission creation event(NEW SUBMISSION) on submission deletion

### DIFF
--- a/hypha/apply/funds/services.py
+++ b/hypha/apply/funds/services.py
@@ -16,7 +16,7 @@ from django.db.models.functions import Coalesce
 from django.http import HttpRequest
 
 from hypha.apply.activity.messaging import MESSAGES, messenger
-from hypha.apply.activity.models import Activity
+from hypha.apply.activity.models import Activity, Event
 from hypha.apply.funds.models.assigned_reviewers import AssignedReviewers
 from hypha.apply.funds.workflow import INITIAL_STATE
 from hypha.apply.review.options import DISAGREE, MAYBE
@@ -58,6 +58,10 @@ def bulk_delete_submissions(
     Returns:
         QuerySet of submissions that have been archived
     """
+    # delete NEW_SUBMISSION events for all submissions
+    submission_ids = submissions.values_list('id', flat=True)
+    Event.objects.filter(type=MESSAGES.NEW_SUBMISSION, object_id__in=submission_ids).delete()
+    # delete submissions
     submissions.delete()
     messenger(
         MESSAGES.BATCH_DELETE_SUBMISSION,

--- a/hypha/apply/funds/views.py
+++ b/hypha/apply/funds/views.py
@@ -38,6 +38,7 @@ from django_tables2.views import SingleTableMixin
 from wagtail.models import Page
 
 from hypha.apply.activity.messaging import MESSAGES, messenger
+from hypha.apply.activity.models import Event
 from hypha.apply.activity.views import (
     ActivityContextMixin,
     CommentFormView,
@@ -1412,6 +1413,9 @@ class SubmissionDeleteView(DeleteView):
             source=submission,
         )
         response = super().delete(request, *args, **kwargs)
+        # delete NEW_SUBMISSION event for this particular submission
+        Event.objects.filter(type=MESSAGES.NEW_SUBMISSION, object_id=submission.id).delete()
+
         return response
 
 

--- a/hypha/apply/funds/views.py
+++ b/hypha/apply/funds/views.py
@@ -1412,10 +1412,10 @@ class SubmissionDeleteView(DeleteView):
             request=request,
             source=submission,
         )
-        response = super().delete(request, *args, **kwargs)
         # delete NEW_SUBMISSION event for this particular submission
         Event.objects.filter(type=MESSAGES.NEW_SUBMISSION, object_id=submission.id).delete()
-
+        # delete submission
+        response = super().delete(request, *args, **kwargs)
         return response
 
 


### PR DESCRIPTION
Possible Fix of #3442 

On submission deletion, all other activities, determination, and other things are getting removed but as this `NEW SUBMISSION` event is not directly connected to submission so not getting removed. It is creating issues at the time of user deletion even after submission deletion.

I was also thinking to show the model name, and object name in error itself but user deletion only seems to be dependent on `Activities` and `Events`(user can also be deleted only by removing Activities and events not submissions related to them), and even if we show staff the event or activities ids I don't think staff can easily delete those anyhow via UI. I think we need to decide a better way to delete a user, maybe issue #3441 help us?
