### PR TITLE
Add word-break: break-word to revision diff table to make long links etc. fit on small screens

### DIFF
--- a/hypha/static_src/src/sass/apply/components/_revisions.scss
+++ b/hypha/static_src/src/sass/apply/components/_revisions.scss
@@ -1,6 +1,7 @@
 .revision-diff-table {
     td {
         vertical-align: top;
+        word-break: break-word;
     }
 }
 


### PR DESCRIPTION
Fixes #3497
