### PR TITLE
Update register flow to redirect back to application form

### DIFF
--- a/hypha/apply/users/models.py
+++ b/hypha/apply/users/models.py
@@ -124,7 +124,7 @@ class UserManager(BaseUserManager.from_queryset(UserQuerySet)):
         return params
 
     def get_or_create_and_notify(self, defaults: dict | None =None, site=None, **kwargs):
-        """Create or get an account for applicant.and send activation email to applicant.
+        """Create or get an account for applicant and send activation email to applicant.
 
         Args:
             defaults: Dict containing user attributes for user creation. Defaults to dict().
@@ -143,6 +143,10 @@ class UserManager(BaseUserManager.from_queryset(UserQuerySet)):
             defaults = {}
 
         email = kwargs.get('email')
+        redirect_url = ''
+        if 'redirect_url' in kwargs:
+            redirect_url = kwargs.pop('redirect_url')
+
         is_registered, _ = is_user_already_registered(email=email)
 
         if is_registered:
@@ -168,7 +172,7 @@ class UserManager(BaseUserManager.from_queryset(UserQuerySet)):
             except IntegrityError:
                 raise
 
-            send_activation_email(user, site)
+            send_activation_email(user, site, redirect_url=redirect_url)
             _created = True
 
         applicant_group = Group.objects.get(name=APPLICANT_GROUP_NAME)

--- a/hypha/apply/users/templates/users/change_password.html
+++ b/hypha/apply/users/templates/users/change_password.html
@@ -15,6 +15,9 @@
 
 <div class="wrapper mt-6 max-w-2xl">
     <form class="form" action="" method="POST" novalidate>
+        {% if redirect_url %}
+            <input type="hidden" value="{{ redirect_url }}" name="next">
+        {% endif %}
         {% if form.non_field_errors %}
             <ul class="errorlist">
                 {% for error in form.non_field_errors %}

--- a/hypha/apply/users/templates/users/login.html
+++ b/hypha/apply/users/templates/users/login.html
@@ -57,9 +57,9 @@
 
                     <div class="inline-flex gap-8 w-full mt-4">
                         {% if ENABLE_REGISTRATION_WITHOUT_APPLICATION %}
-                            <a href="{% url 'users_public:register' %}" hx-boost="true"> {% trans "Create account" %}</a>
+                            <a href="{% url 'users_public:register' %}{% if redirect_url %}?next={{ redirect_url }}{% endif %}" hx-boost="true"> {% trans "Create account" %}</a>
                         {% endif %}
-                        <a class="link" href="{% url 'users:password_reset' %}" hx-boost="true">{% trans "Forgot your password?" %}</a>
+                        <a class="link" href="{% url 'users:password_reset' %}{% if redirect_url %}?next={{ redirect_url }}{% endif %}" hx-boost="true">{% trans "Forgot your password?" %}</a>
                     </div>
                 {% else %}
                     {{ wizard.form }}

--- a/hypha/apply/users/templates/users/password_reset/confirm.html
+++ b/hypha/apply/users/templates/users/password_reset/confirm.html
@@ -13,6 +13,9 @@
 
         <form class="form" method="post" novalidate>
             {% csrf_token %}
+            {% if redirect_url %}
+                <input type="hidden" name="next" value="{{ redirect_url }}" />
+            {% endif %}
 
             {% if form.non_field_errors %}
                 <ul class="errorlist">

--- a/hypha/apply/users/templates/users/password_reset/email.txt
+++ b/hypha/apply/users/templates/users/password_reset/email.txt
@@ -1,8 +1,15 @@
-{% load i18n wagtailadmin_tags %}
+{% load i18n wagtailadmin_tags %}{% base_url_setting as base_url %}
+{% blocktranslate %}Dear {{ user }},{% endblocktranslate %}
+
+{% blocktranslate %}You're receiving this email because you requested a password reset for your user account at {{ org_long_name }}.{% endblocktranslate %}
+
 {% trans "Please follow the link below to reset your password:" %}
 
-{{ protocol }}://{{ domain }}{% url 'users:password_reset_confirm' uidb64=uid token=token %}
+{{ protocol }}://{{ domain }}{% url 'users:password_reset_confirm' uidb64=uid token=token %}{% if redirect_url %}?next={{ redirect_url }}{% endif%}
 
