### PR TITLE
Increase font-weights of page heading

### DIFF
--- a/hypha/apply/determinations/templates/determinations/batch_determination_form.html
+++ b/hypha/apply/determinations/templates/determinations/batch_determination_form.html
@@ -7,11 +7,9 @@
 {% endblock %}
 
 {% block header %}
-    <div class="admin-bar">
-        <div class="admin-bar__inner">
-            <h2 class="heading heading--no-margin">{% trans "Add Batch Determination" %} - {{ action_name }}</h2>
-        </div>
-    </div>
+    {% adminbar %}
+        {% slot header %}{% trans "Add Batch Determination" %} - {{ action_name }}{% endslot %}
+    {% endadminbar %}
 {% endblock %}
 
 {% block determination_information %}

--- a/hypha/apply/funds/templates/funds/applicationsubmission_confirm_delete.html
+++ b/hypha/apply/funds/templates/funds/applicationsubmission_confirm_delete.html
@@ -4,11 +4,10 @@
 {% block title %}{% trans "Deleting" %}: {{object.title }}{% endblock %}
 
 {% block content %}
-    <div class="admin-bar">
-        <div class="admin-bar__inner">
-            <h2 class="heading heading--no-margin">{% trans "Deleting" %}: {{ object.title }}</h2>
-        </div>
-    </div>
+
+    {% adminbar %}
+        {% slot header %}{% trans "Deleting" %}: {{ object.title }}{% endslot %}
+    {% endadminbar %}
 
     <div class="wrapper wrapper--light-grey-bg wrapper--form wrapper--sidebar">
         <div class="wrapper--sidebar--inner">

--- a/hypha/apply/funds/templates/funds/applicationsubmission_detail.html
+++ b/hypha/apply/funds/templates/funds/applicationsubmission_detail.html
@@ -22,8 +22,8 @@
                     {% trans "Back to submissions" %}
                 </a>
             {% endif %}
-            <h1 class="mb-0 mt-2 font-normal">{{ object.title }}</h1>
-            <div class="heading heading--meta text-sm mt-1">
+            <h1 class="mb-0 mt-2 font-medium">{{ object.title }}</h1>
+            <div class="heading heading--meta text-sm mt-1 font-medium">
                 <span>{{ object.stage }}</span>
                 <span>{{ object.page }}</span>
                 {% if request.user.is_apply_staff and object.round %}

--- a/hypha/apply/funds/templates/funds/submission_sealed.html
+++ b/hypha/apply/funds/templates/funds/submission_sealed.html
@@ -6,7 +6,7 @@
 {% block content %}
     <div class="admin-bar">
         <div class="admin-bar__inner">
-            <h1 class="beta heading heading--no-margin heading--bold">{{ object.title }}</h1>
+            <h1 class="text-2xl mb-2 font-medium md:text-3xl md:m-0">{{ object.title }}</h1>
             <h5 class="heading heading--meta">
                 <span>{{ object.stage }}</span>
                 <span>{{ object.page }}</span>

--- a/hypha/apply/projects/templates/application_projects/invoice_confirm_delete.html
+++ b/hypha/apply/projects/templates/application_projects/invoice_confirm_delete.html
@@ -4,15 +4,16 @@
 {% block title %} {% trans "Invoice" %}: {{ object.project.title }}{% endblock %}
 {% block content %}
     {% display_invoice_status_for_user user object as invoice_status %}
-    <div class="admin-bar">
-        <div class="admin-bar__inner">
+
+    {% adminbar %}
+        {% slot back_link %}
             <a class="simplified__projects-link" href="{{ object.project.get_absolute_url }}">
                 {% trans "View project page" %}
             </a>
-            <h2 class="heading heading--no-margin">{% trans "Delete Invoice" %}</h2>
-            <h5 class="heading heading--no-margin">{% trans "For" %}: {{ object.project.title }}</h5>
-        </div>
-    </div>
+        {% endslot %}
+        {% slot header %}{% trans "Delete Invoice" %}{% endslot %}
+        {% slot sub_heading %}{% trans "For" %}: {{ object.project.title }}{% endslot %}
+    {% endadminbar %}
 
     <div class="wrapper wrapper--sidebar wrapper--outer-space-medium">
         <div class="wrapper--sidebar--inner">

