### PR TITLE
Fix rendering of stream form fields

### DIFF
--- a/hypha/apply/categories/blocks.py
+++ b/hypha/apply/categories/blocks.py
@@ -92,7 +92,7 @@ class CategoryQuestionBlock(OptionalFormFieldBlock):
         for field in category_fields.keys():
             if not value.get(field):
                 category = value["category"]
-                if isinstance(category, int):
+                if isinstance(category, int) or isinstance(category, str):
                     category = self.get_instance(id=category)
                 value[field] = getattr(category, category_fields[field])
         return super().render(value, context)


### PR DESCRIPTION
How to reproduce:
- open a application submisssion with checkboxes as an form element.
- Get the error below

```
'str' object has no attribute 'help_text'
```

![Screenshot 2023-10-20 at 9  43 45@2x](https://github.com/HyphaApp/hypha/assets/236356/139fdd68-492f-48bc-9631-fa05d925db3f)

