### PR TITLE
Update UI, and text for Contracting documents section

### DIFF
--- a/hypha/apply/projects/templates/application_projects/includes/contracting_documents.html
+++ b/hypha/apply/projects/templates/application_projects/includes/contracting_documents.html
@@ -61,8 +61,8 @@
                     <div class="docs-block__row-inner">
                     </div>
                     <div class="docs-block__row-inner">
+                        <svg class="icon icon--info-circle"><use xlink:href="#info-circle-fill"></use></svg>
                         <a class="docs-block__icon-link" href="#communications" target="_blank">
-                            <svg class="icon icon--info-circle"><use xlink:href="#info-circle-fill"></use></svg>
                                 <span>{% trans "Corrections/amendments?" %}</span>
                         </a>
                     </div>
@@ -144,8 +144,8 @@
                                     {% endif %}
                                     {% if document_category.required %}<span class="text-red-700">*</span>{% endif %}
                                     {% if document_category.template %}
-                                    <a class="pl-2 font-bold underline decoration-dashed" href="{% url 'apply:projects:category_template' pk=object.pk type='contract_document' category_pk=document_category.pk %}" target="_blank">{% trans "View template" %}</a>
-                                    <svg class="icon icon--info-circle pl-0.5"><use xlink:href="#info-circle-fill"></use></svg>
+                                    <svg class="icon icon--info-circle"><use xlink:href="#info-circle-fill"></use></svg>
+                                    <a class="font-bold underline decoration-dashed" href="{% url 'apply:projects:category_template' pk=object.pk type='contract_document' category_pk=document_category.pk %}" target="_blank">{% trans "View template" %}</a>
                                     {% endif %}
                                 </p>
                                 {% if document_category not in remaining_contract_document_categories %}

--- a/hypha/apply/projects/templates/application_projects/includes/contracting_documents.html
+++ b/hypha/apply/projects/templates/application_projects/includes/contracting_documents.html
@@ -50,22 +50,11 @@
             </div>
             {% if contract_uploaded %}
             <div class="docs-block__row-inner">
-                <a class="docs-block__icon-link" href="{% url 'apply:projects:contract' pk=project.pk file_pk=contract.pk %}" target="_blank">
+                <a class="font-bold flex items-center w-auto text-left bg-white text-light-blue mr-0 mb-1 p-2.5 border-solid border border-light-blue" href="{% url 'apply:projects:contract' pk=project.pk file_pk=contract.pk %}" target="_blank">
                     <svg class="icon icon--project-eye"><use xlink:href="#eye"></use></svg>
                         {% trans "View" %}
                 </a>
             </div>
-            {% if contract.updated_at %}
-            <ul class="mt-0 w-full pl-9">
-                <li class="docs-block__document">
-                    <div class="docs-block__row-inner">
-                    </div>
-                    <div class="docs-block__row-inner">
-                                <i>{{ contract.updated_at }}</i>
-                    </div>
-                </li>
-            </ul>
-            {% endif %}
             {% if not is_contract_approved %}
             <ul class="mt-0 w-full pl-9">
                 <li class="docs-block__document">
@@ -74,7 +63,7 @@
                     <div class="docs-block__row-inner">
                         <a class="docs-block__icon-link" href="#communications" target="_blank">
                             <svg class="icon icon--info-circle"><use xlink:href="#info-circle-fill"></use></svg>
-                                <span>{% trans "Need corrections/amendments to contract?" %}</span>
+                                <span>{% trans "Corrections/amendments?" %}</span>
                         </a>
                     </div>
                 </li>
@@ -85,11 +74,11 @@
             {% show_contract_upload_row object user as show_contract_row %}
             {% if show_contract_row %}
             {% contract_reuploaded_by_applicant object as contract_reuploaded %}
-            <ul class="docs-block__document-list">
+            <ul class="mt-2 w-full pl-9">
                 <li class="docs-block__document">
                     <div class="docs-block__row-inner">
-                        <svg class="icon docs-block__icon {% if contract_uploaded %}is-complete{% endif %}"><use xlink:href="#tick"></use></svg>
-                        <p class="docs-block__title">{% trans "Signed contract by Contracting team " %}
+                        <p class="docs-block__title">
+                            {% if not contract.uploaded_by_contractor_at %}{% trans "Pending signed contract by " %}{% else %}{% trans "Signed contract by " %}{% endif %}{% if user == object.user %}{{ org_short_name }}{% else %}{% trans "Contracting team " %} {% endif %}
                             <i>{% if contract.uploaded_by_contractor_at %}({{ contract.uploaded_by_contractor_at }}){% endif %}</i></p>
                     </div>
                     {% if can_upload_contract and user.is_contracting %}
@@ -108,8 +97,7 @@
 
                 <li class="docs-block__document">
                     <div class="docs-block__row-inner">
-                        <svg class="icon docs-block__icon {% if contract_reuploaded %}is-complete{% endif %}"><use xlink:href="#tick"></use></svg>
-                        <p class="docs-block__title">{% trans "Countersigned contract by Applicant/Contractor " %}
+                        <p class="docs-block__title">{% if not contract.uploaded_by_applicant_at %}{% trans "Pending countersigned contract by " %}{% else %}{% trans "Countersigned contract by " %}{% endif %}{% if user == object.user %}{% trans "you " %} {% else %}{% trans "Vendor " %}{% endif %}
                         <i>{% if contract.uploaded_by_applicant_at %}({{ contract.uploaded_by_applicant_at }}){% endif %}</i></p>
                     </div>
                     {% if can_upload_contract and user.is_applicant %}
