### PR TITLE
Update activity feed for paf assignment action 

### DIFF
--- a/hypha/apply/activity/adapters/activity_feed.py
+++ b/hypha/apply/activity/adapters/activity_feed.py
@@ -50,7 +50,7 @@ class ActivityAdapter(AdapterBase):
             "Lead changed from {old_lead} to {source.lead}"
         ),
         MESSAGES.SEND_FOR_APPROVAL: _("Requested approval"),
-        MESSAGES.APPROVE_PAF: _("PAF assigned to {user}"),
+        MESSAGES.APPROVE_PAF: "handle_paf_assignment",
         MESSAGES.APPROVE_PROJECT: _("Approved"),
         MESSAGES.REQUEST_PROJECT_CHANGE: _(
             'Requested changes for acceptance: "{comment}"'
@@ -163,6 +163,19 @@ class ActivityAdapter(AdapterBase):
         return _("Successfully archived submissions: {title}").format(
             title=submissions_text
         )
+
+    def handle_paf_assignment(self, source, paf_approvals, **kwargs):
+        users = ", ".join(
+            [
+                paf_approval.user.full_name
+                if paf_approval.user.full_name
+                else paf_approval.user.username
+                for paf_approval in paf_approvals
+            ]
+        )  # paf_approvals has to be a list
+        users_sentence = " and".join(users.rsplit(",", 1))
+
+        return _("PAF assigned to {}").format(users_sentence)
 
     def handle_transition(self, old_phase, source, **kwargs):
         submission = source

--- a/hypha/apply/activity/adapters/activity_feed.py
+++ b/hypha/apply/activity/adapters/activity_feed.py
@@ -165,17 +165,18 @@ class ActivityAdapter(AdapterBase):
         )
 
     def handle_paf_assignment(self, source, paf_approvals, **kwargs):
-        users = ", ".join(
-            [
-                paf_approval.user.full_name
-                if paf_approval.user.full_name
-                else paf_approval.user.username
-                for paf_approval in paf_approvals
-            ]
-        )  # paf_approvals has to be a list
-        users_sentence = " and".join(users.rsplit(",", 1))
-
-        return _("PAF assigned to {}").format(users_sentence)
+        if hasattr(paf_approvals, "__iter__"):  # paf_approvals has to be iterable
+            users = ", ".join(
+                [
+                    paf_approval.user.full_name
+                    if paf_approval.user.full_name
+                    else paf_approval.user.username
+                    for paf_approval in paf_approvals
+                ]
+            )
+            users_sentence = " and".join(users.rsplit(",", 1))
+            return _("PAF assigned to {}").format(users_sentence)
+        return None
 
     def handle_transition(self, old_phase, source, **kwargs):
         submission = source

--- a/hypha/apply/activity/adapters/base.py
+++ b/hypha/apply/activity/adapters/base.py
@@ -20,6 +20,7 @@ neat_related = {
     MESSAGES.EDIT_REVIEW: "review",
     MESSAGES.CREATED_PROJECT: "submission",
     MESSAGES.PROJECT_TRANSITION: "old_stage",
+    MESSAGES.APPROVE_PAF: "paf_approvals",  # expect a list
     MESSAGES.UPDATE_PROJECT_LEAD: "old_lead",
     MESSAGES.APPROVE_CONTRACT: "contract",
     MESSAGES.UPLOAD_CONTRACT: "contract",

--- a/hypha/apply/activity/adapters/emails.py
+++ b/hypha/apply/activity/adapters/emails.py
@@ -57,7 +57,6 @@ class EmailAdapter(AdapterBase):
         MESSAGES.CREATED_PROJECT: "handle_project_created",
         MESSAGES.UPDATED_VENDOR: "handle_vendor_updated",
         MESSAGES.SENT_TO_COMPLIANCE: "messages/email/sent_to_compliance.html",
-        MESSAGES.SEND_FOR_APPROVAL: "messages/email/paf_for_approval.html",
         MESSAGES.REQUEST_PROJECT_CHANGE: "messages/email/project_request_change.html",
         MESSAGES.ASSIGN_PAF_APPROVER: "messages/email/assign_paf_approvers.html",
         MESSAGES.APPROVE_PAF: "messages/email/paf_for_approval.html",
@@ -90,7 +89,6 @@ class EmailAdapter(AdapterBase):
             elif message_type in [
                 MESSAGES.SENT_TO_COMPLIANCE,
                 MESSAGES.APPROVE_PAF,
-                MESSAGES.SEND_FOR_APPROVAL,
             ]:
                 subject = _("Project is waiting for approval: {source.title}").format(
                     source=source
@@ -293,7 +291,7 @@ class EmailAdapter(AdapterBase):
             partners = kwargs["added"]
             return [partner.email for partner in partners]
 
-        if message_type in [MESSAGES.SEND_FOR_APPROVAL, MESSAGES.APPROVE_PAF]:
+        if message_type == MESSAGES.APPROVE_PAF:
             from hypha.apply.projects.models.project import ProjectSettings
 
             # notify the assigned approvers


### PR DESCRIPTION
It shows the assigner's name in both places.
![image](https://github.com/HyphaApp/hypha/assets/23638629/2560dfe0-f165-4e5f-9ae2-e061ef97f0f9)

Now, the activity contains the assignee name, and the assigner name is shown as the activity author.
![image](https://github.com/HyphaApp/hypha/assets/23638629/123c29b9-7ce6-4471-acde-5246607b9356)
