### PR TITLE
docs: update the links to images and some references to pages

### DIFF
--- a/docs/getting-started/contributing/code-contributions.md
+++ b/docs/getting-started/contributing/code-contributions.md
@@ -30,5 +30,5 @@ class MyTestCase(TestCase):
   pass
 ```
 
-This is implemented by default for the [BaseViewTestCase](testing.md#test-class-helpers)
+This is implemented by default for the `BaseViewTestCase`
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -31,4 +31,4 @@ View our [Roadmap](https://github.com/HyphaApp/hypha/wiki/Roadmap) for upcoming 
 ## Technology
 
 * Built with [Django](https://www.djangoproject.com/), PostgreSQL and [Wagtail](https://wagtail.io/)
-* Deploy with [Heroku](/setup/deployment/heroku), [Docker](/setup/deployment/docker/), or [your own server](/setup/deployment/stand-alone).
+* Deploy with [Heroku](./setup/deployment/heroku.md), [Docker](./setup/deployment/docker.md), or [your own server](./setup/deployment/stand-alone.md).

--- a/docs/references/user-roles.md
+++ b/docs/references/user-roles.md
@@ -51,11 +51,11 @@ The **Partner** role could be access, edit, and communicate about a specific app
 
 The Partner could only review applications that has been assigned to them. Applications assigned to the Partner are available on their dashboard.
 
-![](/assets/partner_dashboard_assign_submission.png)
+![](../assets/partner_dashboard_assign_submission.png)
 
 The Partner role could be associated or assigned to an application by clicking on Partner button in the **Actions to take** > Assign.
 
-![](/assets/submission_how-to-assign-partner.png)
+![](../assets/submission_how-to-assign-partner.png)
 
 ## Reviewer
 
@@ -86,7 +86,7 @@ An **Applicant** can:
 * Contact staff regarding own application
 * Track the status of their application(s) on their platform
 
-![](/assets/staff_applicant_dashboard.png)
+![](../assets/staff_applicant_dashboard.png)
 
 
 ## Additional Roles

--- a/docs/user-guides/applications/creating-submisison-application.md
+++ b/docs/user-guides/applications/creating-submisison-application.md
@@ -6,19 +6,19 @@ All admin actions associated with applications can be access through the “Appl
 
 There are several types of Forms in the WagTail Amin. Forms are used to create a Fund.
 
-![](/assets/setup_form-1.png)
+![](../../assets/setup_form-1.png)
 
 **Application Form**
 
-![](/assets/setup_form-2.png)
+![](../../assets/setup_form-2.png)
 
 **Review Form**
 
-![](/assets/setup_form-3.png)
+![](../../assets/setup_form-3.png)
 
 **Determination Form**
 
-![](/assets/setup_form-4.png)
+![](../../assets/setup_form-4.png)
 
 
 ****
@@ -51,7 +51,7 @@ Currently users can copy, clone, or duplicate a Fund before creating a new form.
 1. Open Apply and click the bird icon on the bottom-right corner, then click the “Go to Wagtail admin” pop-up
 2. Click `Apply` > `Rounds`
 
-![](/assets/setup_round-select-round-from-nav.png)
+![](../../assets/setup_round-select-round-from-nav.png)
 
 3\. Go to the round and click the Edit button:
 
@@ -63,14 +63,12 @@ Currently users can copy, clone, or duplicate a Fund before creating a new form.
 
 6\. Enter the Lead's name
 
-![](/assets/setup_round-enter-lead-name.jpeg)
+![](../../assets/setup_round-enter-lead-name.jpeg)
 
 7\. Check to ensure the correct reviewers are highlighted
 
-![](/assets/setup_round-select-reviewers.png)
+![](../../assets/setup_round-select-reviewers.png)
 
 8\. You could save a draft or publish. Publish means the application will be publicly visible to applicants.
 
-![](/assets/setup_round-publish-options.png)
-
-
+![](../../assets/setup_round-publish-options.png)

--- a/docs/user-guides/creating-a-user-account.md
+++ b/docs/user-guides/creating-a-user-account.md
@@ -2,7 +2,7 @@
 
 ### Creating superuser
 
-```
+```console
 python manage.py createsuperuser
 ```
 
