### PR TITLE
Update status bar to show statuses without hover

### DIFF
--- a/hypha/static_src/src/sass/apply/components/_status-bar.scss
+++ b/hypha/static_src/src/sass/apply/components/_status-bar.scss
@@ -149,6 +149,15 @@
             opacity: 1;
         }
 
+        &::before {
+            .status-bar__item--is-current & {
+                @include triangle(top, $color--error, 5px);
+                position: absolute;
+                bottom: -10px;
+                left: 5px;
+            }
+        }
+
         // tooltip contents
         &::after {
             position: absolute;

--- a/hypha/static_src/src/sass/apply/components/_status-bar.scss
+++ b/hypha/static_src/src/sass/apply/components/_status-bar.scss
@@ -19,7 +19,6 @@
         width: 100%;
         max-width: 800px;
         margin-right: 40px;
-        color: $color--white;
     }
 
     &__subheading {
@@ -139,7 +138,7 @@
         width: 20px;
         height: 20px;
         border-radius: 50%;
-        opacity: 0;
+        opacity: 1;
         transition: opacity $transition;
 
         .status-bar__item:first-of-type & {
@@ -150,23 +149,12 @@
             opacity: 1;
         }
 
-        // triangle
-        &::before {
-            @include triangle(top, $color--error, 5px);
-            position: absolute;
-            bottom: -10px;
-            left: 5px;
-
-            .status-bar__item--is-complete & {
-                @include triangle(top, $color--primary, 5px);
-            }
-        }
-
         // tooltip contents
         &::after {
             position: absolute;
             top: 30px;
             left: -25px;
+            text-align: center;
             display: block;
             padding: 5px 10px;
             font-size: 12px;
@@ -196,13 +184,20 @@
                 }
             }
 
-            .status-bar__item--is-complete & {
-                background-color: $color--primary;
+            .status-bar__item & {
+                background-color: inherit;
+                color: $color--mid-grey;
             }
-        }
 
-        &:hover {
-            opacity: 1;
+            .status-bar__item--is-complete & {
+                background-color: inherit;
+                color: $color--primary;
+            }
+
+            .status-bar__item--is-current & {
+                background-color: $color--tomato;
+                color: $color--white;
+            }
         }
     }
 }


### PR DESCRIPTION
Status Bar with latest designs.

Current status bar(old):
<img width="877" alt="image" src="https://github.com/HyphaApp/hypha/assets/23638629/c4b97b53-f0ea-488b-ac47-74387a589dba">

Updated status bar(latest):
<img width="862" alt="image" src="https://github.com/HyphaApp/hypha/assets/23638629/4386a212-e008-45f4-9da1-add973241691">


The above status bars are from different submissions so don't get confused with their status steps. The only change is that the statuses are visible in the latest one while in the old one user has to hover over every dot to know its status.
