### PR TITLE
Pin python-docx version to temporarily fix upstream issues

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -41,6 +41,7 @@ drf-yasg==1.21.4
 environs==9.5.0
 gunicorn==20.1.0
 heroicons==2.2.0
+python-docx<1.0.0
 htmldocx==0.0.6
 lark==1.1.5
 mailchimp3==3.0.17


### PR DESCRIPTION
With the latest updates to python-docx, older APIs that are relied upon by htmldocx have broken. This pins the version so htmldocx can utilize the old APIs. For more info on this breakage see [here](https://github.com/python-openxml/python-docx/issues/1256#issuecomment-1756839793).