--- a/hypha/apply/projects/templates/application_projects/invoice_detail.html
+++ b/hypha/apply/projects/templates/application_projects/invoice_detail.html
@@ -4,15 +4,16 @@
 {% block title %}{% trans "Invoice" %}: {{ object.project.title }}{% endblock %}
 {% block content %}
     {% display_invoice_status_for_user user object as invoice_status %}
-    <div class="admin-bar">
-        <div class="admin-bar__inner">
+
+    {% adminbar %}
+        {% slot back_link %}
             <a class="simplified__projects-link" href="{{ object.project.get_absolute_url }}">
                 {% trans "View project page" %}
             </a>
-            <h2 class="heading heading--no-margin">{% trans "Invoice" %}</h2>
-            <h5 class="heading heading--no-margin">{% trans "For" %}: {{ object.project.title }}</h5>
-        </div>
-    </div>
+        {% endslot %}
+        {% slot header %}{% trans "Invoice" %}{% endslot %}
+        {% slot sub_heading %}{% trans "For" %}: {{ object.project.title }}{% endslot %}
+    {% endadminbar %}
 
     <div class="wrapper wrapper--sidebar wrapper--outer-space-medium">
         <div class="wrapper--sidebar--inner">

--- a/hypha/apply/projects/templates/application_projects/invoice_form.html
+++ b/hypha/apply/projects/templates/application_projects/invoice_form.html
@@ -3,15 +3,29 @@
 
 {% block title %}{% if object %}{% trans "Edit" %}{% else %}{% trans "Add" %}{% endif %} {% trans "Invoice" %}: {% if object %}{{ object.project.title }}{% else %}{{ project.title }}{% endif %}{% endblock %}
 {% block content %}
-    <div class="admin-bar">
-        <div class="admin-bar__inner">
+
+    {% adminbar %}
+        {% slot back_link %}
             <a class="simplified__projects-link" href="{{ project.get_absolute_url }}">
                 {% trans "View project page" %}
             </a>
-            <h2 class="heading heading--no-margin">{% if object %}{% trans "Editing" %}{% else %}{% trans "Add" %}{% endif %} {% trans "Invoice" %}</h2>
-            <h5 class="heading heading--no-margin">{% if object %}{{ object.project.title }}{% else %}{% trans "For" %}: {{ project.title }}{% endif %}</h5>
-        </div>
-    </div>
+        {% endslot %}
+        {% slot header %}
+            {% if object %}
+                {% trans "Editing" %}
+            {% else %}
+                {% trans "Add" %}
+            {% endif %}
+            {% trans "Invoice" %}
+        {% endslot %}
+        {% slot sub_heading %}
+            {% if object %}
+                {{ object.project.title }}
+            {% else %}
+                {% trans "For" %}: {{ project.title }}
+            {% endif %}
+        {% endslot %}
+    {% endadminbar %}
 
     {% include "forms/includes/form_errors.html" with form=form %}
 

--- a/hypha/apply/projects/templates/application_projects/project_approval_form.html
+++ b/hypha/apply/projects/templates/application_projects/project_approval_form.html
@@ -2,14 +2,15 @@
 {% load i18n static %}
 {% block title %}{% trans "Editing" %}: {{object.title }}{% endblock %}
 {% block content %}
-    <div class="admin-bar">
-        <div class="admin-bar__inner">
+
+    {% adminbar %}
+        {% slot back_link %}
             <a class="simplified__projects-link" href="{{ object.get_absolute_url }}">
                 {% trans "View project page" %}
             </a>
-            <h2 class="heading heading--no-margin">{% trans "Editing" %}: {{ object.title }}</h2>
-        </div>
-    </div>
+        {% endslot %}
+        {% slot header %}{% trans "Editing" %}: {{ object.title }}{% endslot %}
+    {% endadminbar %}
 
     {% if approval_form_exists %}
 

--- a/hypha/apply/projects/templates/application_projects/project_detail.html
+++ b/hypha/apply/projects/templates/application_projects/project_detail.html
@@ -16,8 +16,8 @@
     {% endif %}
     <div class="admin-bar">
         <div class="admin-bar__inner">
-            <h1 class="mb-0">{{ object.title }}</h1>
-            <div class="heading heading--meta text-sm mt-1">
+            <h1 class="mb-0 font-medium">{{ object.title }}</h1>
+            <div class="heading heading--meta text-sm mt-1 font-medium">
 
                 <span>{{ object.submission.page }}</span>
 

