### PR TITLE
Read WAGTAILADMIN_BASE_URL from env

### DIFF
--- a/hypha/settings/base.py
+++ b/hypha/settings/base.py
@@ -376,7 +376,7 @@ if env.bool('BASIC_AUTH_ENABLED', False):
 
 # This is used by Wagtail's email notifications for constructing absolute URLs.
 PRIMARY_HOST = env.str('PRIMARY_HOST', None)
-WAGTAILADMIN_BASE_URL = env.str("WAGTAILADMIN_BASE_URL", None) or f'https://{PRIMARY_HOST}' if PRIMARY_HOST else None
+WAGTAILADMIN_BASE_URL = env.str("WAGTAILADMIN_BASE_URL", None) or (f'https://{PRIMARY_HOST}' if PRIMARY_HOST else None)
 
 
 # Security settings


### PR DESCRIPTION
base.py does not read WAGTAILADMIN_BASE_URL from the environment.  This patch addresses that.

Currently, base.py sets WAGTAILADMIN_BASE_URL only if PRIMARY_HOST is set.  The code is:

```
WAGTAILADMIN_BASE_URL = env.str("WAGTAILADMIN_BASE_URL", None) or f'https://{PRIMARY_HOST}' if PRIMARY_HOST else None
```

Python interprets that at as "if PRIMARY_HOST is set, then set to WAGTAILADMIN_BASE_URL, but if PRIMARY_HOST is not set, then set to None." It essentially implies parenthese as below:

```
WAGTAILADMIN_BASE_URL = (env.str("WAGTAILADMIN_BASE_URL", None) or f'https://{PRIMARY_HOST}') if PRIMARY_HOST else None
```

But what I think we actually want is "set it to WAGTAILADMIN_BASE_URL if that has been set in the env, then fallback to PRIMARY_HOST, then fallback to None.  We can do that by putting explicit parens around the part following 'or':

```
WAGTAILADMIN_BASE_URL = env.str("WAGTAILADMIN_BASE_URL", None) or (f'https://{PRIMARY_HOST}' if PRIMARY_HOST else None)
```

This patch puts those explicit parens in.

