### PR TITLE
Fix wagtail user view pagination

### DIFF
--- a/hypha/apply/users/templates/wagtailusers/users/results.html
+++ b/hypha/apply/users/templates/wagtailusers/users/results.html
@@ -17,7 +17,7 @@
             {% include "wagtailusers/users/list.html" %}
 
             {# call pagination_nav with no linkurl, to generate general-purpose links like <a href="?p=2"> #}
-            {% include "wagtailadmin/shared/pagination_nav.html" with items=page_obj %}
+            {% include "wagtailadmin/shared/pagination_nav.html" with items=users %}
         {% else %}
             {% if is_searching %}
                 <h2 role="alert">{% blocktrans trimmed %}Sorry, no users match "<em>{{ query_string }}</em>"{% endblocktrans %}</h2>


### PR DESCRIPTION
Closes #3607.

A quick one, just needed to have the variable changed from `page_obj` to `users`, which is created and included in the context [here](https://github.com/HyphaApp/hypha/blob/main/hypha/apply/users/admin_views.py#L167). See screenshots below for a working example. Items per page was changed from 20 to 5 to allow for demonstration. All other functionality works as expected (ie. changing pages)

<img width="1399" alt="Screenshot" src="https://github.com/HyphaApp/hypha/assets/145372368/ac1f566b-2983-4123-990f-a15d0b0d9085">