--- a/hypha/apply/projects/templates/application_projects/project_form.html
+++ b/hypha/apply/projects/templates/application_projects/project_form.html
@@ -5,11 +5,10 @@
 {% block title %}{% trans "Editing" %}: {{ object.title }}{% endblock %}
 
 {% block content %}
-    <div class="admin-bar">
-        <div class="admin-bar__inner">
-            <h2 class="heading heading--no-margin">{% trans "Editing" %}: {{ object.title}}</h2>
-        </div>
-    </div>
+
+    {% adminbar %}
+        {% slot header %}{% trans "Editing" %}: {{ object.title}}{% endslot %}
+    {% endadminbar %}
 
     {% include "forms/includes/form_errors.html" with form=form %}
 

--- a/hypha/apply/projects/templates/application_projects/report_detail.html
+++ b/hypha/apply/projects/templates/application_projects/report_detail.html
@@ -4,15 +4,16 @@
 {% block title %}{% trans "Report" %} | {{ object.project.title }}{% endblock %}
 {% block body_class %}{% endblock %}
 {% block content %}
-    <div class="admin-bar">
-        <div class="admin-bar__inner">
+
+    {% adminbar %}
+        {% slot back_link %}
             <a class="admin-bar__back-link" href="{{ object.project.get_absolute_url }}">
                 {% trans "View project page" %}
             </a>
-            <h2 class="heading heading--no-margin">{{ object.project.title }}</h2>
-            <h5 class="heading heading--no-margin">{% trans "View report" %}</h5>
-        </div>
-    </div>
+        {% endslot %}
+        {% slot header %}{{ object.project.title }}{% endslot %}
+        {% slot sub_heading %}{% trans "View report" %}{% endslot %}
+    {% endadminbar %}
 
     <div class="wrapper wrapper--sidebar wrapper--outer-space-medium">
         <div class="wrapper--sidebar--inner">

--- a/hypha/apply/projects/templates/application_projects/report_form.html
+++ b/hypha/apply/projects/templates/application_projects/report_form.html
@@ -8,15 +8,16 @@
 
 {% block title %}{% trans "Edit Report" %} | {{ object.project.title }}{% endblock %}
 {% block content %}
-    <div class="admin-bar">
-        <div class="admin-bar__inner">
+
+    {% adminbar %}
+        {% slot back_link %}
             <a class="admin-bar__back-link" href="{{ object.project.get_absolute_url }}">
                 {% trans "View project page" %}
             </a>
-            <h2 class="heading heading--no-margin">{{ object.project.title }}</h2>
-            <h5 class="heading heading--no-margin">{% trans "Submit a report" %}</h5>
-        </div>
-    </div>
+        {% endslot %}
+        {% slot header %}{{ object.project.title }}{% endslot %}
+        {% slot sub_heading %}{% trans "Submit a report" %}{% endslot %}
+    {% endadminbar %}
 
     {% include "forms/includes/form_errors.html" with form=form %}
 

--- a/hypha/apply/projects/templates/application_projects/vendor_detail.html
+++ b/hypha/apply/projects/templates/application_projects/vendor_detail.html
@@ -4,14 +4,15 @@
 {% block title %}{% trans "Contracting Information for" %} {{ project.title }} {% endblock %}
 
 {% block content %}
-    <div class="admin-bar">
-        <div class="admin-bar__inner">
+
+    {% adminbar %}
+        {% slot back_link %}
             <a class="simplified__projects-link" href="{{ project.get_absolute_url }}">
                 {% trans "View project page" %}
             </a>
-            <h2 class="heading heading--no-margin">{% trans "Contracting Information for" %} {{ project.title }}</h2>
-        </div>
-    </div>
+        {% endslot %}
+        {% slot header %}{% trans "Contracting Information for" %} {{ project.title }}{% endslot %}
+    {% endadminbar %}
 
     <div class="grid">
         <div>

--- a/hypha/apply/projects/templates/application_projects/vendor_form.html
+++ b/hypha/apply/projects/templates/application_projects/vendor_form.html
@@ -3,11 +3,10 @@
 
 {% block title %}{% trans "Update Contracting Information" %}{% endblock %}
 {% block content %}
