### PR TITLE
Upgrade development dependencies to latest

### DIFF
--- a/.github/workflows/hypha-ci.yml
+++ b/.github/workflows/hypha-ci.yml
@@ -73,7 +73,7 @@ jobs:
       - name: Install python dependencies
         run: pip install `grep -E "ruff|djhtml|black" requirements-dev.txt`
       - name: Run ruff
-        run: ruff --format github .
+        run: ruff check --output-format=github .
       - name: Run black
         run: black . --check
       - name: Run djhtml

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,11 +1,11 @@
 repos:
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.0.280
+    rev: v0.1.1
     hooks:
       - id: ruff
         args: [--fix, --exit-non-zero-on-fix]
   - repo: https://github.com/psf/black
-    rev: 23.7.0
+    rev: 23.10.0
     hooks:
       - id: black
         # It is recommended to specify the latest version of Python
@@ -19,6 +19,6 @@ repos:
       - id: djhtml
         files: .*/templates/.*\.html$
   - repo: https://github.com/pre-commit/mirrors-prettier
-    rev: v3.0.0 # Use the sha or tag you want to point at
+    rev: v3.0.3 # Use the sha or tag you want to point at
     hooks:
       - id: prettier

--- a/Makefile
+++ b/Makefile
@@ -51,7 +51,7 @@ endif
 .PHONY: lint
 lint:
 	@echo "Checking python code style with ruff"
-	ruff .
+	ruff check .
 	black . --check
 	@echo "Checking html file indendation."
 	djhtml hypha/ --check

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,20 +1,20 @@
 -r requirements.txt
 
-black==23.7.0
-coverage==6.4.4
-django-browser-reload==1.6.0
-django-coverage-plugin==2.0.3
-django-debug-toolbar==3.8.1
+black==23.10.0
+coverage==7.3.2
+django-browser-reload==1.12.0
+django-coverage-plugin==3.1.0
+django-debug-toolbar==4.2.0
 djhtml==3.0.6
 dslr==0.4.0
 factory_boy==3.2.1
 model-bakery==1.10.1
 pre-commit==3.3.3
-pytest-cov==4.0.0
+pytest-cov==4.1.0
 pytest-django==4.5.2
-pytest-split==0.8.0
-pytest-xdist[psutil]==3.1.0
-responses==0.22.0
-ruff==0.0.263
+pytest-split==0.8.1
+pytest-xdist[psutil]==3.3.1
+responses==0.23.3
+ruff==0.1.1
 wagtail-factories==2.1.0
 Werkzeug==2.2.3


### PR DESCRIPTION
- black
- coverage
- django-browser-reload
- django-coverage-plugin
- django-debug-toolbar
- pytest-cov
- pytest-split
- pytest-xdist
- reponses
- ruff
