### PR TITLE
Fix draft determination disabled proposal form issue

### DIFF
--- a/hypha/static_src/src/javascript/apply/determination-template.js
+++ b/hypha/static_src/src/javascript/apply/determination-template.js
@@ -68,6 +68,9 @@
         new DeterminationCopy(el);
     });
     window.addEventListener("load", function (event) {
-        document.querySelector("#id_proposal_form").disabled = true;
+        const proposal_form_field = document.querySelector("#id_proposal_form");
+        if (!proposal_form_field.value) {
+            proposal_form_field.disabled = true;
+        }
     });
 })();


### PR DESCRIPTION
Fixes #3621 

**Problem**: 
Proposal form field on the determination form is disabled by default 'on load' but there is a case when a user has selected the form and saved the determination as draft and when the user comes back to submit that saved determination, the proposal form field will be disabled and on submission, there will be no proposal form attached(pick default one).

**Solution**:
Add a check if the proposal form field has some value on load then don't disable it otherwise disable it.
 **Why it is disabled at all**: We don't want to confuse the user by keeping it enabled on the top(We can keep it on top or bottom as we are appending this field to the streamfield form, and as it is related to determination field so top is favorable).