-    <div class="admin-bar">
-        <div class="admin-bar__inner">
-            <h2 class="heading heading--no-margin">{% trans "Update Contracting Information" %}</h2>
-        </div>
-    </div>
+
+    {% adminbar %}
+        {% slot header %}{% trans "Update Contracting Information" %}{% endslot %}
+    {% endadminbar %}
 
     {% include "forms/includes/form_errors.html" with form=form %}
 

--- a/hypha/apply/projects/templates/application_projects/vendor_success.html
+++ b/hypha/apply/projects/templates/application_projects/vendor_success.html
@@ -3,11 +3,11 @@
 
 {% block title %}{% trans "Contractor Setup Completed" %}{% endblock %}
 {% block content %}
-    <div class="admin-bar">
-        <div class="admin-bar__inner">
-            <h2 class="heading heading--no-margin">{% trans "Contractor Setup Completed" %}</h2>
-        </div>
-    </div>
+
+    {% adminbar %}
+        {% slot header %}{% trans "Contractor Setup Completed" %}{% endslot %}
+    {% endadminbar %}
+
     <div class="wrapper wrapper--small">
         <h3>{% trans "Thank you for submitting your information." %}</h3>
         <p>{% trans "Your {{ ORG_SHORT_NAME }} Programme Manager will be in touch with you if there are any issues." %}</p>

--- a/hypha/apply/review/templates/review/review_confirm_delete.html
+++ b/hypha/apply/review/templates/review/review_confirm_delete.html
@@ -4,11 +4,10 @@
 {% block title %}{% trans "Deleting" %}: {{ object }}{% endblock %}
 
 {% block content %}
-    <div class="admin-bar">
-        <div class="admin-bar__inner">
-            <h2 class="heading heading--no-margin">{% trans "Deleting" %}: {{ object }}</h2>
-        </div>
-    </div>
+
+    {% adminbar %}
+        {% slot header %}{% trans "Deleting" %}: {{ object }}{% endslot %}
+    {% endadminbar %}
 
     <div class="wrapper wrapper--light-grey-bg wrapper--form wrapper--sidebar">
         <div class="wrapper--sidebar--inner">

--- a/hypha/apply/review/templates/review/review_detail.html
+++ b/hypha/apply/review/templates/review/review_detail.html
@@ -2,17 +2,20 @@
 {% load i18n bleach_tags submission_tags %}
 {% block title %}{% trans "Review for" %} {{ review.submission.title }}{% endblock %}
 {% block content %}
-    <div class="admin-bar">
-        <div class="admin-bar__inner">
-            <a class="simplified__submissions-link" href="{{ review.submission.get_absolute_url }}">
-                {% trans "Back to submission" %}
-            </a>
-            <h1 class="beta heading heading--no-margin heading--bold">{% trans "Review" %}</h1>
-            <h5>{% trans "For" %}: {{ review.submission.title }} {% trans "by" %} {{ review.author }} {% trans "at" %} {{ review.created_at|date:"SHORT_DATE_FORMAT" }} {% if review.is_updated %}<small>({% trans "Last updated" %}: {{ review.updated_at|date:"SHORT_DATE_FORMAT" }})</small>{% endif %}</h5>
 
-            {% include 'review/includes/review_opinions_list.html' with opinions=review.opinions.all %}
-        </div>
-    </div>
+    {% adminbar %}
+        {% slot back_link %}
+            <a class="simplified__submissions-link" href="{{ review.submission.get_absolute_url }}">
+                {% trans "View submission" %}
+            </a>
+        {% endslot %}
+        {% slot header %}{% trans "Review" %}{% endslot %}
+        {% slot sub_heading %}
+            {% trans "For" %}: {{ review.submission.title }} {% trans "by" %} {{ review.author }} {% trans "at" %} {{ review.created_at|date:"SHORT_DATE_FORMAT" }} {% if review.is_updated %}<small>({% trans "Last updated" %}: {{ review.updated_at|date:"SHORT_DATE_FORMAT" }})</small>{% endif %}
+        {% endslot %}
+
+        {% include 'review/includes/review_opinions_list.html' with opinions=review.opinions.all %}
+    {% endadminbar %}
 
     <div style="display: flex; gap: 2rem; padding-top: 2rem;">
         <div>

