### PR TITLE
Fix links on docs front page to deployments instructions.

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -31,4 +31,4 @@ View our [Roadmap](https://github.com/HyphaApp/hypha/wiki/Roadmap) for upcoming 
 ## Technology
 
 * Built with [Django](https://www.djangoproject.com/), PostgreSQL and [Wagtail](https://wagtail.io/)
-* Deploy with [Heroku](https://docs.hypha.app/deployment/heroku), [Docker](https://docs.hypha.app/deployment/docker), or [your own server](https://docs.hypha.app/deployment/stand-alone).
+* Deploy with [Heroku](/setup/deployment/heroku), [Docker](/setup/deployment/docker/), or [your own server](/setup/deployment/stand-alone).


### PR DESCRIPTION
Fixes https://github.com/HyphaApp/hypha-site/issues/5
