### PR TITLE
Update the query text on all.html

### DIFF
--- a/hypha/apply/funds/templates/submissions/all.html
+++ b/hypha/apply/funds/templates/submissions/all.html
@@ -464,7 +464,7 @@
             {% empty %}
                 <div class="flex flex-col items-center justify-center py-20 px-4 border-t">
                     <h2 class='text-2xl'>No results matched your search</h2>
-                    <p>Try <a href="./" hx-get="./" hx-target="#main" hx-push-url="true" hx-swap="outerHTML">clearing</a> all the query and start again.</p>
+                    <p>Try <a href="./" hx-get="./" hx-target="#main" hx-push-url="true" hx-swap="outerHTML">clearing</a> the current query and try again.</p>
                 </div>
             {% endfor %}
         </section>


### PR DESCRIPTION
Change the query text to be linguistically correct

Fixes the language used in the clear query section for no results found in hypha/apply/funds/templates/submissions/all.html