### PR TITLE
Remove depreciation warning for mkdocs material emoji support

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -47,8 +47,8 @@ markdown_extensions:
   - admonition
   - attr_list
   - pymdownx.emoji:
-      emoji_index: !!python/name:materialx.emoji.twemoji
-      emoji_generator: !!python/name:materialx.emoji.to_svg
+      emoji_index: !!python/name:material.extensions.emoji.twemoji
+      emoji_generator: !!python/name:material.extensions.emoji.to_svg
   - md_in_html
   - def_list
   - footnotes


### PR DESCRIPTION
Material extension now deprecated as MkDocs for Material now implements this logic directly.

https://pypi.org/project/mkdocs-material-extensions/