-{% if user.USERNAME_FIELD != "email" %}
-{% trans "Your username (in case you've forgotten):" %} {{ user.get_username }}
-{% endif %}
+{% blocktrans %}Kind Regards,
+The {{ org_short_name }} Team{% endblocktrans %}
+
+--
+{{ org_long_name }}
+{% if site %}{{ site.root_url }}{% else %}{{ base_url }}{% endif %}

--- a/hypha/apply/users/templates/users/password_reset/form.html
+++ b/hypha/apply/users/templates/users/password_reset/form.html
@@ -22,6 +22,9 @@
                 <h2 class="text-2xl">{% trans "Forgot password?" %}</h2>
                 <p class="form__help">{% trans "Please enter your user account's email address and we will send you a password reset link." %}</p>
                 {% csrf_token %}
+                {% if redirect_url %}
+                    <input type="hidden" name="next" value="{{ redirect_url }}">
+                {% endif %}
                 <p>{{ form.email.label_tag }}</p>
                 <p>{{ form.email }}</p>
 
@@ -29,7 +32,7 @@
             </form>
 
             <div class="mt-4">
-                <a href="{% url 'users_public:login' %}" hx-boost="true">
+                <a href="{% url 'users_public:login' %}{% if redirect_url %}?next={{ redirect_url }}{% endif %}" hx-boost="true">
                     {% trans "Log in" %}
                 </a>
             </div>

--- a/hypha/apply/users/templates/users/register.html
+++ b/hypha/apply/users/templates/users/register.html
@@ -10,6 +10,9 @@
         <div class="px-4 pt-4">
             <form class="form" method="post" action="{% url 'users_public:register' %}">
                 {% csrf_token %}
+                {% if redirect_url %}
+                    <input type="hidden" value="{{ redirect_url }}" name="next">
+                {% endif %}
                 <h2 class="text-2xl">Create your account</h2>
 
                 {% if form.non_field_errors %}
@@ -26,7 +29,7 @@
                 </div>
             </form>
             <p>
-                {% trans "Already have an account?" %}<a href="{% url 'users_public:login' %}" hx-boost="true"> {% trans "Log in" %}</a>
+                {% trans "Already have an account?" %}<a href="{% url 'users_public:login' %}{% if redirect_url %}?next={{ redirect_url }}{% endif %}" hx-boost="true"> {% trans "Log in" %}</a>
             </p>
         </div>
     </section>

--- a/hypha/apply/users/urls.py
+++ b/hypha/apply/users/urls.py
@@ -10,6 +10,8 @@ from .views import (
     EmailChangeDoneView,
     EmailChangePasswordView,
     LoginView,
+    PasswordResetConfirmView,
+    PasswordResetView,
     RegisterView,
     RegistrationSuccessView,
     TWOFAAdminDisableView,
@@ -54,18 +56,7 @@ urlpatterns = [
                 )),
                 name='password_change',
             ),
