### PR TITLE
Fix application form submit button remaining disabled

### DIFF
--- a/hypha/static_src/src/javascript/apply/application-form.js
+++ b/hypha/static_src/src/javascript/apply/application-form.js
@@ -26,7 +26,10 @@
             $error_fields[0].querySelector('input').focus();
 
             $error_fields.each(function (index, error_field) {
-                error_field.querySelector('input').setAttribute('aria-invalid', true);
+                const inputEl = error_field.querySelector('input, textarea');
+                if (inputEl) {
+                    inputEl.setAttribute('aria-invalid', true);
+                }
             });
         }
 


### PR DESCRIPTION
If application form has a textarea and on submitting the form there is
an Django validation error for that textarea. Then the current javascript
crashes as it's to find an <input> in the form__error DOM element. Due to
the javascript exception the mousemove handler is not registered and
submit buttom remains disabled.

This PR ensure
1. The aria-invalid is applied to the invalid text area as well.
2. The JS doesn't crash if the input in undefined.
