### PR TITLE
Fix application form js error with invalid textarea

### DIFF
--- a/hypha/static_src/src/javascript/apply/application-form.js
+++ b/hypha/static_src/src/javascript/apply/application-form.js
@@ -33,7 +33,12 @@
         var $error_fields = $application_form.find(".form__error");
         if ($error_fields.length) {
             // set focus to the first error field
-            $error_fields[0].querySelector("input").focus();
+            const firstErrorField = $error_fields[0];
+            const firstInputEl =
+                firstErrorField.querySelector("input, textarea");
+            if (firstInputEl) {
+                firstInputEl.focus();
+            }
 
             $error_fields.each(function (index, error_field) {
                 const inputEl = error_field.querySelector("input, textarea");


### PR DESCRIPTION
If the application form contains a textarea and that field is invalid
the JavaScript responsible to focus on the first element with error and
that causes rest of the application-form.js file to not executing,
causing the submit buttom to remain disabled.