-            path(
-                'reset/',
-                ratelimit(key='post:email', rate=settings.DEFAULT_RATE_LIMIT, method='POST')
-                (ratelimit(key='ip', rate=settings.DEFAULT_RATE_LIMIT, method='POST')
-                    (
-                        auth_views.PasswordResetView.as_view(
-                            template_name='users/password_reset/form.html',
-                            email_template_name='users/password_reset/email.txt',
-                            success_url=reverse_lazy('users:password_reset_done')
-                        ))),
-                name='password_reset'
-            ),
+            path('reset/', PasswordResetView.as_view(), name='password_reset'),
             path(
                 'reset/done/',
                 auth_views.PasswordResetDoneView.as_view(template_name='users/password_reset/done.html'),
@@ -73,12 +64,7 @@ urlpatterns = [
             ),
             path(
                 'reset/confirm/<uidb64>/<token>/',
-                auth_views.PasswordResetConfirmView.as_view(
-                    template_name='users/password_reset/confirm.html',
-                    post_reset_login=True,
-                    post_reset_login_backend=settings.CUSTOM_AUTH_BACKEND,
-                    success_url=reverse_lazy('users:account')
-                ),
+                PasswordResetConfirmView.as_view(),
                 name='password_reset_confirm'
             ),
             path(

--- a/hypha/apply/users/utils.py
+++ b/hypha/apply/users/utils.py
@@ -5,7 +5,7 @@ from django.core.mail import send_mail
 from django.template.loader import render_to_string
 from django.urls import reverse
 from django.utils.encoding import force_bytes
-from django.utils.http import urlsafe_base64_encode
+from django.utils.http import url_has_allowed_host_and_scheme, urlsafe_base64_encode
 from django.utils.translation import gettext_lazy as _
 
 
@@ -53,7 +53,7 @@ def can_use_oauth_check(user):
     return False
 
 
-def send_activation_email(user, site=None):
+def send_activation_email(user, site=None, redirect_url=''):
     """
     Send the activation email. The activation key is the username,
     signed using TimestampSigner.
@@ -64,6 +64,8 @@ def send_activation_email(user, site=None):
     uid = urlsafe_base64_encode(force_bytes(user.pk))
 
     activation_path = reverse('users:activate', kwargs={'uidb64': uid, 'token': token})
+    if redirect_url:
+        activation_path = f'{activation_path}?next={redirect_url}'
 
     timeout_days = settings.PASSWORD_RESET_TIMEOUT // (24 * 3600)
 
@@ -121,3 +123,35 @@ def send_confirmation_email(user, token, updated_email=None, site=None):
         send_mail(subject, message, settings.DEFAULT_FROM_EMAIL, [updated_email])
     else:
         user.email_user(subject, message, settings.DEFAULT_FROM_EMAIL)
+
+
+def get_redirect_url(request, redirect_field: str, success_url_allowed_hosts=None) -> str:
+    """
+    Return the user-originating redirect URL if it's safe.
+
+    Args:
+        request (HttpRequest): The request object.
+        redirect_field (str): The name of a field containing the redirect URL.
+        success_url_allowed_hosts (set): A set of allowed hosts for the redirect URL.
+    """
+    # If no allowed hosts are provided, use settings.ALLOWED_HOSTS
+    if success_url_allowed_hosts is None:
+        success_url_allowed_hosts = set(settings.ALLOWED_HOSTS)
+
+    # Try to get the redirect URL from the request's POST data, and if it's not
+    # there, try to get it from the request's GET data. If it's not in either,
+    # default to an empty string.
+    redirect_to = request.POST.get(
+        redirect_field,
+        request.GET.get(redirect_field, '')
+    )
+
+    # Check if the redirect URL is safe. If it is, return it. Otherwise, return
+    # an empty string.
+    url_is_safe = url_has_allowed_host_and_scheme(
+        url=redirect_to,
+        allowed_hosts={request.get_host(), *success_url_allowed_hosts},
+        require_https=request.is_secure(),
+    )
+    return redirect_to if url_is_safe else ''
+

--- a/hypha/public/utils/templates/utils/includes/login_button.html
+++ b/hypha/public/utils/templates/utils/includes/login_button.html
@@ -1,5 +1,5 @@
 {% load i18n %}
-<a href="{{ APPLY_SITE.root_url }}{% url 'users_public:login' %}" class="button button--transparent button--contains-icons {{ class }}">
+<a href="{{ APPLY_SITE.root_url }}{% url 'users_public:login' %}{% if redirect_url %}?next={{ redirect_url }}{% endif %}" class="button button--transparent button--contains-icons {{ class }}">
     <svg class="icon icon--person"><use xlink:href="#person-icon"></use></svg>
     {% if user.is_authenticated %}
     My {{ ORG_SHORT_NAME }}

--- a/hypha/public/utils/templates/utils/includes/register_button.html
+++ b/hypha/public/utils/templates/utils/includes/register_button.html
@@ -1,4 +1,4 @@
 {% load i18n %}
-<a href="{{ APPLY_SITE.root_url }}{% url 'users_public:register' %}" class="button button--transparent {{ class }}">
+<a href="{{ APPLY_SITE.root_url }}{% url 'users_public:register' %}{% if redirect_url %}?next={{ redirect_url }}{% endif %}" class="button button--transparent {{ class }}">
     {% trans "Register" %}
 </a>


### PR DESCRIPTION
This pull request ensures that users are directed to the form submission page after successfully registering or resetting their password if registration is required before applying to a fund. Additionally, the forgot password email template is updated to be consistent with other email formats.

The flow to set the password after clicking on the activation link remains unchanged.