@@ -147,7 +135,13 @@
                     {% for document_category in all_contract_document_categories %}
                         <li class="docs-block__document">
                             <div class="docs-block__document-inner">
-                                <p class="docs-block__document-info">{{ document_category.name }}
+                                <p class="docs-block__document-info">
+                                    {% if document_category in remaining_contract_document_categories %}
+                                        {% trans "Pending " %}
+                                        {{ document_category.name|lower }}
+                                    {% else %}
+                                        {{ document_category.name }}
+                                    {% endif %}
                                     {% if document_category.required %}<span class="text-red-700">*</span>{% endif %}
                                     {% if document_category.template %}
                                     <a class="pl-2 font-bold underline decoration-dashed" href="{% url 'apply:projects:category_template' pk=object.pk type='contract_document' category_pk=document_category.pk %}" target="_blank">{% trans "View template" %}</a>

--- a/hypha/apply/projects/templates/application_projects/includes/contracting_documents.html
+++ b/hypha/apply/projects/templates/application_projects/includes/contracting_documents.html
@@ -50,7 +50,7 @@
             </div>
             {% if contract_uploaded %}
             <div class="docs-block__row-inner">
-                <a class="font-bold flex items-center w-auto text-left bg-white text-light-blue mr-0 mb-1 p-2.5 border-solid border border-light-blue" href="{% url 'apply:projects:contract' pk=project.pk file_pk=contract.pk %}" target="_blank">
+                <a class="font-bold flex items-center w-auto text-left bg-white text-light-blue mr-0 mb-1 p-2.5 border-solid border border-light-blue focus:text-light-blue hover:bg-light-blue hover:text-white" href="{% url 'apply:projects:contract' pk=project.pk file_pk=contract.pk %}" target="_blank">
                     <svg class="icon icon--project-eye"><use xlink:href="#eye"></use></svg>
                         {% trans "View" %}
                 </a>
@@ -78,7 +78,7 @@
                 <li class="docs-block__document">
                     <div class="docs-block__row-inner">
                         <p class="docs-block__title">
-                            {% if not contract.uploaded_by_contractor_at %}{% trans "Pending signed contract by " %}{% else %}{% trans "Signed contract by " %}{% endif %}{% if user == object.user %}{{ org_short_name }}{% else %}{% trans "Contracting team " %} {% endif %}
+                            {% if not contract.uploaded_by_contractor_at %}{% trans "Pending signed contract by " %}{% else %}{% trans "Signed contract by " %}{% endif %}{% if user == object.user %}{{ ORG_SHORT_NAME }}{% else %}{% trans "Contracting team " %} {% endif %}
                             <i>{% if contract.uploaded_by_contractor_at %}({{ contract.uploaded_by_contractor_at }}){% endif %}</i></p>
                     </div>
                     {% if can_upload_contract and user.is_contracting %}

--- a/hypha/apply/projects/views/project.py
+++ b/hypha/apply/projects/views/project.py
@@ -319,6 +319,7 @@ class ContractsMixin:
         context['contract_to_sign'] = contract_to_sign
         context['contracts'] = contracts.approved()
         context['contract'] = latest_contract
+        context['org_short_name'] = settings.ORG_SHORT_NAME
         return context
 
 

--- a/hypha/apply/projects/views/project.py
+++ b/hypha/apply/projects/views/project.py
@@ -319,7 +319,6 @@ class ContractsMixin:
         context['contract_to_sign'] = contract_to_sign
         context['contracts'] = contracts.approved()
         context['contract'] = latest_contract
-        context['org_short_name'] = settings.ORG_SHORT_NAME
         return context
 
 

--- a/hypha/static_src/src/sass/apply/components/_icon.scss
+++ b/hypha/static_src/src/sass/apply/components/_icon.scss
@@ -122,6 +122,10 @@
         height: 1em;
         margin-right: 2px;
         stroke: $color--light-blue;
+
+        a:hover & {
+            stroke: $color--white;
+        }
     }
 
     &--caret-down {

--- a/hypha/static_src/src/sass/apply/components/_icon.scss
+++ b/hypha/static_src/src/sass/apply/components/_icon.scss
@@ -123,7 +123,7 @@
         margin-right: 2px;
         stroke: $color--light-blue;
 
-        a:hover & {
+        .border:hover & {
             stroke: $color--white;
         }
     }


### PR DESCRIPTION
Fixes #3458  Refs: #3448

For staff:

<img width="884" alt="image" src="https://github.com/HyphaApp/hypha/assets/23638629/8ce94412-c1ef-4a60-9d16-e66d51e6fe9a">

For Vendor:
<img width="884" alt="image" src="https://github.com/HyphaApp/hypha/assets/23638629/0546b80e-653b-441d-af73-92a1f9e81935">

After contract and document upload:
for staff:
<img width="884" alt="image" src="https://github.com/HyphaApp/hypha/assets/23638629/dea09d90-8092-46e3-88ae-fb3d25117171">

for vendor:
<img width="884" alt="image" src="https://github.com/HyphaApp/hypha/assets/23638629/f82de3b7-8235-4889-99fb-f470429d784f">

