### PR TITLE
Add pre-commit with black,prettier and djhtml

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -10,6 +10,9 @@ indent_style = space
 insert_final_newline = true
 trim_trailing_whitespace = true
 
+[*.{yml,yaml,json}]
+indent_size = 2
+
 [*.md]
 trim_trailing_whitespace = false
 

--- a/.eslintrc.yaml
+++ b/.eslintrc.yaml
@@ -1,4 +1,6 @@
-extends: eslint:recommended
+extends:
+  - eslint:recommended
+  - prettier
 env:
   browser: true
   commonjs: true
@@ -7,50 +9,39 @@ globals:
   jQuery: true
 rules:
   array-bracket-spacing:
-  - "error"
-  - never
+    - "error"
+    - never
   block-scoped-var: "error"
-  brace-style:
-  - "error"
-  - stroustrup
-  - allowSingleLine: true
-  comma-dangle:
-  - "error"
-  - never
   comma-spacing: "error"
   comma-style:
-  - "error"
-  - last
+    - "error"
+    - last
   computed-property-spacing:
-  - "error"
-  - never
+    - "error"
+    - never
   curly:
-  - "error"
-  - all
+    - "error"
+    - all
   eol-last: "error"
   eqeqeq:
-  - "error"
-  - smart
+    - "error"
+    - smart
   guard-for-in: "error"
-  indent:
-  - "error"
-  - 4
-  - SwitchCase: 1
   key-spacing:
-  - "error"
-  - beforeColon: false
-    afterColon: true
+    - "error"
+    - beforeColon: false
+      afterColon: true
   keyword-spacing:
-  - "error"
-  - before: true
-    after: true
+    - "error"
+    - before: true
+      after: true
   linebreak-style:
-  - "error"
-  - unix
+    - "error"
+    - unix
   lines-around-comment:
-  - "error"
-  - beforeBlockComment: true
-    afterBlockComment: false
+    - "error"
+    - beforeBlockComment: true
+      afterBlockComment: false
   new-parens: "error"
   no-array-constructor: "error"
   no-caller: "error"
@@ -59,8 +50,8 @@ rules:
   no-extend-native: "error"
   no-extra-bind: "error"
   no-extra-parens:
-  - "error"
-  - functions
+    - "error"
+    - functions
   no-implied-eval: "error"
   no-iterator: "error"
   no-label-var: "error"
@@ -87,60 +78,50 @@ rules:
   no-undefined: "error"
   no-unused-expressions: "error"
   no-unused-vars:
-  - "error"
-  - vars: all
-    args: none
+    - "error"
+    - vars: all
+      args: none
   no-with: "error"
-  object-curly-spacing:
-  - "error"
-  - never
   one-var:
-  - "error"
-  - never
-  quote-props:
-  - "error"
-  - consistent-as-needed
-  quotes:
-  - "error"
-  - single
-  - avoid-escape
+    - "error"
+    - never
   semi:
-  - "error"
-  - always
+    - "error"
+    - always
   semi-spacing:
-  - "error"
-  - before: false
-    after: true
+    - "error"
+    - before: false
+      after: true
   space-before-blocks:
-  - "error"
-  - always
+    - "error"
+    - always
   space-before-function-paren:
-  - "error"
-  - anonymous: always
-    named: never
+    - "error"
+    - anonymous: always
+      named: never
   space-in-parens:
-  - "error"
-  - never
+    - "error"
+    - never
   space-infix-ops: "error"
   space-unary-ops:
-  - "error"
-  - words: true
-    nonwords: false
+    - "error"
+    - words: true
+      nonwords: false
   spaced-comment:
-  - "error"
-  - always
+    - "error"
+    - always
   strict:
-  - "error"
-  - function
+    - "error"
+    - function
   yoda:
-  - "error"
-  - never
+    - "error"
+    - never
   max-nested-callbacks:
-  - "warn"
-  - 3
+    - "warn"
+    - 3
   valid-jsdoc:
-  - "warn"
-  - prefer:
-      returns: return
-      property: prop
-    requireReturn: false
+    - "warn"
+    - prefer:
+        returns: return
+        property: prop
+      requireReturn: false

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,24 @@
+repos:
+  - repo: https://github.com/astral-sh/ruff-pre-commit
+    rev: v0.0.280
+    hooks:
+      - id: ruff
+        args: [--fix, --exit-non-zero-on-fix]
+  - repo: https://github.com/psf/black
+    rev: 23.7.0
+    hooks:
+      - id: black
+        # It is recommended to specify the latest version of Python
+        # supported by your project here, or alternatively use
+        # pre-commit's default_language_version, see
+        # https://pre-commit.com/#top_level-default_language_version
+        language_version: python3.11
+  - repo: https://github.com/rtts/djhtml
+    rev: "3.0.6"
+    hooks:
+      - id: djhtml
+        files: .*/templates/.*\.html$
+  - repo: https://github.com/pre-commit/mirrors-prettier
+    rev: v3.0.0 # Use the sha or tag you want to point at
+    hooks:
+      - id: prettier