@@ -21,19 +21,19 @@ Creating additional users and assigning them Roles is done in Wagtail by someone
 
 In the WagTail Admin, you could create a new user account as well as assign a role to a user account by clicking on the "Add User" button on the far right-hand corner of the screen. You can also search for users in the search bar. User roles are essential to WagTail and the Hypha platform. System Administrators are able to oversee user accounts and manage the level of access for different users. 
 
-![](/assets/manage_user-nav.jpg)
+![](../assets/manage_user-nav.jpg)
 
 The "Add User" form will request your email, name, and role within the platform.
 
-![](/assets/manage_user-add-user.jpg)
+![](../assets/manage_user-add-user.jpg)
 
 Selecting a role with enable to administrative access within the platform. Commonly used roles within the platform are **Staff**, **Partner**, and **Reviewer**.
 
-![](/assets/manage_user-update-group.jpg)
+![](../assets/manage_user-update-group.jpg)
 
 
 ### Filtering by Roles and Status
 
 You could quickly search for user groups and their status (ie active or inactive) using the filter. The search function shows the user account's most recent login date. 
 
-![](/assets/manage_user-apply-filter.jpg)
+![](../assets/manage_user-apply-filter.jpg)

--- a/docs/user-guides/login.md
+++ b/docs/user-guides/login.md
@@ -4,9 +4,9 @@
 
 **Step 2**: Click the "My \[Organization Name]" button in the upper-right corner of the screen.
 
-![Screenshot of the main page of sandbox.opentech.fund.  Top banner of the page has "Hypha" logo in upper left, across top are links to "Funds," "Labs," "Results," "News," "About" and "Search" (a magnifying glass icon).  Two buttons in the upper right show "(person icon) My SB" and "Select Language (dropdown arrow)". The main portion of the page has a blue pixellated background with white sans serif large text that reads "SANDBOX TEST SITE" and in smaller text below "It will reset every 24h. So test all you want.  Below this text is clickable text that says "Learn more how to use it".  Pinned to the footer of the window in the right-hand corner is a button labeled "Apply"](/assets/how-to-login-nav.png)
+![Screenshot of the main page of sandbox.opentech.fund.  Top banner of the page has "Hypha" logo in upper left, across top are links to "Funds," "Labs," "Results," "News," "About" and "Search" (a magnifying glass icon).  Two buttons in the upper right show "(person icon) My SB" and "Select Language (dropdown arrow)". The main portion of the page has a blue pixellated background with white sans serif large text that reads "SANDBOX TEST SITE" and in smaller text below "It will reset every 24h. So test all you want.  Below this text is clickable text that says "Learn more how to use it".  Pinned to the footer of the window in the right-hand corner is a button labeled "Apply"](../assets/how-to-login-nav.png)
 
 
 **Step 3**: Enter your credentials in the "Email address" and "Password" fields & click "Login"
 
-![Screenshot of the login page of sandbox.opentech.fund, as above, but with "Email address\*" and "Password\*" text-entry boxes filled in with "staff@example.com" and "\*\*\*\*\*\*\*\*\*\*\*"](/assets/how-to-login-login-page.png)
+![Screenshot of the login page of sandbox.opentech.fund, as above, but with "Email address" and "Password" text-entry boxes filled in with "staff@example.com"](../assets/how-to-login-login-page.png)


### PR DESCRIPTION
The images are linked relative to page now. This prevents the mkdocs
warnings and also let these images render itself nicely inside the
editor or github interface.

This way of referencing also helps for future if the docs get deployed
to a path instead of a top-level domain