--- a/hypha/apply/review/templates/review/review_edit_form.html
+++ b/hypha/apply/review/templates/review/review_edit_form.html
@@ -2,12 +2,13 @@
 {% load i18n %}
 {% block title %}{{ title }}{% endblock %}
 {% block content %}
-    <div class="admin-bar">
-        <div class="admin-bar__inner">
-            <h1 class="beta heading heading--no-margin heading--bold">{{ title }}</h1>
-            <h5>{% trans "For" %} <a href="{% url "funds:submissions:detail" submission.id %}">{{ submission.title }}</a></h5>
-        </div>
-    </div>
+
+    {% adminbar %}
+        {% slot header %}{{ title }}{% endslot %}
+        {% slot sub_heading %}
+            {% trans "For" %} <a class="text-blue-300 hover:underline" href="{% url "funds:submissions:detail" submission.id %}">{{ submission.title }}</a>
+        {% endslot %}
+    {% endadminbar %}
 
     {% include "forms/includes/form_errors.html" with form=form %}
 

--- a/hypha/apply/review/templates/review/review_form.html
+++ b/hypha/apply/review/templates/review/review_form.html
@@ -2,12 +2,13 @@
 {% load i18n %}
 {% block title %}{{ title }}{% endblock %}
 {% block content %}
-    <div class="admin-bar">
-        <div class="admin-bar__inner">
-            <h1 class="beta heading heading--no-margin heading--bold">{{ title }}</h1>
-            <h5>{% trans "For" %} <a href="{% url "funds:submissions:detail" submission.id %}">{{ submission.title }}</a></h5>
-        </div>
-    </div>
+
+    {% adminbar %}
+        {% slot header %}{{ title }}{% endslot %}
+        {% slot sub_heading %}
+            {% trans "For" %} <a href="{% url "funds:submissions:detail" submission.id %}">{{ submission.title }}</a>
+        {% endslot %}
+    {% endadminbar %}
 
     {% include "forms/includes/form_errors.html" with form=form %}
 

--- a/hypha/apply/review/templates/review/reviewopinion_confirm_delete.html
+++ b/hypha/apply/review/templates/review/reviewopinion_confirm_delete.html
@@ -4,11 +4,10 @@
 {% block title %}{% trans "Deleting" %}: {{ object }}{% endblock %}
 
 {% block content %}
-    <div class="admin-bar">
-        <div class="admin-bar__inner">
-            <h2 class="heading heading--no-margin">{% trans "Deleting" %}: {{ object }}</h2>
-        </div>
-    </div>
+
+    {% adminbar %}
+        {% slot header %}{% trans "Deleting" %}: {{ object }}{% endslot %}
+    {% endadminbar %}
 
     <div class="wrapper wrapper--light-grey-bg wrapper--form wrapper--sidebar">
         <div class="wrapper--sidebar--inner">

--- a/hypha/core/templates/components/admin_bar.html
+++ b/hypha/core/templates/components/admin_bar.html
@@ -4,7 +4,7 @@
     <div class="admin-bar__inner items-center md:flex md:justify-between">
         <div>
             {% render_slot slots.back_link %}
-            <h1 class="text-2xl mb-0 md:text-3xl md:m-0">{% render_slot slots.header %}</h1>
+            <h1 class="text-2xl mb-2 font-medium md:text-3xl md:m-0">{% render_slot slots.header %}</h1>
             {% if slots.sub_heading %}<p class="text-sm hidden md:block m-0">{% render_slot slots.sub_heading %}</p>{% endif %}
         </div>
 


### PR DESCRIPTION
Fixes #3588

Increase the font-weight on the heading in the admin bar. The application details and project detail doesn't use the admin bar so updated the font weight on it separately. 

The are other pages that doesn't still use admin-bar web component. They'll get the same treatment once admin-bar component is used in them. I'll try to convert more pages to use the admin-bar in this PR. 

- [x] Review edit page
- [x] Review detail page
- [x] Add Review page

![Screenshot 2023-10-03 at 07 12 32@2x](https://github.com/HyphaApp/hypha/assets/236356/874639d8-de75-46a8-8a6c-cea38962a34f)

![Screenshot 2023-10-03 at 07 14 43@2x](https://github.com/HyphaApp/hypha/assets/236356/27bd3297-66b1-4496-998b-dd61cc8fde35)



Related #3587 