--- a/.prettierignore
+++ b/.prettierignore
@@ -1,0 +1,20 @@
+# Ignore all HTML files, use djHtml instead.
+**/*.html
+
+# Ignore markdown files, prettier is not great with them
+**/*.md
+
+# Minified JavaScript files shouldn't be changed
+**/**.min.js
+**/javascript/esm/**
+
+# Ignore all files in the static & media directory.
+static_compiled/**
+media/**
+
+# Ignore all files in the virtualenv directory.
+.venv/**
+venv/**
+
+node_modules/**
+htmlcov/**

--- a/.stylelintrc.yaml
+++ b/.stylelintrc.yaml
@@ -1,6 +1,5 @@
-plugins:
-  - stylelint-scss
 extends:
+  - stylelint-config-standard
   - stylelint-config-standard-scss
 rules:
   at-rule-disallowed-list:
@@ -8,21 +7,11 @@ rules:
   at-rule-no-unknown: null
   at-rule-no-vendor-prefix: true
   block-no-empty: null
-  block-opening-brace-space-before: always
-  color-hex-case: lower
   color-hex-length: short
   color-named: never
-  color-no-hex: true
   color-no-invalid-hex: true
-  declaration-bang-space-after: never
-  declaration-bang-space-before: always
   declaration-block-no-redundant-longhand-properties: null
-  declaration-block-semicolon-newline-after: always
-  declaration-block-semicolon-space-before: never
   declaration-block-single-line-max-declarations: 1
-  declaration-block-trailing-semicolon: always
-  declaration-colon-space-after: always-single-line
-  declaration-colon-space-before: never
   declaration-empty-line-before: null
   declaration-no-important: true
   declaration-property-value-disallowed-list:
@@ -37,10 +26,7 @@ rules:
     border-left:
       - none
   font-family-name-quotes: null
-  function-comma-space-after: always-single-line
-  function-parentheses-space-inside: never
   function-url-quotes: always
-  indentation: 4
   length-zero-no-unit: true
   max-nesting-depth:
     - 4
@@ -50,12 +36,8 @@ rules:
       - supports
       - include
   media-feature-name-no-vendor-prefix: true
-  media-feature-parentheses-space-inside: never
   media-feature-range-notation: prefix
   no-descending-specificity: null
-  no-missing-end-of-source-newline: true
-  number-leading-zero: never
-  number-no-trailing-zeros: true
   property-no-unknown: true
   property-no-vendor-prefix: true
   rule-empty-line-before:
@@ -81,7 +63,6 @@ rules:
   selector-class-pattern:
     - "^[a-z0-9\\-]+$"
     - message: Selector should be written in lowercase with hyphens (selector-class-pattern)
-  selector-list-comma-newline-after: always
   selector-max-compound-selectors: 3
   selector-max-id: 0
   #selector-no-qualifying-type: true
@@ -89,5 +70,4 @@ rules:
   selector-pseudo-element-colon-notation: double
   selector-pseudo-element-no-unknown: true
   shorthand-property-no-redundant-values: true
-  string-quotes: single
   value-no-vendor-prefix: true

--- a/Makefile
+++ b/Makefile
@@ -10,6 +10,7 @@ help:
 	@echo "  make build              build js and css resources for development"
 	@echo "  make cov-html           generate html coverage report"
 	@echo "  make lint               run css, js and python linting."
+	@echo "  make fmt                run code formatters on all code."
 	@echo "  make lint-fix           try fixing plausible python linting issues."
 	@echo "  make py-test            run all python tests and display coverage"
 	@echo "  make test               run linting and test and generate html coverage report"
@@ -28,6 +29,13 @@ build:
 	@echo "Build js and css resources for development."
 	npm run dev:build
 
+.PHONY: fmt
+fmt:
+	@echo "run code formatters on all code."
+	python -m ruff --fix .
+	python -m black .
+	npx prettier . --write
+
 .PHONY: cov-html
 cov-html:
 ifneq ("$(wildcard .coverage)","")
@@ -43,8 +51,12 @@ endif
 lint:
 	@echo "Checking python code style with ruff"
 	ruff .
+	# black . --check
 	@echo "Checking js and css code style."
 	npm run lint
+	# @TODO: enable once we have a consistent code style
+	# npx prettier . --check
+
 
 .PHONY: lint-fix
 lint-fix:

--- a/docs/getting-started/development/manual.md
+++ b/docs/getting-started/development/manual.md
@@ -242,6 +242,17 @@ Open http://localhost:9100/ to preview the documentation site.
 !!! tip
     You can use `$ make serve` command to run Django Development Server, watch and compile frontend changes and preview docs all at once.
 
+
+## Coding Style
+
+Hypha's coding style is enforced by black, ruff and prettier and comes pre-configured with prettier. 
+
+Install pre-commit to auto-format the code before each commit:
+
+```
+pre-commit install
+```
+
 ## Running tests
 
 Hypha uses `ruff` and [py.test](https://pytest-django.readthedocs.io/en/latest/) test runner and uses `hypha/settings/testing.py` for test settings.

--- a/hypha/static_src/src/javascript/apply/form-group-toggle.js
+++ b/hypha/static_src/src/javascript/apply/form-group-toggle.js
@@ -1,47 +1,59 @@
+/* eslint-disable no-loop-func */
 (function ($) {
-
-    'use strict';
+    "use strict";
 
     var i;
     for (i = 2; i < 20; i++) {
-        var $field_group = $('.field-group-' + i);
+        var $field_group = $(".field-group-" + i);
         if ($field_group.length) {
-            var classes = 'field-group-wrapper field-group-wrapper-' + i;
-            $field_group.each(function () { // eslint-disable-line no-loop-func
-                if ($(this).data('hidden') && classes.indexOf('js-hidden') === -1) {
-                    classes += ' js-hidden';
+            var classes = "field-group-wrapper field-group-wrapper-" + i;
+            $field_group.each(function () {
+                if (
+                    $(this).data("hidden") &&
+                    classes.indexOf("js-hidden") === -1
+                ) {
+                    classes += " js-hidden";
                 }
             });
             $field_group.wrapAll('<div class="' + classes + '" />');
-        }
-        else {
+        } else {
             break;
         }
     }
 
-    $('.form-fields-grouper input[type="radio"]').on('change', function () {
+    $('.form-fields-grouper input[type="radio"]').on("change", function () {
         var radio_input_value = $(this).val();
-        var fields_grouper_div = this.closest('.form-fields-grouper');
-        var fields_grouper_for = $(fields_grouper_div).data('grouper-for');
-        var group_toggle_on_value = $(fields_grouper_div).data('toggle-on');
-        var group_toggle_off_value = $(fields_grouper_div).data('toggle-off');
+        var fields_grouper_div = this.closest(".form-fields-grouper");
+        var fields_grouper_for = $(fields_grouper_div).data("grouper-for");
+        var group_toggle_on_value = $(fields_grouper_div).data("toggle-on");
+        var group_toggle_off_value = $(fields_grouper_div).data("toggle-off");
 
         if (radio_input_value === group_toggle_on_value) {
-            $('.field-group-wrapper-' + fields_grouper_for).removeClass('js-hidden').addClass('highlighted');
-            $('.field-group-' + fields_grouper_for).each(function () { // eslint-disable-line no-loop-func
-                if ($(this).data('required') === 'True') {
-                    $(this).children('.form__item').children().attr('required', true);
-                    $(this).children('label').append('<span class="form__required">*</span>');
+            $(".field-group-wrapper-" + fields_grouper_for)
+                .removeClass("js-hidden")
+                .addClass("highlighted");
+            $(".field-group-" + fields_grouper_for).each(function () {
+                if ($(this).data("required") === "True") {
+                    $(this)
+                        .children(".form__item")
+                        .children()
+                        .attr("required", true);
+                    $(this)
+                        .children("label")
+                        .append('<span class="form__required">*</span>');
                 }
             });
-        }
-        else if (radio_input_value === group_toggle_off_value) {
-            $('.field-group-wrapper-' + fields_grouper_for).removeClass('highlighted').addClass('js-hidden');
-            $('.field-group-' + fields_grouper_for).each(function () { // eslint-disable-line no-loop-func
-                $(this).children('.form__item').children().attr('required', false);
-                $(this).children('label').children('.form__required').remove();
+        } else if (radio_input_value === group_toggle_off_value) {
+            $(".field-group-wrapper-" + fields_grouper_for)
+                .removeClass("highlighted")
+                .addClass("js-hidden");
+            $(".field-group-" + fields_grouper_for).each(function () {
+                $(this)
+                    .children(".form__item")
+                    .children()
+                    .attr("required", false);
+                $(this).children("label").children(".form__required").remove();
             });
         }
     });
-
 })(jQuery);

--- a/hypha/static_src/src/sass/apply/components/_activity-notifications.scss
+++ b/hypha/static_src/src/sass/apply/components/_activity-notifications.scss
@@ -17,7 +17,7 @@
         background-color: $color--white;
         border: 1px solid $color--light-grey;
         min-width: 400px;
-        box-shadow: rgba(0, 0, 0, 10%) 0 4px 6px -1px, rgba(0, 0, 0, 6%) 0 2px 4px -1px;  /* stylelint-disable-line */
+        box-shadow: rgba(#000, 10%) 0 4px 6px -1px, rgba(#000, 6%) 0 2px 4px -1px;
     }
 
     &__header {

--- a/hypha/static_src/src/sass/apply/components/_all-submissions-table.scss
+++ b/hypha/static_src/src/sass/apply/components/_all-submissions-table.scss
@@ -1,4 +1,4 @@
-// stylelint-disable selector-max-compound-selectors
+// stylelint-disable selector-class-pattern,selector-max-compound-selectors
 
 .all-submissions-table {
     @include table-ordering-styles;
@@ -14,7 +14,7 @@
         }
 
         th {
-            &.reviews_stats { // stylelint-disable-line selector-class-pattern
+            &.reviews_stats {
                 color: $color--black-60;
 
                 div {
@@ -118,12 +118,13 @@
                     font-size: 13px;
                     text-align: center;
                     vertical-align: middle;
-                    background: url('./../../images/quote-outline.svg') transparent no-repeat center center;
+                    background: url("./../../images/quote-outline.svg")
+                        transparent no-repeat center center;
                     background-size: 24px;
                 }
             }
 
-            &.reviews_stats { // stylelint-disable-line selector-class-pattern
+            &.reviews_stats {
                 display: none;
 
                 @include media-query($table-breakpoint) {
@@ -144,9 +145,7 @@
 
             &.fund,
             &.round,
-            &.screening_status { // stylelint-disable-line selector-class-pattern
-                -webkit-hyphens: auto; // stylelint-disable-line property-no-vendor-prefix
-                -ms-hyphens: auto; // stylelint-disable-line property-no-vendor-prefix
+            &.screening_status {
                 hyphens: auto;
             }
 
@@ -172,7 +171,8 @@
                 }
             }
 
-            > span.mobile-label { // stylelint-disable-line force-element-nesting
+            // stylelint-disable-next-line force-element-nesting
+            > span.mobile-label {
                 display: inline-block;
                 width: 90px;
 

--- a/hypha/static_src/src/sass/apply/components/_all-submissions-table.scss
+++ b/hypha/static_src/src/sass/apply/components/_all-submissions-table.scss
@@ -54,7 +54,7 @@
                 }
             }
 
-            &.organization_name { // stylelint-disable-line selector-class-pattern
+            &.organization_name {
                 @include media-query($table-breakpoint) {
                     width: 110px;
                 }
@@ -149,7 +149,7 @@
                 hyphens: auto;
             }
 
-            &.organization_name { // stylelint-disable-line selector-class-pattern
+            &.organization_name {
                 @include media-query($table-breakpoint) {
                     padding-left: 15px;
                 }

--- a/hypha/static_src/src/sass/apply/components/_feed.scss
+++ b/hypha/static_src/src/sass/apply/components/_feed.scss
@@ -144,7 +144,8 @@
 
             span {
                 &:first-child {
-                    &::after { // stylelint-disable-line max-nesting-depth
+                    // stylelint-disable-next-line max-nesting-depth
+                    &::after {
                         @include triangle(right, $color--black-50, 4px);
                         display: inline-block;
                         margin: 0 5px 0 10px;

--- a/hypha/static_src/src/sass/apply/components/_form.scss
+++ b/hypha/static_src/src/sass/apply/components/_form.scss
@@ -59,12 +59,14 @@
                 font-weight: 700;
             }
 
-            &.id_occurrence { // stylelint-disable-line selector-class-pattern
+            // stylelint-disable-next-line selector-class-pattern
+            &.id_occurrence {
                 width: 15%;
                 margin: 0 1rem;
             }
 
-            &.id_frequency { // stylelint-disable-line selector-class-pattern
+            // stylelint-disable-next-line selector-class-pattern
+            &.id_frequency {
                 margin: 0;
             }
         }
@@ -246,7 +248,8 @@
                 }
 
                 input {
-                    &:first-of-type { // stylelint-disable-line max-nesting-depth
+                    // stylelint-disable-next-line max-nesting-depth
+                    &:first-of-type {
                         @supports (display: grid) {
                             grid-column: 1;
                         }

--- a/hypha/static_src/src/sass/apply/components/_icon.scss
+++ b/hypha/static_src/src/sass/apply/components/_icon.scss
@@ -5,7 +5,8 @@
     transition: fill $transition;
     fill: $color--dark-grey;
 
-    .header__menus--mobile.is-visible & { // stylelint-disable-line force-element-nesting, selector-class-pattern
+    // stylelint-disable-next-line force-element-nesting, selector-class-pattern
+    .header__menus--mobile.is-visible & {
         fill: $color--white;
     }
 
@@ -67,7 +68,8 @@
     &--speech-bubble {
         fill: $color--white;
 
-        .activity-feed__header & { // stylelint-disable-line selector-class-pattern
+        // stylelint-disable-next-line selector-class-pattern
+        .activity-feed__header & {
             margin-left: 10px;
         }
     }

--- a/hypha/static_src/src/sass/apply/components/_select2.scss
+++ b/hypha/static_src/src/sass/apply/components/_select2.scss
@@ -7,7 +7,8 @@
 
     .select2-container--default,
     &.select2-container--default {
-        width: 100% !important; // stylelint-disable-line declaration-no-important
+        // stylelint-disable-next-line declaration-no-important
+        width: 100% !important;
 
         .select2-selection--single {
             height: $dropdown-height;
@@ -49,11 +50,14 @@
     }
 }
 
-.select2-container { // stylelint-disable-line no-duplicate-selectors
+// stylelint-disable-next-line no-duplicate-selectors
+.select2-container {
     &--default {
         .select2-results__option--highlighted[aria-selected] {
-            color: $color--default !important; // stylelint-disable-line declaration-no-important
-            background-color: transparentize($color--primary, .9) !important; // stylelint-disable-line declaration-no-important, max-line-length
+            // stylelint-disable-next-line declaration-no-important
+            color: $color--default !important;
+            // stylelint-disable-next-line declaration-no-important, max-line-length
+            background-color: transparentize($color--primary, .9) !important;
         }
     }
 

--- a/hypha/static_src/src/sass/apply/components/_submission-meta.scss
+++ b/hypha/static_src/src/sass/apply/components/_submission-meta.scss
@@ -4,7 +4,8 @@
     tbody {
         td {
             &.phase {
-                span { // stylelint-disable-line selector-max-compound-selectors
+                // stylelint-disable-next-line selector-max-compound-selectors
+                span {
                     display: inline-block;
                     padding: 10px;
                     font-size: 13px;

--- a/hypha/static_src/src/sass/public/base/_base.scss
+++ b/hypha/static_src/src/sass/public/base/_base.scss
@@ -116,10 +116,14 @@ ol {
     left: 0;
     z-index: 5;
     width: 100%;
-    background-image: linear-gradient(-180deg, rgba(0, 0, 0, .72) 0%, rgba(116, 116, 118, 0) 96%); // stylelint-disable-line color-function-notation, max-line-length
+    background-image: linear-gradient(
+        -180deg,
+        rgba(#000, 0.72) 0%,
+        rgba(#747476, 0) 96%
+    );
 
-    content: '';
-    opacity: .5;
+    content: "";
+    opacity: 0.5;
 }
 
 .light-grey-bg {

--- a/hypha/static_src/src/sass/public/components/_all-investments-table.scss
+++ b/hypha/static_src/src/sass/public/components/_all-investments-table.scss
@@ -1,4 +1,4 @@
-// stylelint-disable selector-max-compound-selectors
+// stylelint-disable selector-max-compound-selectors, selector-class-pattern
 
 .all-investments-table {
     @include table-ordering-styles;
@@ -14,7 +14,7 @@
         }
 
         th {
-            &.reviews_stats { // stylelint-disable-line selector-class-pattern
+            &.reviews_stats {
                 color: $color--black-60;
 
                 div {
@@ -142,12 +142,13 @@
                     font-size: 13px;
                     text-align: center;
                     vertical-align: middle;
-                    background: url('./../../images/quote-outline.svg') transparent no-repeat center center;
+                    background: url("./../../images/quote-outline.svg")
+                        transparent no-repeat center center;
                     background-size: 24px;
                 }
             }
 
-            &.reviews_stats { // stylelint-disable-line selector-class-pattern
+            &.reviews_stats {
                 display: none;
 
                 @include media-query($table-breakpoint) {
@@ -168,9 +169,7 @@
 
             &.fund,
             &.round,
-            &.screening_status { // stylelint-disable-line selector-class-pattern
-                -webkit-hyphens: auto; // stylelint-disable-line property-no-vendor-prefix
-                -ms-hyphens: auto; // stylelint-disable-line property-no-vendor-prefix
+            &.screening_status {
                 hyphens: auto;
             }
 
@@ -190,7 +189,8 @@
                 }
             }
 
-            > span.mobile-label { // stylelint-disable-line force-element-nesting
+            // stylelint-disable-next-line force-element-nesting
+            > span.mobile-label {
                 display: inline-block;
                 width: 90px;
 

--- a/hypha/static_src/src/sass/public/components/_form.scss
+++ b/hypha/static_src/src/sass/public/components/_form.scss
@@ -257,7 +257,8 @@
                 }
 
                 input {
-                    &:first-of-type { // stylelint-disable-line max-nesting-depth
+                    // stylelint-disable-next-line max-nesting-depth
+                    &:first-of-type {
                         @supports (display: grid) {
                             grid-column: 1;
                         }
@@ -328,8 +329,6 @@
             background: transparent;
             border-radius: 0;
             appearance: none;
-            -webkit-appearance: none; // stylelint-disable-line property-no-vendor-prefix
-            -moz-appearance: none; // stylelint-disable-line property-no-vendor-prefix
 
             option {
                 background-color: $color--white;

--- a/hypha/static_src/src/sass/public/components/_icon.scss
+++ b/hypha/static_src/src/sass/public/components/_icon.scss
@@ -8,7 +8,8 @@
         fill: $color--dark-grey;
     }
 
-    .header__menus--mobile.is-visible & { // stylelint-disable-line selector-class-pattern
+    // stylelint-disable-next-line selector-class-pattern
+    .header__menus--mobile.is-visible & {
         fill: $color--white;
     }
 

--- a/hypha/static_src/src/sass/public/components/_investment-meta.scss
+++ b/hypha/static_src/src/sass/public/components/_investment-meta.scss
@@ -4,7 +4,8 @@
     tbody {
         td {
             &.phase {
-                span { // stylelint-disable-line selector-max-compound-selectors
+                // stylelint-disable-next-line selector-max-compound-selectors
+                span {
                     display: inline-block;
                     padding: 10px;
                     font-size: 13px;

--- a/hypha/static_src/src/sass/public/components/_nav.scss
+++ b/hypha/static_src/src/sass/public/components/_nav.scss
@@ -156,7 +156,8 @@
             color: $color--default;
         }
 
-        .header__menus--mobile & { // stylelint-disable-line selector-class-pattern
+        // stylelint-disable-next-line selector-class-pattern
+        .header__menus--mobile & {
             color: $color--white;
         }
 

--- a/hypha/static_src/src/sass/public/components/_select2.scss
+++ b/hypha/static_src/src/sass/public/components/_select2.scss
@@ -49,11 +49,14 @@
     }
 }
 
-.select2-container { // stylelint-disable-line no-duplicate-selectors
+// stylelint-disable-next-line no-duplicate-selectors
+.select2-container {
     &--default {
         .select2-results__option--highlighted[aria-selected] {
-            color: $color--default !important; // stylelint-disable-line declaration-no-important
-            background-color: transparentize($color--primary, .9) !important; // stylelint-disable-line declaration-no-important, max-line-length
+            // stylelint-disable-next-line declaration-no-important
+            color: $color--default !important;
+            // stylelint-disable-next-line declaration-no-important
+            background-color: transparentize($color--primary, .9) !important;
         }
     }
 

--- a/hypha/static_src/src/sass/public/components/_table.scss
+++ b/hypha/static_src/src/sass/public/components/_table.scss
@@ -45,7 +45,8 @@ table {
                 box-shadow: 0 6px 35px -13px $color--black-50;
             }
 
-            &.reviews-summary__tr { // stylelint-disable-line selector-class-pattern
+            // stylelint-disable-next-line selector-class-pattern
+            &.reviews-summary__tr {
                 box-shadow: none;
             }
         }

--- a/hypha/static_src/src/sass/public/layout/_header.scss
+++ b/hypha/static_src/src/sass/public/layout/_header.scss
@@ -181,7 +181,8 @@
                 fill: $color--dark-grey;
             }
 
-            .header__menus--mobile.is-visible & { // stylelint-disable-line selector-class-pattern
+            // stylelint-disable-next-line selector-class-pattern
+            .header__menus--mobile.is-visible & {
                 fill: $color--white;
             }
         }

--- a/package-lock.json
+++ b/package-lock.json
@@ -18,13 +18,16 @@
                 "core-js": "^3.31.1",
                 "daterangepicker": "^3.1.0",
                 "eslint": "^8.44.0",
+                "eslint-config-prettier": "^8.8.0",
                 "eslint-plugin-template": "^0.7.0",
                 "htmx.org": "^1.9.2",
                 "nodemon": "^3.0.1",
                 "npm-run-all2": "^6.0.6",
+                "prettier": "3.0.0",
                 "sass": "^1.63.6",
+                "stylelint": "^15.10.2",
+                "stylelint-config-standard": "^34.0.0",
                 "stylelint-config-standard-scss": "^10.0.0",
-                "stylelint-scss": "^5.0.1",
                 "tailwindcss": "^3.3.2"
             },
             "engines": {
@@ -1778,7 +1781,6 @@
                     "url": "https://opencollective.com/csstools"
                 }
             ],
-            "peer": true,
             "engines": {
                 "node": "^14 || ^16 || >=18"
             },
@@ -1791,7 +1793,6 @@
             "resolved": "https://registry.npmjs.org/@csstools/css-tokenizer/-/css-tokenizer-2.1.1.tgz",
             "integrity": "sha512-GbrTj2Z8MCTUv+52GE0RbFGM527xuXZ0Xa5g0Z+YN573uveS4G0qi6WNOMyz3yrFM/jaILTTwJ0+umx81EzqfA==",
             "dev": true,
-            "peer": true,
             "engines": {
                 "node": "^14 || ^16 || >=18"
             },
@@ -1815,7 +1816,6 @@
                     "url": "https://opencollective.com/csstools"
                 }
             ],
-            "peer": true,
             "engines": {
                 "node": "^14 || ^16 || >=18"
             },
@@ -1839,7 +1839,6 @@
                     "url": "https://opencollective.com/csstools"
                 }
             ],
-            "peer": true,
             "engines": {
                 "node": "^14 || ^16 || >=18"
             },
@@ -2084,8 +2083,7 @@
             "version": "1.2.2",
             "resolved": "https://registry.npmjs.org/@types/minimist/-/minimist-1.2.2.tgz",
             "integrity": "sha512-jhuKLIRrhvCPLqwPcx6INqmKeiA5EWrsCOPhrlFSrbrmU4ZMPjj5Ul/oLCMDO98XRUIwVm78xICz4EPCektzeQ==",
-            "dev": true,
-            "peer": true
+            "dev": true
         },
         "node_modules/@types/normalize-package-data": {
             "version": "2.4.1",
@@ -2217,7 +2215,6 @@
             "resolved": "https://registry.npmjs.org/array-union/-/array-union-2.1.0.tgz",
             "integrity": "sha512-HGyxoOTYUyCM6stUe6EJgnd4EoewAI7zMdfqO+kGjnlZmBDz/cR5pf8r/cR4Wq60sL/p0IkcjUEEPwS3GFrIyw==",
             "dev": true,
-            "peer": true,
             "engines": {
                 "node": ">=8"
             }
@@ -2227,7 +2224,6 @@
             "resolved": "https://registry.npmjs.org/arrify/-/arrify-1.0.1.tgz",
             "integrity": "sha512-3CYzex9M9FGQjCGMGyi6/31c8GJbgb0qGyrx5HWxPd0aCwh4cB2YjMb2Xf9UuoogrMrlO9cTqnB5rI5GHZTcUA==",
             "dev": true,
-            "peer": true,
             "engines": {
                 "node": ">=0.10.0"
             }
@@ -2237,7 +2233,6 @@
             "resolved": "https://registry.npmjs.org/astral-regex/-/astral-regex-2.0.0.tgz",
             "integrity": "sha512-Z7tMw1ytTXt5jqMcOP+OQteU1VuNK9Y02uuJtKQ1Sv69jXQKKg5cibLwGJow8yzZP+eAc18EmLGPal0bp36rvQ==",
             "dev": true,
-            "peer": true,
             "engines": {
                 "node": ">=8"
             }
@@ -2364,7 +2359,6 @@
             "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-6.3.0.tgz",
             "integrity": "sha512-Gmy6FhYlCY7uOElZUSbxo2UCDH8owEk996gkbrpsgGtrJLM3J7jGxl9Ic7Qwwj4ivOE5AWZWRMecDdF7hqGjFA==",
             "dev": true,
-            "peer": true,
             "engines": {
                 "node": ">=10"
             },
@@ -2386,7 +2380,6 @@
             "resolved": "https://registry.npmjs.org/camelcase-keys/-/camelcase-keys-7.0.2.tgz",
             "integrity": "sha512-Rjs1H+A9R+Ig+4E/9oyB66UC5Mj9Xq3N//vcLf2WzgdTi/3gUu3Z9KoqmlrEG4VuuLK8wJHofxzdQXz/knhiYg==",
             "dev": true,
-            "peer": true,
             "dependencies": {
                 "camelcase": "^6.3.0",
                 "map-obj": "^4.1.0",
@@ -2405,7 +2398,6 @@
             "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-1.4.0.tgz",
             "integrity": "sha512-yGSza74xk0UG8k+pLh5oeoYirvIiWo5t0/o3zHHAO2tRDiZcxWP7fywNlXhqb6/r6sWvwi+RsyQMWhVLe4BVuA==",
             "dev": true,
-            "peer": true,
             "engines": {
                 "node": ">=10"
             },
@@ -2493,8 +2485,7 @@
             "version": "2.9.3",
             "resolved": "https://registry.npmjs.org/colord/-/colord-2.9.3.tgz",
             "integrity": "sha512-jeC1axXpnb0/2nn/Y1LPuLdgXBLH7aDcHu4KEKfqw3CUhX7ZpfBSlPKyqXE6btIgEzfWtrX3/tyBCaCvXvMkOw==",
-            "dev": true,
-            "peer": true
+            "dev": true
         },
         "node_modules/commander": {
             "version": "4.1.1",
@@ -2546,7 +2537,6 @@
             "resolved": "https://registry.npmjs.org/cosmiconfig/-/cosmiconfig-8.2.0.tgz",
             "integrity": "sha512-3rTMnFJA1tCOPwRxtgF4wd7Ab2qvDbL8jX+3smjIbS4HlZBagTlpERbdN7iAbWlrfxE3M8c27kTwTawQ7st+OQ==",
             "dev": true,
-            "peer": true,
             "dependencies": {
                 "import-fresh": "^3.2.1",
                 "js-yaml": "^4.1.0",
@@ -2564,22 +2554,19 @@
             "version": "2.3.1",
             "resolved": "https://registry.npmjs.org/json-parse-even-better-errors/-/json-parse-even-better-errors-2.3.1.tgz",
             "integrity": "sha512-xyFwyhro/JEof6Ghe2iz2NcXoj2sloNsWr/XsERDK/oiPCfaNhl5ONfp+jQdAZRQQ0IJWNzH9zIZF7li91kh2w==",
-            "dev": true,
-            "peer": true
+            "dev": true
         },
         "node_modules/cosmiconfig/node_modules/lines-and-columns": {
             "version": "1.2.4",
             "resolved": "https://registry.npmjs.org/lines-and-columns/-/lines-and-columns-1.2.4.tgz",
             "integrity": "sha512-7ylylesZQ/PV29jhEDl3Ufjo6ZX7gCqJr5F7PKrqc93v7fzSymt1BpwEU8nAUXs8qzzvqhbjhK5QZg6Mt/HkBg==",
-            "dev": true,
-            "peer": true
+            "dev": true
         },
         "node_modules/cosmiconfig/node_modules/parse-json": {
             "version": "5.2.0",
             "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-5.2.0.tgz",
             "integrity": "sha512-ayCKvm/phCGxOkYRSCM82iDwct8/EonSEgCSxWxD7ve6jHggsFl4fZVQBPRNgQoKiuV/odhFrGzQXZwbifC8Rg==",
             "dev": true,
-            "peer": true,
             "dependencies": {
                 "@babel/code-frame": "^7.0.0",
                 "error-ex": "^1.3.1",
@@ -2612,7 +2599,6 @@
             "resolved": "https://registry.npmjs.org/css-functions-list/-/css-functions-list-3.2.0.tgz",
             "integrity": "sha512-d/jBMPyYybkkLVypgtGv12R+pIFw4/f/IHtCTxWpZc8ofTYOPigIgmA6vu5rMHartZC+WuXhBUHfnyNUIQSYrg==",
             "dev": true,
-            "peer": true,
             "engines": {
                 "node": ">=12.22"
             }
@@ -2622,7 +2608,6 @@
             "resolved": "https://registry.npmjs.org/css-tree/-/css-tree-2.3.1.tgz",
             "integrity": "sha512-6Fv1DV/TYw//QF5IzQdqsNDjx/wc8TrMBZsqjL9eW01tWb7R7k/mq+/VXfJCl7SoD5emsJop9cOByJZfs8hYIw==",
             "dev": true,
-            "peer": true,
             "dependencies": {
                 "mdn-data": "2.0.30",
                 "source-map-js": "^1.0.1"
@@ -2675,7 +2660,6 @@
             "resolved": "https://registry.npmjs.org/decamelize/-/decamelize-5.0.1.tgz",
             "integrity": "sha512-VfxadyCECXgQlkoEAjeghAr5gY3Hf+IKjKb+X8tGVDtveCjN+USwprd2q3QXBR9T1+x2DG0XZF5/w+7HAtSaXA==",
             "dev": true,
-            "peer": true,
             "engines": {
                 "node": ">=10"
             },
@@ -2688,7 +2672,6 @@
             "resolved": "https://registry.npmjs.org/decamelize-keys/-/decamelize-keys-1.1.1.tgz",
             "integrity": "sha512-WiPxgEirIV0/eIOMcnFBA3/IJZAZqKnwAwWyvvdi4lsr1WCN22nhdf/3db3DoZcUjTV2SqfzIwNyp6y2xs3nmg==",
             "dev": true,
-            "peer": true,
             "dependencies": {
                 "decamelize": "^1.1.0",
                 "map-obj": "^1.0.0"
@@ -2705,7 +2688,6 @@
             "resolved": "https://registry.npmjs.org/decamelize/-/decamelize-1.2.0.tgz",
             "integrity": "sha512-z2S+W9X73hAUUki+N+9Za2lBlun89zigOyGrsax+KUQ6wKW4ZoWpEYBkGhQjwAjjDCkWxhY0VKEhk8wzY7F5cA==",
             "dev": true,
-            "peer": true,
             "engines": {
                 "node": ">=0.10.0"
             }
@@ -2715,7 +2697,6 @@
             "resolved": "https://registry.npmjs.org/map-obj/-/map-obj-1.0.1.tgz",
             "integrity": "sha512-7N/q3lyZ+LVCp7PzuxrJr4KMbBE2hW7BT7YNia330OFxIf4d3r5zVpicP2650l7CPN6RM9zOJRl3NGpqSiw3Eg==",
             "dev": true,
-            "peer": true,
             "engines": {
                 "node": ">=0.10.0"
             }
@@ -2737,7 +2718,6 @@
             "resolved": "https://registry.npmjs.org/dir-glob/-/dir-glob-3.0.1.tgz",
             "integrity": "sha512-WkrWp9GR4KXfKGYzOLmTuGVi1UWFfws377n9cc55/tb6DuqyF6pcQ5AbiHEshaDpY9v6oaSr2XCDidGmMwdzIA==",
             "dev": true,
-            "peer": true,
             "dependencies": {
                 "path-type": "^4.0.0"
             },
@@ -2829,8 +2809,7 @@
             "version": "8.0.0",
             "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
             "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
-            "dev": true,
-            "peer": true
+            "dev": true
         },
         "node_modules/entities": {
             "version": "1.1.2",
@@ -2919,6 +2898,18 @@
             },
             "funding": {
                 "url": "https://opencollective.com/eslint"
+            }
+        },
+        "node_modules/eslint-config-prettier": {
+            "version": "8.8.0",
+            "resolved": "https://registry.npmjs.org/eslint-config-prettier/-/eslint-config-prettier-8.8.0.tgz",
+            "integrity": "sha512-wLbQiFre3tdGgpDv67NQKnJuTlcUVYHas3k+DZCc2U2BadthoEY4B7hLPvAxaqdyOGCzuLfii2fqGph10va7oA==",
+            "dev": true,
+            "bin": {
+                "eslint-config-prettier": "bin/cli.js"
+            },
+            "peerDependencies": {
+                "eslint": ">=7.0.0"
             }
         },
         "node_modules/eslint-plugin-template": {
@@ -3177,7 +3168,6 @@
             "resolved": "https://registry.npmjs.org/fastest-levenshtein/-/fastest-levenshtein-1.0.16.tgz",
             "integrity": "sha512-eRnCtTTtGZFpQCwhJiUOuxPQWRXVKYDn0b2PeHfXL6/Zi53SLAzAHfVhVWK2AryC/WH05kGfxhFIPvTF0SXQzg==",
             "dev": true,
-            "peer": true,
             "engines": {
                 "node": ">= 4.9.1"
             }
@@ -3337,7 +3327,6 @@
             "resolved": "https://registry.npmjs.org/global-modules/-/global-modules-2.0.0.tgz",
             "integrity": "sha512-NGbfmJBp9x8IxyJSd1P+otYK8vonoJactOogrVfFRIAEY1ukil8RSKDz2Yo7wh1oihl51l/r6W4epkeKJHqL8A==",
             "dev": true,
-            "peer": true,
             "dependencies": {
                 "global-prefix": "^3.0.0"
             },
@@ -3350,7 +3339,6 @@
             "resolved": "https://registry.npmjs.org/global-prefix/-/global-prefix-3.0.0.tgz",
             "integrity": "sha512-awConJSVCHVGND6x3tmMaKcQvwXLhjdkmomy2W+Goaui8YPgYgXJZewhg3fWC+DlfqqQuWg8AwqjGTD2nAPVWg==",
             "dev": true,
-            "peer": true,
             "dependencies": {
                 "ini": "^1.3.5",
                 "kind-of": "^6.0.2",
@@ -3365,7 +3353,6 @@
             "resolved": "https://registry.npmjs.org/which/-/which-1.3.1.tgz",
             "integrity": "sha512-HxJdYWq1MTIQbJ3nw0cqssHoTNU267KlrDuGZ1WYlxDStUtKUhOaJmh112/TZmHxxUfuJqPXSOm7tDyas0OSIQ==",
             "dev": true,
-            "peer": true,
             "dependencies": {
                 "isexe": "^2.0.0"
             },
@@ -3387,7 +3374,6 @@
             "resolved": "https://registry.npmjs.org/globby/-/globby-11.1.0.tgz",
             "integrity": "sha512-jhIXaOzy1sb8IyocaruWSn1TjmnBVs8Ayhcy83rmxNJ8q2uWKCAj3CnJY+KpGSXCueAPc0i05kVvVKtP1t9S3g==",
             "dev": true,
-            "peer": true,
             "dependencies": {
                 "array-union": "^2.1.0",
                 "dir-glob": "^3.0.1",
@@ -3408,7 +3394,6 @@
             "resolved": "https://registry.npmjs.org/slash/-/slash-3.0.0.tgz",
             "integrity": "sha512-g9Q1haeby36OSStwb4ntCGGGaKsaVSjQ68fBxoQcutl5fS1vuY18H3wSt3jFyFtrkx+Kz0V1G85A4MyAdDMi2Q==",
             "dev": true,
-            "peer": true,
             "engines": {
                 "node": ">=8"
             }
@@ -3417,8 +3402,7 @@
             "version": "0.1.4",
             "resolved": "https://registry.npmjs.org/globjoin/-/globjoin-0.1.4.tgz",
             "integrity": "sha512-xYfnw62CKG8nLkZBfWbhWwDw02CHty86jfPcc2cr3ZfeuK9ysoVPPEUxf21bAD/rWAgk52SuBrLJlefNy8mvFg==",
-            "dev": true,
-            "peer": true
+            "dev": true
         },
         "node_modules/graphemer": {
             "version": "1.4.0",
@@ -3431,7 +3415,6 @@
             "resolved": "https://registry.npmjs.org/hard-rejection/-/hard-rejection-2.1.0.tgz",
             "integrity": "sha512-VIZB+ibDhx7ObhAe7OVtoEbuP4h/MuOTHJ+J8h/eBXotJYl0fBgR72xDFCKgIh22OJZIOVNxBMWuhAr10r8HdA==",
             "dev": true,
-            "peer": true,
             "engines": {
                 "node": ">=6"
             }
@@ -3483,7 +3466,6 @@
             "resolved": "https://registry.npmjs.org/html-tags/-/html-tags-3.3.1.tgz",
             "integrity": "sha512-ztqyC3kLto0e9WbNp0aeP+M3kTt+nbaIveGmUxAtZa+8iFgKLUOD4YKM5j+f3QD89bra7UeumolZHKuOXnTmeQ==",
             "dev": true,
-            "peer": true,
             "engines": {
                 "node": ">=8"
             },
@@ -3553,7 +3535,6 @@
             "resolved": "https://registry.npmjs.org/import-lazy/-/import-lazy-4.0.0.tgz",
             "integrity": "sha512-rKtvo6a868b5Hu3heneU+L4yEQ4jYKLtjpnPeUdK7h0yzXGmyBTypknlkCvHFBqfX9YlorEiMM6Dnq/5atfHkw==",
             "dev": true,
-            "peer": true,
             "engines": {
                 "node": ">=8"
             }
@@ -3572,7 +3553,6 @@
             "resolved": "https://registry.npmjs.org/indent-string/-/indent-string-5.0.0.tgz",
             "integrity": "sha512-m6FAo/spmsW2Ab2fU35JTYwtOKa2yAwXSwgjSv1TJzh4Mh7mC3lzAOVLBprb72XsTrgkEIsl7YrFNAiDiRhIGg==",
             "dev": true,
-            "peer": true,
             "engines": {
                 "node": ">=12"
             },
@@ -3600,8 +3580,7 @@
             "version": "1.3.8",
             "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.8.tgz",
             "integrity": "sha512-JV/yugV2uzW5iMRSiZAyDtQd+nxtUnjeLt0acNdw98kKLrvuRVyB80tsREOE7yvGVgalhZ6RNXCmEHkUKBKxew==",
-            "dev": true,
-            "peer": true
+            "dev": true
         },
         "node_modules/is-arrayish": {
             "version": "0.2.1",
@@ -3647,7 +3626,6 @@
             "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
             "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
             "dev": true,
-            "peer": true,
             "engines": {
                 "node": ">=8"
             }
@@ -3687,7 +3665,6 @@
             "resolved": "https://registry.npmjs.org/is-plain-obj/-/is-plain-obj-1.1.0.tgz",
             "integrity": "sha512-yvkRyxmFKEOQ4pNXCmJG5AEQNlXJS5LaONXo5/cLdTZdWvsZ1ioJEonLGAosKlMWE8lwUy/bJzMjcw8az73+Fg==",
             "dev": true,
-            "peer": true,
             "engines": {
                 "node": ">=0.10.0"
             }
@@ -3697,7 +3674,6 @@
             "resolved": "https://registry.npmjs.org/is-plain-object/-/is-plain-object-5.0.0.tgz",
             "integrity": "sha512-VRSzKkbMm5jMDoKLbltAkFQ5Qr7VDiTFGXxYFXXowVj387GeGNOCsOH6Msy00SGZ3Fp84b1Naa1psqgcCIEP5Q==",
             "dev": true,
-            "peer": true,
             "engines": {
                 "node": ">=0.10.0"
             }
@@ -3791,7 +3767,6 @@
             "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.3.tgz",
             "integrity": "sha512-dcS1ul+9tmeD95T+x28/ehLgd9mENa3LsvDTtzm3vyBEO7RPptvAD+t44WVXaUjTBRcrpFeFlC8WCruUR456hw==",
             "dev": true,
-            "peer": true,
             "engines": {
                 "node": ">=0.10.0"
             }
@@ -3800,8 +3775,7 @@
             "version": "0.27.0",
             "resolved": "https://registry.npmjs.org/known-css-properties/-/known-css-properties-0.27.0.tgz",
             "integrity": "sha512-uMCj6+hZYDoffuvAJjFAPz56E9uoowFHmTkqRtRq5WyC5Q6Cu/fTZKNQpX/RbzChBYLLl3lo8CjFZBAZXq9qFg==",
-            "dev": true,
-            "peer": true
+            "dev": true
         },
         "node_modules/levn": {
             "version": "0.4.1",
@@ -3865,8 +3839,7 @@
             "version": "4.4.2",
             "resolved": "https://registry.npmjs.org/lodash.truncate/-/lodash.truncate-4.4.2.tgz",
             "integrity": "sha512-jttmRe7bRse52OsWIMDLaXxWqRAmtIUccAQ3garviCqJjafXOfNMO0yMfNpdD6zbGaTU0P5Nz7e7gAT6cKmJRw==",
-            "dev": true,
-            "peer": true
+            "dev": true
         },
         "node_modules/lru-cache": {
             "version": "5.1.1",
@@ -3895,7 +3868,6 @@
             "resolved": "https://registry.npmjs.org/map-obj/-/map-obj-4.3.0.tgz",
             "integrity": "sha512-hdN1wVrZbb29eBGiGjJbeP8JbKjq1urkHJ/LIP/NY48MZ1QVXUsQBV1G1zvYFHn1XE06cwjBsOI2K3Ulnj1YXQ==",
             "dev": true,
-            "peer": true,
             "engines": {
                 "node": ">=8"
             },
@@ -3908,7 +3880,6 @@
             "resolved": "https://registry.npmjs.org/mathml-tag-names/-/mathml-tag-names-2.1.3.tgz",
             "integrity": "sha512-APMBEanjybaPzUrfqU0IMU5I0AswKMH7k8OTLs0vvV4KZpExkTkY87nR/zpbuTPj+gARop7aGUbl11pnDfW6xg==",
             "dev": true,
-            "peer": true,
             "funding": {
                 "type": "github",
                 "url": "https://github.com/sponsors/wooorm"
@@ -3918,8 +3889,7 @@
             "version": "2.0.30",
             "resolved": "https://registry.npmjs.org/mdn-data/-/mdn-data-2.0.30.tgz",
             "integrity": "sha512-GaqWWShW4kv/G9IEucWScBx9G1/vsFZZJUO+tD26M8J8z3Kw5RDQjaoZe03YAClgeS/SWPOcb4nkFBTEi5DUEA==",
-            "dev": true,
-            "peer": true
+            "dev": true
         },
         "node_modules/memorystream": {
             "version": "0.3.1",
@@ -3935,7 +3905,6 @@
             "resolved": "https://registry.npmjs.org/meow/-/meow-10.1.5.tgz",
             "integrity": "sha512-/d+PQ4GKmGvM9Bee/DPa8z3mXs/pkvJE2KEThngVNOqtmljC6K7NMPxtc2JeZYTmpWb9k/TmxjeL18ez3h7vCw==",
             "dev": true,
-            "peer": true,
             "dependencies": {
                 "@types/minimist": "^1.2.2",
                 "camelcase-keys": "^7.0.0",
@@ -3962,7 +3931,6 @@
             "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-4.1.0.tgz",
             "integrity": "sha512-kyCuEOWjJqZuDbRHzL8V93NzQhwIB71oFWSyzVo+KPZI+pnQPPxucdkrOZvkLRnrf5URsQM+IJ09Dw29cRALIA==",
             "dev": true,
-            "peer": true,
             "dependencies": {
                 "lru-cache": "^6.0.0"
             },
@@ -3975,7 +3943,6 @@
             "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
             "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
             "dev": true,
-            "peer": true,
             "dependencies": {
                 "yallist": "^4.0.0"
             },
@@ -3988,7 +3955,6 @@
             "resolved": "https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-3.0.3.tgz",
             "integrity": "sha512-p2W1sgqij3zMMyRC067Dg16bfzVH+w7hyegmpIvZ4JNjqtGOVAIvLmjBx3yP7YTe9vKJgkoNOPjwQGogDoMXFA==",
             "dev": true,
-            "peer": true,
             "dependencies": {
                 "hosted-git-info": "^4.0.1",
                 "is-core-module": "^2.5.0",
@@ -4004,7 +3970,6 @@
             "resolved": "https://registry.npmjs.org/semver/-/semver-7.5.4.tgz",
             "integrity": "sha512-1bCSESV6Pv+i21Hvpxp3Dx+pSD8lIPt8uVjRrxAUt/nbswYc+tK6Y2btiULjd4+fnq15PX+nqQDC7Oft7WkwcA==",
             "dev": true,
-            "peer": true,
             "dependencies": {
                 "lru-cache": "^6.0.0"
             },
@@ -4020,7 +3985,6 @@
             "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-1.4.0.tgz",
             "integrity": "sha512-yGSza74xk0UG8k+pLh5oeoYirvIiWo5t0/o3zHHAO2tRDiZcxWP7fywNlXhqb6/r6sWvwi+RsyQMWhVLe4BVuA==",
             "dev": true,
-            "peer": true,
             "engines": {
                 "node": ">=10"
             },
@@ -4032,8 +3996,7 @@
             "version": "4.0.0",
             "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
             "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
-            "dev": true,
-            "peer": true
+            "dev": true
         },
         "node_modules/merge2": {
             "version": "1.4.1",
@@ -4062,7 +4025,6 @@
             "resolved": "https://registry.npmjs.org/min-indent/-/min-indent-1.0.1.tgz",
             "integrity": "sha512-I9jwMn07Sy/IwOj3zVkVik2JTvgpaykDZEigL6Rx6N9LbMywwUSMtxET+7lVoDLLd3O3IXwJwvuuns8UB/HeAg==",
             "dev": true,
-            "peer": true,
             "engines": {
                 "node": ">=4"
             }
@@ -4093,7 +4055,6 @@
             "resolved": "https://registry.npmjs.org/minimist-options/-/minimist-options-4.1.0.tgz",
             "integrity": "sha512-Q4r8ghd80yhO/0j1O3B2BjweX3fiHg9cdOwjJd2J76Q135c+NDxGCqdYKQ1SKBuFfgWbAUzBfvYjPUEeNgqN1A==",
             "dev": true,
-            "peer": true,
             "dependencies": {
                 "arrify": "^1.0.1",
                 "is-plain-obj": "^1.1.0",
@@ -4504,7 +4465,6 @@
             "resolved": "https://registry.npmjs.org/path-type/-/path-type-4.0.0.tgz",
             "integrity": "sha512-gDKb8aZMDeD/tZWs9P6+q0J9Mwkdl6xMV8TjnGP3qJVJ06bdMgkbBlLU8IdfOsIsFz2BW1rNVT3XuNEl8zPAvw==",
             "dev": true,
-            "peer": true,
             "engines": {
                 "node": ">=8"
             }
@@ -4686,7 +4646,6 @@
             "resolved": "https://registry.npmjs.org/postcss-safe-parser/-/postcss-safe-parser-6.0.0.tgz",
             "integrity": "sha512-FARHN8pwH+WiS2OPCxJI8FuRJpTVnn6ZNFiqAM2aeW2LwTHWWmWgIyKC6cUo0L8aeKiF/14MNvnpls6R2PBeMQ==",
             "dev": true,
-            "peer": true,
             "engines": {
                 "node": ">=12.0"
             },
@@ -4748,6 +4707,21 @@
                 "node": ">= 0.8.0"
             }
         },
+        "node_modules/prettier": {
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.0.0.tgz",
+            "integrity": "sha512-zBf5eHpwHOGPC47h0zrPyNn+eAEIdEzfywMoYn2XPi0P44Zp0tSq64rq0xAREh4auw2cJZHo9QUob+NqCQky4g==",
+            "dev": true,
+            "bin": {
+                "prettier": "bin/prettier.cjs"
+            },
+            "engines": {
+                "node": ">=14"
+            },
+            "funding": {
+                "url": "https://github.com/prettier/prettier?sponsor=1"
+            }
+        },
         "node_modules/pstree.remy": {
             "version": "1.1.8",
             "resolved": "https://registry.npmjs.org/pstree.remy/-/pstree.remy-1.1.8.tgz",
@@ -4788,7 +4762,6 @@
             "resolved": "https://registry.npmjs.org/quick-lru/-/quick-lru-5.1.1.tgz",
             "integrity": "sha512-WuyALRjWPDGtt/wzJiadO5AXY+8hZ80hVpe6MyivgraREW751X3SbhRvG3eLKOYN+8VEvqLcf3wdnt44Z4S4SA==",
             "dev": true,
-            "peer": true,
             "engines": {
                 "node": ">=10"
             },
@@ -4837,7 +4810,6 @@
             "resolved": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-8.0.0.tgz",
             "integrity": "sha512-snVCqPczksT0HS2EC+SxUndvSzn6LRCwpfSvLrIfR5BKDQQZMaI6jPRC9dYvYFDRAuFEAnkwww8kBBNE/3VvzQ==",
             "dev": true,
-            "peer": true,
             "dependencies": {
                 "find-up": "^5.0.0",
                 "read-pkg": "^6.0.0",
@@ -4855,7 +4827,6 @@
             "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-4.1.0.tgz",
             "integrity": "sha512-kyCuEOWjJqZuDbRHzL8V93NzQhwIB71oFWSyzVo+KPZI+pnQPPxucdkrOZvkLRnrf5URsQM+IJ09Dw29cRALIA==",
             "dev": true,
-            "peer": true,
             "dependencies": {
                 "lru-cache": "^6.0.0"
             },
@@ -4867,22 +4838,19 @@
             "version": "2.3.1",
             "resolved": "https://registry.npmjs.org/json-parse-even-better-errors/-/json-parse-even-better-errors-2.3.1.tgz",
             "integrity": "sha512-xyFwyhro/JEof6Ghe2iz2NcXoj2sloNsWr/XsERDK/oiPCfaNhl5ONfp+jQdAZRQQ0IJWNzH9zIZF7li91kh2w==",
-            "dev": true,
-            "peer": true
+            "dev": true
         },
         "node_modules/read-pkg-up/node_modules/lines-and-columns": {
             "version": "1.2.4",
             "resolved": "https://registry.npmjs.org/lines-and-columns/-/lines-and-columns-1.2.4.tgz",
             "integrity": "sha512-7ylylesZQ/PV29jhEDl3Ufjo6ZX7gCqJr5F7PKrqc93v7fzSymt1BpwEU8nAUXs8qzzvqhbjhK5QZg6Mt/HkBg==",
-            "dev": true,
-            "peer": true
+            "dev": true
         },
         "node_modules/read-pkg-up/node_modules/lru-cache": {
             "version": "6.0.0",
             "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
             "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
             "dev": true,
-            "peer": true,
             "dependencies": {
                 "yallist": "^4.0.0"
             },
@@ -4895,7 +4863,6 @@
             "resolved": "https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-3.0.3.tgz",
             "integrity": "sha512-p2W1sgqij3zMMyRC067Dg16bfzVH+w7hyegmpIvZ4JNjqtGOVAIvLmjBx3yP7YTe9vKJgkoNOPjwQGogDoMXFA==",
             "dev": true,
-            "peer": true,
             "dependencies": {
                 "hosted-git-info": "^4.0.1",
                 "is-core-module": "^2.5.0",
@@ -4911,7 +4878,6 @@
             "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-5.2.0.tgz",
             "integrity": "sha512-ayCKvm/phCGxOkYRSCM82iDwct8/EonSEgCSxWxD7ve6jHggsFl4fZVQBPRNgQoKiuV/odhFrGzQXZwbifC8Rg==",
             "dev": true,
-            "peer": true,
             "dependencies": {
                 "@babel/code-frame": "^7.0.0",
                 "error-ex": "^1.3.1",
@@ -4930,7 +4896,6 @@
             "resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-6.0.0.tgz",
             "integrity": "sha512-X1Fu3dPuk/8ZLsMhEj5f4wFAF0DWoK7qhGJvgaijocXxBmSToKfbFtqbxMO7bVjNA1dmE5huAzjXj/ey86iw9Q==",
             "dev": true,
-            "peer": true,
             "dependencies": {
                 "@types/normalize-package-data": "^2.4.0",
                 "normalize-package-data": "^3.0.2",
@@ -4949,7 +4914,6 @@
             "resolved": "https://registry.npmjs.org/semver/-/semver-7.5.4.tgz",
             "integrity": "sha512-1bCSESV6Pv+i21Hvpxp3Dx+pSD8lIPt8uVjRrxAUt/nbswYc+tK6Y2btiULjd4+fnq15PX+nqQDC7Oft7WkwcA==",
             "dev": true,
-            "peer": true,
             "dependencies": {
                 "lru-cache": "^6.0.0"
             },
@@ -4965,7 +4929,6 @@
             "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-1.4.0.tgz",
             "integrity": "sha512-yGSza74xk0UG8k+pLh5oeoYirvIiWo5t0/o3zHHAO2tRDiZcxWP7fywNlXhqb6/r6sWvwi+RsyQMWhVLe4BVuA==",
             "dev": true,
-            "peer": true,
             "engines": {
                 "node": ">=10"
             },
@@ -4977,8 +4940,7 @@
             "version": "4.0.0",
             "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
             "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
-            "dev": true,
-            "peer": true
+            "dev": true
         },
         "node_modules/readable-stream": {
             "version": "3.6.2",
@@ -5011,7 +4973,6 @@
             "resolved": "https://registry.npmjs.org/redent/-/redent-4.0.0.tgz",
             "integrity": "sha512-tYkDkVVtYkSVhuQ4zBgfvciymHaeuel+zFKXShfDnFP5SyVEP7qo70Rf1jTOTCx3vGNAbnEi/xFkcfQVMIBWag==",
             "dev": true,
-            "peer": true,
             "dependencies": {
                 "indent-string": "^5.0.0",
                 "strip-indent": "^4.0.0"
@@ -5099,7 +5060,6 @@
             "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
             "integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==",
             "dev": true,
-            "peer": true,
             "engines": {
                 "node": ">=0.10.0"
             }
@@ -5259,7 +5219,6 @@
             "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-4.0.2.tgz",
             "integrity": "sha512-MY2/qGx4enyjprQnFaZsHib3Yadh3IXyV2C321GY0pjGfVBu4un0uDJkwgdxqO+Rdx8JMT8IfJIRwbYVz3Ob3Q==",
             "dev": true,
-            "peer": true,
             "engines": {
                 "node": ">=14"
             },
@@ -5326,7 +5285,6 @@
             "resolved": "https://registry.npmjs.org/slice-ansi/-/slice-ansi-4.0.0.tgz",
             "integrity": "sha512-qMCMfhY040cVHT43K9BFygqYbUPFZKHOg7K73mtTWJRb8pyP3fzf4Ixd5SzdEJQ6MRUg/WBnOLxghZtKKurENQ==",
             "dev": true,
-            "peer": true,
             "dependencies": {
                 "ansi-styles": "^4.0.0",
                 "astral-regex": "^2.0.0",
@@ -5344,7 +5302,6 @@
             "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
             "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
             "dev": true,
-            "peer": true,
             "dependencies": {
                 "color-convert": "^2.0.1"
             },
@@ -5360,7 +5317,6 @@
             "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
             "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
             "dev": true,
-            "peer": true,
             "dependencies": {
                 "color-name": "~1.1.4"
             },
@@ -5372,8 +5328,7 @@
             "version": "1.1.4",
             "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
             "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
-            "dev": true,
-            "peer": true
+            "dev": true
         },
         "node_modules/source-map-js": {
             "version": "1.0.2",
@@ -5430,7 +5385,6 @@
             "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
             "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
             "dev": true,
-            "peer": true,
             "dependencies": {
                 "emoji-regex": "^8.0.0",
                 "is-fullwidth-code-point": "^3.0.0",
@@ -5457,7 +5411,6 @@
             "resolved": "https://registry.npmjs.org/strip-indent/-/strip-indent-4.0.0.tgz",
             "integrity": "sha512-mnVSV2l+Zv6BLpSD/8V87CW/y9EmmbYzGCIavsnsI6/nwn26DwffM/yztm30Z/I2DY9wdS3vXVCMnHDgZaVNoA==",
             "dev": true,
-            "peer": true,
             "dependencies": {
                 "min-indent": "^1.0.1"
             },
@@ -5484,15 +5437,13 @@
             "version": "0.1.0",
             "resolved": "https://registry.npmjs.org/style-search/-/style-search-0.1.0.tgz",
             "integrity": "sha512-Dj1Okke1C3uKKwQcetra4jSuk0DqbzbYtXipzFlFMZtowbF1x7BKJwB9AayVMyFARvU8EDrZdcax4At/452cAg==",
-            "dev": true,
-            "peer": true
+            "dev": true
         },
         "node_modules/stylelint": {
-            "version": "15.10.1",
-            "resolved": "https://registry.npmjs.org/stylelint/-/stylelint-15.10.1.tgz",
-            "integrity": "sha512-CYkzYrCFfA/gnOR+u9kJ1PpzwG10WLVnoxHDuBA/JiwGqdM9+yx9+ou6SE/y9YHtfv1mcLo06fdadHTOx4gBZQ==",
+            "version": "15.10.2",
+            "resolved": "https://registry.npmjs.org/stylelint/-/stylelint-15.10.2.tgz",
+            "integrity": "sha512-UxqSb3hB74g4DTO45QhUHkJMjKKU//lNUAOWyvPBVPZbCknJ5HjOWWZo+UDuhHa9FLeVdHBZXxu43eXkjyIPWg==",
             "dev": true,
-            "peer": true,
             "dependencies": {
                 "@csstools/css-parser-algorithms": "^2.3.0",
                 "@csstools/css-tokenizer": "^2.1.1",
@@ -5501,7 +5452,7 @@
                 "balanced-match": "^2.0.0",
                 "colord": "^2.9.3",
                 "cosmiconfig": "^8.2.0",
-                "css-functions-list": "^3.1.0",
+                "css-functions-list": "^3.2.0",
                 "css-tree": "^2.3.1",
                 "debug": "^4.3.4",
                 "fast-glob": "^3.3.0",
@@ -5521,7 +5472,7 @@
                 "micromatch": "^4.0.5",
                 "normalize-path": "^3.0.0",
                 "picocolors": "^1.0.0",
-                "postcss": "^8.4.24",
+                "postcss": "^8.4.25",
                 "postcss-resolve-nested-selector": "^0.1.1",
                 "postcss-safe-parser": "^6.0.0",
                 "postcss-selector-parser": "^6.0.13",
@@ -5576,15 +5527,18 @@
             }
         },
         "node_modules/stylelint-config-standard": {
-            "version": "33.0.0",
-            "resolved": "https://registry.npmjs.org/stylelint-config-standard/-/stylelint-config-standard-33.0.0.tgz",
-            "integrity": "sha512-eyxnLWoXImUn77+ODIuW9qXBDNM+ALN68L3wT1lN2oNspZ7D9NVGlNHb2QCUn4xDug6VZLsh0tF8NyoYzkgTzg==",
+            "version": "34.0.0",
+            "resolved": "https://registry.npmjs.org/stylelint-config-standard/-/stylelint-config-standard-34.0.0.tgz",
+            "integrity": "sha512-u0VSZnVyW9VSryBG2LSO+OQTjN7zF9XJaAJRX/4EwkmU0R2jYwmBSN10acqZisDitS0CLiEiGjX7+Hrq8TAhfQ==",
             "dev": true,
             "dependencies": {
-                "stylelint-config-recommended": "^12.0.0"
+                "stylelint-config-recommended": "^13.0.0"
+            },
+            "engines": {
+                "node": "^14.13.1 || >=16.0.0"
             },
             "peerDependencies": {
-                "stylelint": "^15.5.0"
+                "stylelint": "^15.10.0"
             }
         },
         "node_modules/stylelint-config-standard-scss": {
@@ -5606,6 +5560,30 @@
                 }
             }
         },
+        "node_modules/stylelint-config-standard-scss/node_modules/stylelint-config-standard": {
+            "version": "33.0.0",
+            "resolved": "https://registry.npmjs.org/stylelint-config-standard/-/stylelint-config-standard-33.0.0.tgz",
+            "integrity": "sha512-eyxnLWoXImUn77+ODIuW9qXBDNM+ALN68L3wT1lN2oNspZ7D9NVGlNHb2QCUn4xDug6VZLsh0tF8NyoYzkgTzg==",
+            "dev": true,
+            "dependencies": {
+                "stylelint-config-recommended": "^12.0.0"
+            },
+            "peerDependencies": {
+                "stylelint": "^15.5.0"
+            }
+        },
+        "node_modules/stylelint-config-standard/node_modules/stylelint-config-recommended": {
+            "version": "13.0.0",
+            "resolved": "https://registry.npmjs.org/stylelint-config-recommended/-/stylelint-config-recommended-13.0.0.tgz",
+            "integrity": "sha512-EH+yRj6h3GAe/fRiyaoO2F9l9Tgg50AOFhaszyfov9v6ayXJ1IkSHwTxd7lB48FmOeSGDPLjatjO11fJpmarkQ==",
+            "dev": true,
+            "engines": {
+                "node": "^14.13.1 || >=16.0.0"
+            },
+            "peerDependencies": {
+                "stylelint": "^15.10.0"
+            }
+        },
         "node_modules/stylelint-scss": {
             "version": "5.0.1",
             "resolved": "https://registry.npmjs.org/stylelint-scss/-/stylelint-scss-5.0.1.tgz",
@@ -5625,15 +5603,13 @@
             "version": "2.0.0",
             "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-2.0.0.tgz",
             "integrity": "sha512-1ugUSr8BHXRnK23KfuYS+gVMC3LB8QGH9W1iGtDPsNWoQbgtXSExkBu2aDR4epiGWZOjZsj6lDl/N/AqqTC3UA==",
-            "dev": true,
-            "peer": true
+            "dev": true
         },
         "node_modules/stylelint/node_modules/resolve-from": {
             "version": "5.0.0",
             "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-5.0.0.tgz",
             "integrity": "sha512-qYg9KP24dD5qka9J47d0aVky0N+b4fTU89LN9iDnjB5waksiC49rvMB0PrUJQGoTmH50XPiqOvAjDfaijGxYZw==",
             "dev": true,
-            "peer": true,
             "engines": {
                 "node": ">=8"
             }
@@ -5703,7 +5679,6 @@
             "resolved": "https://registry.npmjs.org/supports-hyperlinks/-/supports-hyperlinks-3.0.0.tgz",
             "integrity": "sha512-QBDPHyPQDRTy9ku4URNGY5Lah8PAaXs6tAAwp55sL5WCsSW7GIfdf6W5ixfziW+t7wh3GVvHyHHyQ1ESsoRvaA==",
             "dev": true,
-            "peer": true,
             "dependencies": {
                 "has-flag": "^4.0.0",
                 "supports-color": "^7.0.0"
@@ -5717,7 +5692,6 @@
             "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
             "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
             "dev": true,
-            "peer": true,
             "engines": {
                 "node": ">=8"
             }
@@ -5727,7 +5701,6 @@
             "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
             "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
             "dev": true,
-            "peer": true,
             "dependencies": {
                 "has-flag": "^4.0.0"
             },
@@ -5751,8 +5724,7 @@
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/svg-tags/-/svg-tags-1.0.0.tgz",
             "integrity": "sha512-ovssysQTa+luh7A5Weu3Rta6FJlFBBbInjOh722LIt6klpU2/HtdUbszju/G4devcvk8PGt7FCLv5wftu3THUA==",
-            "dev": true,
-            "peer": true
+            "dev": true
         },
         "node_modules/tabbable": {
             "version": "5.3.3",
@@ -5765,7 +5737,6 @@
             "resolved": "https://registry.npmjs.org/table/-/table-6.8.1.tgz",
             "integrity": "sha512-Y4X9zqrCftUhMeH2EptSSERdVKt/nEdijTOacGD/97EKjhQ/Qs8RTlEGABSJNNN8lac9kheH+af7yAkEWlgneA==",
             "dev": true,
-            "peer": true,
             "dependencies": {
                 "ajv": "^8.0.1",
                 "lodash.truncate": "^4.4.2",
@@ -5782,7 +5753,6 @@
             "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.12.0.tgz",
             "integrity": "sha512-sRu1kpcO9yLtYxBKvqfTeh9KzZEwO3STyX1HT+4CaDzC6HpTGYhIhPIzj9XuKU7KYDwnaeh5hcOwjy1QuJzBPA==",
             "dev": true,
-            "peer": true,
             "dependencies": {
                 "fast-deep-equal": "^3.1.1",
                 "json-schema-traverse": "^1.0.0",
@@ -5798,8 +5768,7 @@
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
             "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
-            "dev": true,
-            "peer": true
+            "dev": true
         },
         "node_modules/tailwindcss": {
             "version": "3.3.2",
@@ -5916,7 +5885,6 @@
             "resolved": "https://registry.npmjs.org/trim-newlines/-/trim-newlines-4.1.1.tgz",
             "integrity": "sha512-jRKj0n0jXWo6kh62nA5TEh3+4igKDXLvzBJcPpiizP7oOolUrYIxmVBG9TOtHYFHoddUk6YvAkGeGoSVTXfQXQ==",
             "dev": true,
-            "peer": true,
             "engines": {
                 "node": ">=12"
             },
@@ -6081,7 +6049,6 @@
             "resolved": "https://registry.npmjs.org/write-file-atomic/-/write-file-atomic-5.0.1.tgz",
             "integrity": "sha512-+QU2zd6OTD8XWIJCbffaiQeH9U73qIqafo1x6V1snCWYGJf6cVE0cDR4D8xRzcEnfI21IFrUPzPGtcPf8AC+Rw==",
             "dev": true,
-            "peer": true,
             "dependencies": {
                 "imurmurhash": "^0.1.4",
                 "signal-exit": "^4.0.1"
@@ -6110,7 +6077,6 @@
             "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-20.2.9.tgz",
             "integrity": "sha512-y11nGElTIV+CT3Zv9t7VKl+Q3hTQoT9a1Qzezhhl6Rp21gJ/IVTW7Z3y9EWXhuUBC2Shnf+DX0antecpAwSP8w==",
             "dev": true,
-            "peer": true,
             "engines": {
                 "node": ">=10"
             }

--- a/package.json
+++ b/package.json
@@ -4,6 +4,9 @@
     "description": "The node.js requirements to build this project.",
     "author": "Fredrik Jonsson",
     "license": "GPL-2.0",
+    "prettier": {
+        "trailingComma": "es5"
+    },
     "babel": {
         "exclude": [
             "**/*.min.js",
@@ -35,13 +38,16 @@
         "core-js": "^3.31.1",
         "daterangepicker": "^3.1.0",
         "eslint": "^8.44.0",
+        "eslint-config-prettier": "^8.8.0",
         "eslint-plugin-template": "^0.7.0",
         "htmx.org": "^1.9.2",
         "nodemon": "^3.0.1",
         "npm-run-all2": "^6.0.6",
+        "prettier": "3.0.0",
         "sass": "^1.63.6",
+        "stylelint": "^15.10.2",
+        "stylelint-config-standard": "^34.0.0",
         "stylelint-config-standard-scss": "^10.0.0",
-        "stylelint-scss": "^5.0.1",
         "tailwindcss": "^3.3.2"
     },
     "scripts": {

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -36,7 +36,6 @@ ignore = [
     # 'F821',
     # 'W605',
 ]
-line-length = 88
 select = [
     'C',  # flake8-comprehensions
     'B',  # flake8-bugbear

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,17 +1,19 @@
 -r requirements.txt
 
+black==23.7.0
 coverage==6.4.4
 django-browser-reload==1.6.0
 django-coverage-plugin==2.0.3
 django-debug-toolbar==3.8.1
+djhtml==3.0.6
 dslr==0.4.0
 factory_boy==3.2.1
-ruff==0.0.263
 model-bakery==1.10.1
 pytest-cov==4.0.0
 pytest-django==4.5.2
 pytest-split==0.8.0
 pytest-xdist[psutil]==3.1.0
 responses==0.22.0
+ruff==0.0.263
 wagtail-factories==2.1.0
 Werkzeug==2.2.3

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -9,6 +9,7 @@ djhtml==3.0.6
 dslr==0.4.0
 factory_boy==3.2.1
 model-bakery==1.10.1
+pre-commit==3.3.3
 pytest-cov==4.0.0
 pytest-django==4.5.2
 pytest-split==0.8.0


### PR DESCRIPTION
- Add black, djhtml, prettier
- Add precommit


This PR add configurations for black, djhtml and prettier.

- black is used for formatting python files
- djhtml for formatting html files. Use `{# fmt: off #}` and `{# fmt: on #}` where needed.
- prettier for formatting of sass,css,yml and js files

Note: prettier picks up some of it's config from `.editorconfig`, so it's updated appropriately

Formating of mardown files, minified or vendored js files are ignored.

Formatting used off-the-self rules for better consistency with the community as large.

The formatting is not applied to all the files as it will introduce a lot of merge conflict with
current PRs, instead `pre-commit` config is provide which can be installed by `precommit install` 
locally. It will format only the modified files in the PR/commits. 

Once majority of the current active PRs are either rebased & formatted using precommit or merged, we can
run the `make fmt` on the full repo and activate additional prettier and black checks in our lint rules.

The modified sass files fixes the eslint error that would came up if we were to apply the prettier formatter on them. 

Fixes #3500
