### PR TITLE
Advise that docker is not for prod

### DIFF
--- a/docs/setup/deployment/docker.md
+++ b/docs/setup/deployment/docker.md
@@ -1,5 +1,11 @@
 # Docker
 
+This is a set of instructions on spinning up hypha in a docker container for
+evaluation of the system. While Docker is a well suited to this type of quick
+exploration, we do not currently recommend these docker instructions for
+production use. Instead, we advise production deployments to instead install
+into a [stand-alone](stand-alone.md) directory.
+
 ## Requirements
 
 Recent version of [Docker](https://www.docker.com/get-started).


### PR DESCRIPTION
Fixes #3452 

Current project views are that the docker setup isn't the best way to roll out to prod.  Adding that to the docs gives readers a better idea of what to expect as an outcome from this section.

