### PR TITLE
Remove hx-boot from the primary nav

### DIFF
--- a/hypha/public/navigation/templates/navigation/primarynav-apply.html
+++ b/hypha/public/navigation/templates/navigation/primarynav-apply.html
@@ -1,4 +1,4 @@
-<nav role="navigation" aria-label="Primary" hx-boost="true">
+<nav role="navigation" aria-label="Primary">
     <ul class="nav nav--primary" role="menubar">
         {% if request.user.is_apply_staff %}
             {% include "navigation/primarynav-apply-item.html" with name="My dashboard" url="dashboard:dashboard" %}


### PR DESCRIPTION
This fixes the issue where the select2 widget doesn't initialized
properly during the page load.

The select2 internals are dependent on the window.onload and the is not
easy way to switch to activate on htmx.onload event.

Consequently, the hx-boost is removed from the primary navs so the
select2 behaves as expected.
