### PR TITLE
Fix invoice status visibility and payment failed public message

### DIFF
--- a/hypha/apply/activity/adapters/activity_feed.py
+++ b/hypha/apply/activity/adapters/activity_feed.py
@@ -101,7 +101,6 @@ class ActivityAdapter(AdapterBase):
             MESSAGES.APPROVE_CONTRACT,
             MESSAGES.UPLOAD_CONTRACT,
             MESSAGES.SUBMIT_CONTRACT_DOCUMENTS,
-            MESSAGES.UPDATE_INVOICE_STATUS,
             MESSAGES.DELETE_INVOICE,
             MESSAGES.CREATE_INVOICE,
         ]:
@@ -118,6 +117,7 @@ class ActivityAdapter(AdapterBase):
             invoice = kwargs.get("invoice", None)
             if invoice and not is_invoice_public_transition(invoice):
                 return {"visibility": TEAM}
+            return {"visibility": APPLICANT}
         return {}
 
     def reviewers_updated(self, added=None, removed=None, **kwargs):

--- a/hypha/apply/activity/adapters/utils.py
+++ b/hypha/apply/activity/adapters/utils.py
@@ -12,6 +12,7 @@ from hypha.apply.projects.models.payment import (
     CHANGES_REQUESTED_BY_STAFF,
     DECLINED,
     PAID,
+    PAYMENT_FAILED,
     RESUBMITTED,
     SUBMITTED,
 )
@@ -62,6 +63,7 @@ def is_invoice_public_transition(invoice):
         APPROVED_BY_FINANCE_2,
         DECLINED,
         PAID,
+        PAYMENT_FAILED,
     ]:
         return True
     if not settings.INVOICE_EXTENDED_WORKFLOW and invoice.status == APPROVED_BY_FINANCE:

--- a/hypha/apply/projects/utils.py
+++ b/hypha/apply/projects/utils.py
@@ -11,6 +11,7 @@ from .models.payment import (
     CHANGES_REQUESTED_BY_STAFF,
     DECLINED,
     PAID,
+    PAYMENT_FAILED,
     RESUBMITTED,
     SUBMITTED,
 )
@@ -136,6 +137,8 @@ def get_invoice_public_status(invoice_status):
         return _("Declined")
     if invoice_status == PAID:
         return _("Paid")
+    if invoice_status == PAYMENT_FAILED:
+        return _("Payment failed")
 
 
 def get_project_status_display_value(project_status):


### PR DESCRIPTION
Issue:
'Approved by staff' and 'Changes requested by finance' are internal statuses, and shouldn't be visible to the applicant.
![image](https://github.com/HyphaApp/hypha/assets/23638629/62396999-a176-4579-bea0-649bde2af154).

How it should be(fixed in this PR):
Staff view- 
![image](https://github.com/HyphaApp/hypha/assets/23638629/7dcd6d9e-f905-42f8-9770-4f62abd83ed9)

Applicant view-
![image](https://github.com/HyphaApp/hypha/assets/23638629/fc6eb21b-7d58-4d8c-b55b-8954795a7ddc)



