### PR TITLE
Add RateLimit to registrations

### DIFF
--- a/hypha/apply/users/views.py
+++ b/hypha/apply/users/views.py
@@ -49,6 +49,7 @@ from .utils import send_confirmation_email
 
 User = get_user_model()
 
+@method_decorator(ratelimit(key='ip', rate=settings.DEFAULT_RATE_LIMIT, method='POST'), name='dispatch')
 class RegisterView(View):
     form = CustomUserCreationForm()
 


### PR DESCRIPTION
A vulnerability was introduced with #3064 where registrations could be created en masse using arbitrary email addresses.  An attacker could use this to make hypha auto generate mass emails to those recipients. Adding a ratelimit to the registration should prevent that from being too aggressive.
