### PR TITLE
Add proposal attachments list(files from submissions) to PAF edit form

### DIFF
--- a/hypha/apply/projects/templates/application_projects/project_approval_form.html
+++ b/hypha/apply/projects/templates/application_projects/project_approval_form.html
@@ -18,7 +18,7 @@
         {% include "forms/includes/form_errors.html" with form=sow_form %}
     {% endif %}
 
-    <div class="wrapper wrapper--light-grey-bg wrapper--form wrapper--sidebar">
+    <div class="wrapper wrapper--light-grey-bg wrapper--sidebar pt-8 pl-20 pb-8 mt-4 mb-12 mx-auto ">
         <div class="wrapper--sidebar--inner">
             <form class="form application-form" action="" method="post" enctype="multipart/form-data">
                 {% csrf_token %}
@@ -70,6 +70,14 @@
                 {% endfor %}
             </form>
         </div>
+        <aside class="sidebar sidebar__project">
+            <div class="js-actions-sidebar sidebar__inner sidebar__inner--actions {% if mobile %}sidebar__inner--mobile{% endif %}">
+                <h5>{% trans "Proposal attachments" %}</h5>
+                {% for file in submissions_attachments %}
+                <p><b><a href="{{ file.url }}" target="_blank">{{ file.filename }}</a></b></p>
+                {% endfor %}
+            </div>
+        </aside>
     </div>
 
 {% else %}

--- a/hypha/apply/projects/views/project.py
+++ b/hypha/apply/projects/views/project.py
@@ -1238,6 +1238,14 @@ class ProjectApprovalFormEditView(BaseStreamForm, UpdateView):
         self.paf_form = self.get_paf_form()
         if self.approval_sow_form:
             self.sow_form = self.get_sow_form()
+
+        submission_attachments = []
+        for field, files in self.object.submission.extract_files().items():
+            if isinstance(files, list):
+                submission_attachments.extend(files)
+            else:
+                submission_attachments.append(files)
+
         return {
             "title": self.object.title,
             "buttons": self.buttons(),
@@ -1246,6 +1254,7 @@ class ProjectApprovalFormEditView(BaseStreamForm, UpdateView):
             "paf_form": self.paf_form,
             "sow_form": self.sow_form,
             "object": self.object,
+            'submissions_attachments': submission_attachments,
             **kwargs
         }
 

--- a/hypha/apply/projects/views/project.py
+++ b/hypha/apply/projects/views/project.py
@@ -1240,7 +1240,7 @@ class ProjectApprovalFormEditView(BaseStreamForm, UpdateView):
             self.sow_form = self.get_sow_form()
 
         submission_attachments = []
-        for field, files in self.object.submission.extract_files().items():
+        for _field, files in self.object.submission.extract_files().items():
             if isinstance(files, list):
                 submission_attachments.extend(files)
             else:


### PR DESCRIPTION
Fixes #3499 

<img width="1279" alt="image" src="https://github.com/HyphaApp/hypha/assets/23638629/31c59105-0508-4cfb-820d-f1ab44eb6a44">


Just showing the file names, couldn't add the date and user because we don't know if those files were uploaded by the applicant at the time of submit or if staff edited the submission and uploaded files later.
