### PR TITLE
Add grey background to PAF detail page

### DIFF
--- a/hypha/apply/projects/templates/application_projects/project_approval_detail.html
+++ b/hypha/apply/projects/templates/application_projects/project_approval_detail.html
@@ -2,174 +2,172 @@
 {% load i18n static approval_tools project_tags apply_tags %}
 
 {% block title %}{{ object.title }}{% endblock %}
+{% block body_class %}bg-light-grey{% endblock %}
 
 {% block extra_css %}
     <link rel="stylesheet" href="{% static 'css/apply/fancybox.css' %}">
     {{ reviewer_form.media.css }}
 {% endblock %}
 
-{% block content_wrapper %}
-    <main class="wrapper wrapper--large wrapper--main bg-light-grey" id="main">
-        {% block content %}
-            {% adminbar %}
-                {% slot back_link %}
-                    <a class="simplified__projects-link" href="{{ object.get_absolute_url }}" rel="noopener">
-                        {% trans "Back to Project" %}
-                    </a>
-                {% endslot %}
+{% block content %}
+    {% adminbar %}
+        {% slot back_link %}
+            <a class="simplified__projects-link" href="{{ object.get_absolute_url }}" rel="noopener">
+                {% trans "Back to Project" %}
+            </a>
+        {% endslot %}
 
-                {% slot header %}
-                    {{ object.title }}
-                {% endslot %}
-                {% slot sub_heading %}
-                    <div class="heading heading--meta text-sm mt-1">
-                        <span>{{ object.submission.page }}</span>
-                        <span>{{ object.submission.round }}</span>
-                        <span>{% trans "Lead" %}: {{ object.lead }}</span>
-                    </div>
-                {% endslot %}
-            {% endadminbar %}
+        {% slot header %}
+            {{ object.title }}
+        {% endslot %}
+        {% slot sub_heading %}
+            <div class="heading heading--meta text-sm mt-1">
+                <span>{{ object.submission.page }}</span>
+                <span>{{ object.submission.round }}</span>
+                <span>{% trans "Lead" %}: {{ object.lead }}</span>
+            </div>
+        {% endslot %}
+    {% endadminbar %}
 
-            <div class="simplified">
-                <div class="wrapper wrapper--large wrapper--tabs">
-                    <div class="wrapper wrapper--sidebar">
-                        <article class="wrapper--sidebar--inner">
-                            <h4 class="mb-2">{% trans "Project Information" %}</h4>
-                            <div class="card card--solid">
+    <div class="simplified">
+        <div class="wrapper wrapper--large wrapper--tabs">
+            <div class="wrapper wrapper--sidebar">
+                <article class="wrapper--sidebar--inner">
+                    <h4 class="mb-2">{% trans "Project Information" %}</h4>
+                    <div class="card card--solid">
 
-                                {% if object.output_answers %}
-                                    <div class="simplified__paf_answers">
-                                        {{ object.output_answers }}
-                                    </div>
-                                {% endif %}
-
-                                {% has_project_sow_form object as project_sow %}
-                                {% if project_sow and object.sow.output_answers %}
-                                    <div class="simplified__paf_answers">
-                                        {{ object.sow.output_answers }}
-                                    </div>
-                                {% endif %}
+                        {% if object.output_answers %}
+                            <div class="simplified__paf_answers">
+                                {{ object.output_answers }}
                             </div>
+                        {% endif %}
 
-                            <h4 class="mb-2">{% trans "Approvals" %}</h4>
-                            <div class="card card--solid">
-                                {% for approval in project.paf_approvals.all %}
-                                    {% if approval.approved %}
-                                        <p><b>{{ approval.paf_reviewer_role.label }}</b> - {{ approval.user }} ({{ approval.approved_at|date:"DATE_FORMAT" }})</p>
-                                    {% else %}
-                                        <p><b>{{ approval.paf_reviewer_role.label }}</b> {% trans " - Pending" %}</p>
-                                    {% endif %}
-                                {% endfor %}
+                        {% has_project_sow_form object as project_sow %}
+                        {% if project_sow and object.sow.output_answers %}
+                            <div class="simplified__paf_answers">
+                                {{ object.sow.output_answers }}
                             </div>
-
-                            <h4 class="mb-2">{% trans "Review" %}</h4>
-                            <div class="card card--solid">
-                                <p class="font-bold mb-0 mt-0">{% trans "Submission lead" %}</p>
-                                <p class="mt-2 mb-0">{{ project.submission.lead }}</p>
-
-                                <p class="font-bold mt-6 mb-0">{% trans "Staff reviewers" %}</p>
-                                {% for review in project.submission.reviews.by_staff %}
-                                    <p class="mt-2 mb-0">
-                                        {{ review.author }}
-                                        {% if review.author.role %}
-                                            {% trans "as" %} {{ review.author.role }}
-                                        {% endif %}
-                                        - {{ review.created_at|date:"DATE_FORMAT" }}
-                                    </p>
-                                {% empty %}
-                                    <p class="mt-2 mb-0">{% trans "No reviews" %}</p>
-                                {% endfor %}
-                                <p class="font-bold mb-0 mt-6">{% trans "Advisory council" %}</p>
-                                {% for review in project.submission.reviews.by_reviewers %}
-                                    <p class="mt-2 mb-0">
-                                        {{ review.author }} - {{ review.created_at|date:"DATE_FORMAT" }}
-                                    </p>
-                                {% empty %}
-                                    <p class="mt-2 mb-0">{% trans "No reviews" %}</p>
-                                {% endfor %}
-                            </div>
-
-                            <h4 class="mb-2">{% trans "Supporting Documents" %}</h4>
-                            <div class="card card--solid">
-                                <p><a href="{% url 'apply:submissions:simplified' pk=object.submission_id %}">{% trans "Submission" %}</a></p>
-                                {% for packet_file in object.packet_files.all %}
-                                    <p><a href="{% url 'apply:projects:document' pk=object.pk file_pk=packet_file.pk %}">{{ packet_file.title }}</a></p>
-                                {% endfor %}
-                            </div>
-                        </article>
-                        {% user_can_update_paf_status object user request=request as can_update_paf_status %}
-                        {% user_can_take_actions object user as can_take_actions %}
-                        {% if can_take_actions %}
-                            <aside class="sidebar sidebar__project">
-                                {% if mobile %}
-                                    <a class="js-actions-toggle button button--white button--full-width button--actions">{% trans "Actions to take" %}</a>
-                                {% endif %}
-
-                                <div class="js-actions-sidebar sidebar__inner sidebar__inner--light-blue sidebar__inner--actions {% if mobile %}sidebar__inner--mobile{% endif %}">
-                                    <h5>{% trans "Actions to take" %}</h5>
-                                    {% user_can_edit_project object user as can_edit_project %}
-                                    {% if can_edit_project %}
-                                        <a class="button button--bottom-space button--primary button--full-width {% if user_can_approve %} is-disabled {% endif %}" href="{% url 'apply:projects:edit' pk=object.pk %}">{% trans "Edit PAF" %}</a>
-                                    {% endif %}
-                                    <div class="dropdown">
-                                        <button class="button button--project-action--paf-download dropbtn button--bottom-space button--full-width" type="button" data-dropdown-target="#dropdown-content-download">
-                                            {% trans 'Download Approval Form' %}
-                                        </button>
-                                        <div id="dropdown-content-download" class="dropdown-content">
-                                            <a class="dropdown-item" href="{% url 'apply:projects:download' pk=object.pk export_type='pdf' %}">
-                                                {% trans 'Download as PDF' %}</a>
-                                            <a class="dropdown-item" href="{% url 'apply:projects:download' pk=object.pk export_type='docx' %}">
-                                                {% trans 'Download as DOCX' %}</a>
-                                        </div>
-                                    </div>
-                                    {% user_can_update_paf_approvers object user request as can_update_paf_approvers %}
-                                    {% if can_update_paf_approvers %}
-                                        {% if user != project.lead %}
-                                            <a data-fancybox
-                                               data-src="#change-assigned-paf-approvers"
-                                               class="button button--bottom-space button--white button--full-width"
-                                               href="#">
-                                                {% trans "Change approver" %}
-                                            </a>
-                                            <div class="modal" id="change-assigned-paf-approvers">
-                                                <h4 class="modal__project-header-bar">{% trans "Change Approver" %}</h4>
-                                                <p>{% trans "Selected approver will be notified. On unselecting, every listed member here will be notified." %} </p>
-                                                {% trans "Submit" as submit %}
-                                                {% include 'funds/includes/delegated_form_base.html' with form=assign_approvers_form value=submit %}
-                                            </div>
-                                        {% endif %}
-                                    {% endif %}
-                                    {% user_can_assign_approvers_to_project object user request as can_assign_paf_approvers %}
-                                    {% if can_assign_paf_approvers %}
-                                        <a data-fancybox data-src="#assign-paf-approvers" class="button button--bottom-space button--primary button--full-width" href="#">
-                                            {% trans "Assign approver" %}
-                                        </a>
-                                        <div class="modal" id="assign-paf-approvers">
-                                            <h4 class="modal__project-header-bar">{% trans "Assign Approver" %}</h4>
-                                            <p>{% trans "Selected approver will be notified. On unselecting, every listed member here will be notified." %} </p>
-                                            {% trans "Submit" as submit %}
-                                            {% include 'funds/includes/delegated_form_base.html' with form=assign_approvers_form value=submit %}
-                                        </div>
-                                    {% endif %}
-                                    {% if can_update_paf_status %}
-                                        <a data-fancybox data-src="#change-status" class="button button--primary button--full-width {% if user_can_approve %} is-disabled {% endif %}" href="#">{% trans "Update Status" %}</a>
-                                        <div class="modal" id="change-status">
-                                            <h4 class="modal__project-header-bar">{% trans "Update status" %}</h4>
-                                            <p>{% trans "Project's current status" %}: {{ object.get_status_display }}</p>
-                                            {% trans "Update Status" as update %}
-                                            {% include 'funds/includes/delegated_form_base.html' with form=change_paf_status value=update %}
-                                        </div>
-                                    {% endif %}
-                                </div>
-
-                            </aside>
                         {% endif %}
                     </div>
-                </div>
+
+                    <h4 class="mb-2">{% trans "Approvals" %}</h4>
+                    <div class="card card--solid">
+                        {% for approval in project.paf_approvals.all %}
+                            {% if approval.approved %}
+                                <p><b>{{ approval.paf_reviewer_role.label }}</b> - {{ approval.user }} ({{ approval.approved_at|date:"DATE_FORMAT" }})</p>
+                            {% else %}
+                                <p><b>{{ approval.paf_reviewer_role.label }}</b> {% trans " - Pending" %}</p>
+                            {% endif %}
+                        {% endfor %}
+                    </div>
+
+                    <h4 class="mb-2">{% trans "Review" %}</h4>
+                    <div class="card card--solid">
+                        <p class="font-bold mb-0 mt-0">{% trans "Submission lead" %}</p>
+                        <p class="mt-2 mb-0">{{ project.submission.lead }}</p>
+
+                        <p class="font-bold mt-6 mb-0">{% trans "Staff reviewers" %}</p>
+                        {% for review in project.submission.reviews.by_staff %}
+                            <p class="mt-2 mb-0">
+                                {{ review.author }}
+                                {% if review.author.role %}
+                                    {% trans "as" %} {{ review.author.role }}
+                                {% endif %}
+                                - {{ review.created_at|date:"DATE_FORMAT" }}
+                            </p>
+                        {% empty %}
+                            <p class="mt-2 mb-0">{% trans "No reviews" %}</p>
+                        {% endfor %}
+                        <p class="font-bold mb-0 mt-6">{% trans "Advisory council" %}</p>
+                        {% for review in project.submission.reviews.by_reviewers %}
+                            <p class="mt-2 mb-0">
+                                {{ review.author }} - {{ review.created_at|date:"DATE_FORMAT" }}
+                            </p>
+                        {% empty %}
+                            <p class="mt-2 mb-0">{% trans "No reviews" %}</p>
+                        {% endfor %}
+                    </div>
+
+                    <h4 class="mb-2">{% trans "Supporting Documents" %}</h4>
+                    <div class="card card--solid">
+                        <p><a href="{% url 'apply:submissions:simplified' pk=object.submission_id %}">{% trans "Submission" %}</a></p>
+                        {% for packet_file in object.packet_files.all %}
+                            <p><a href="{% url 'apply:projects:document' pk=object.pk file_pk=packet_file.pk %}">{{ packet_file.title }}</a></p>
+                        {% endfor %}
+                    </div>
+                </article>
+                {% user_can_update_paf_status object user request=request as can_update_paf_status %}
+                {% user_can_take_actions object user as can_take_actions %}
+                {% if can_take_actions %}
+                    <aside class="sidebar sidebar__project">
+                        {% if mobile %}
+                            <a class="js-actions-toggle button button--white button--full-width button--actions">{% trans "Actions to take" %}</a>
+                        {% endif %}
+
+                        <div class="js-actions-sidebar sidebar__inner sidebar__inner--light-blue sidebar__inner--actions {% if mobile %}sidebar__inner--mobile{% endif %}">
+                            <h5>{% trans "Actions to take" %}</h5>
+                            {% user_can_edit_project object user as can_edit_project %}
+                            {% if can_edit_project %}
+                                <a class="button button--bottom-space button--primary button--full-width {% if user_can_approve %} is-disabled {% endif %}" href="{% url 'apply:projects:edit' pk=object.pk %}">{% trans "Edit PAF" %}</a>
+                            {% endif %}
+                            <div class="dropdown">
+                                <button class="button button--project-action--paf-download dropbtn button--bottom-space button--full-width" type="button" data-dropdown-target="#dropdown-content-download">
+                                    {% trans 'Download Approval Form' %}
+                                </button>
+                                <div id="dropdown-content-download" class="dropdown-content">
+                                    <a class="dropdown-item" href="{% url 'apply:projects:download' pk=object.pk export_type='pdf' %}">
+                                        {% trans 'Download as PDF' %}</a>
+                                    <a class="dropdown-item" href="{% url 'apply:projects:download' pk=object.pk export_type='docx' %}">
+                                        {% trans 'Download as DOCX' %}</a>
+                                </div>
+                            </div>
+                            {% user_can_update_paf_approvers object user request as can_update_paf_approvers %}
+                            {% if can_update_paf_approvers %}
+                                {% if user != project.lead %}
+                                    <a data-fancybox
+                                       data-src="#change-assigned-paf-approvers"
+                                       class="button button--bottom-space button--white button--full-width"
+                                       href="#">
+                                        {% trans "Change approver" %}
+                                    </a>
+                                    <div class="modal" id="change-assigned-paf-approvers">
+                                        <h4 class="modal__project-header-bar">{% trans "Change Approver" %}</h4>
+                                        <p>{% trans "Selected approver will be notified. On unselecting, every listed member here will be notified." %} </p>
+                                        {% trans "Submit" as submit %}
+                                        {% include 'funds/includes/delegated_form_base.html' with form=assign_approvers_form value=submit %}
+                                    </div>
+                                {% endif %}
+                            {% endif %}
+                            {% user_can_assign_approvers_to_project object user request as can_assign_paf_approvers %}
+                            {% if can_assign_paf_approvers %}
+                                <a data-fancybox data-src="#assign-paf-approvers" class="button button--bottom-space button--primary button--full-width" href="#">
+                                    {% trans "Assign approver" %}
+                                </a>
+                                <div class="modal" id="assign-paf-approvers">
+                                    <h4 class="modal__project-header-bar">{% trans "Assign Approver" %}</h4>
+                                    <p>{% trans "Selected approver will be notified. On unselecting, every listed member here will be notified." %} </p>
+                                    {% trans "Submit" as submit %}
+                                    {% include 'funds/includes/delegated_form_base.html' with form=assign_approvers_form value=submit %}
+                                </div>
+                            {% endif %}
+                            {% if can_update_paf_status %}
+                                <a data-fancybox data-src="#change-status" class="button button--primary button--full-width {% if user_can_approve %} is-disabled {% endif %}" href="#">{% trans "Update Status" %}</a>
+                                <div class="modal" id="change-status">
+                                    <h4 class="modal__project-header-bar">{% trans "Update status" %}</h4>
+                                    <p>{% trans "Project's current status" %}: {{ object.get_status_display }}</p>
+                                    {% trans "Update Status" as update %}
+                                    {% include 'funds/includes/delegated_form_base.html' with form=change_paf_status value=update %}
+                                </div>
+                            {% endif %}
+                        </div>
+
+                    </aside>
+                {% endif %}
             </div>
-        {% endblock content %}
-    </main>
-{% endblock content_wrapper %}
+        </div>
+    </div>
+{% endblock content %}
+
 
 {% block extra_js %}
     {{ block.super }}

--- a/hypha/apply/projects/templates/application_projects/project_approval_detail.html
+++ b/hypha/apply/projects/templates/application_projects/project_approval_detail.html
@@ -8,164 +8,168 @@
     {{ reviewer_form.media.css }}
 {% endblock %}
 
-{% block content %}
-    {% adminbar %}
-        {% slot back_link %}
-            <a class="simplified__projects-link" href="{{ object.get_absolute_url }}" rel="noopener">
-                {% trans "Back to Project" %}
-            </a>
-        {% endslot %}
+{% block content_wrapper %}
+    <main class="wrapper wrapper--large wrapper--main bg-light-grey" id="main">
+        {% block content %}
+            {% adminbar %}
+                {% slot back_link %}
+                    <a class="simplified__projects-link" href="{{ object.get_absolute_url }}" rel="noopener">
+                        {% trans "Back to Project" %}
+                    </a>
+                {% endslot %}
 
-        {% slot header %}
-            {{ object.title }}
-        {% endslot %}
-        {% slot sub_heading %}
-            <div class="heading heading--meta text-sm mt-1">
-                <span>{{ object.submission.page }}</span>
-                <span>{{ object.submission.round }}</span>
-                <span>{% trans "Lead" %}: {{ object.lead }}</span>
-            </div>
-        {% endslot %}
-    {% endadminbar %}
-
-    <div class="simplified">
-        <div class="wrapper wrapper--large wrapper--tabs">
-            <div class="wrapper wrapper--sidebar">
-                <article class="wrapper--sidebar--inner">
-                    <h4 class="mb-2">{% trans "Project Information" %}</h4>
-                    <div class="card card--solid">
-
-                        {% if object.output_answers %}
-                            <div class="simplified__paf_answers">
-                                {{ object.output_answers }}
-                            </div>
-                        {% endif %}
-
-                        {% has_project_sow_form object as project_sow %}
-                        {% if project_sow and object.sow.output_answers %}
-                            <div class="simplified__paf_answers">
-                                {{ object.sow.output_answers }}
-                            </div>
-                        {% endif %}
+                {% slot header %}
+                    {{ object.title }}
+                {% endslot %}
+                {% slot sub_heading %}
+                    <div class="heading heading--meta text-sm mt-1">
+                        <span>{{ object.submission.page }}</span>
+                        <span>{{ object.submission.round }}</span>
+                        <span>{% trans "Lead" %}: {{ object.lead }}</span>
                     </div>
+                {% endslot %}
+            {% endadminbar %}
 
-                    <h4 class="mb-2">{% trans "Approvals" %}</h4>
-                    <div class="card card--solid">
-                        {% for approval in project.paf_approvals.all %}
-                            {% if approval.approved %}
-                                <p><b>{{ approval.paf_reviewer_role.label }}</b> - {{ approval.user }} ({{ approval.approved_at|date:"DATE_FORMAT" }})</p>
-                            {% else %}
-                                <p><b>{{ approval.paf_reviewer_role.label }}</b> {% trans " - Pending" %}</p>
-                            {% endif %}
-                        {% endfor %}
-                    </div>
+            <div class="simplified">
+                <div class="wrapper wrapper--large wrapper--tabs">
+                    <div class="wrapper wrapper--sidebar">
+                        <article class="wrapper--sidebar--inner">
+                            <h4 class="mb-2">{% trans "Project Information" %}</h4>
+                            <div class="card card--solid">
 
-                    <h4 class="mb-2">{% trans "Review" %}</h4>
-                    <div class="card card--solid">
-                        <p class="font-bold mb-0 mt-0">{% trans "Submission lead" %}</p>
-                        <p class="mt-2 mb-0">{{ project.submission.lead }}</p>
-
-                        <p class="font-bold mt-6 mb-0">{% trans "Staff reviewers" %}</p>
-                        {% for review in project.submission.reviews.by_staff %}
-                            <p class="mt-2 mb-0">
-                                {{ review.author }}
-                                {% if review.author.role %}
-                                    {% trans "as" %} {{ review.author.role }}
-                                {% endif %}
-                                - {{ review.created_at|date:"DATE_FORMAT" }}
-                            </p>
-                        {% empty %}
-                            <p class="mt-2 mb-0">{% trans "No reviews" %}</p>
-                        {% endfor %}
-                        <p class="font-bold mb-0 mt-6">{% trans "Advisory council" %}</p>
-                        {% for review in project.submission.reviews.by_reviewers %}
-                            <p class="mt-2 mb-0">
-                                {{ review.author }} - {{ review.created_at|date:"DATE_FORMAT" }}
-                            </p>
-                        {% empty %}
-                            <p class="mt-2 mb-0">{% trans "No reviews" %}</p>
-                        {% endfor %}
-                    </div>
-
-                    <h4 class="mb-2">{% trans "Supporting Documents" %}</h4>
-                    <div class="card card--solid">
-                        <p><a href="{% url 'apply:submissions:simplified' pk=object.submission_id %}">{% trans "Submission" %}</a></p>
-                        {% for packet_file in object.packet_files.all %}
-                            <p><a href="{% url 'apply:projects:document' pk=object.pk file_pk=packet_file.pk %}">{{ packet_file.title }}</a></p>
-                        {% endfor %}
-                    </div>
-                </article>
-                {% user_can_update_paf_status object user request=request as can_update_paf_status %}
-                {% user_can_take_actions object user as can_take_actions %}
-                {% if can_take_actions %}
-                    <aside class="sidebar sidebar__project">
-                        {% if mobile %}
-                            <a class="js-actions-toggle button button--white button--full-width button--actions">{% trans "Actions to take" %}</a>
-                        {% endif %}
-
-                        <div class="js-actions-sidebar sidebar__inner sidebar__inner--light-blue sidebar__inner--actions {% if mobile %}sidebar__inner--mobile{% endif %}">
-                            <h5>{% trans "Actions to take" %}</h5>
-                            {% user_can_edit_project object user as can_edit_project %}
-                            {% if can_edit_project %}
-                                <a class="button button--bottom-space button--primary button--full-width {% if user_can_approve %} is-disabled {% endif %}" href="{% url 'apply:projects:edit' pk=object.pk %}">{% trans "Edit PAF" %}</a>
-                            {% endif %}
-                            <div class="dropdown">
-                                <button class="button button--project-action--paf-download dropbtn button--bottom-space button--full-width" type="button" data-dropdown-target="#dropdown-content-download">
-                                    {% trans 'Download Approval Form' %}
-                                </button>
-                                <div id="dropdown-content-download" class="dropdown-content">
-                                    <a class="dropdown-item" href="{% url 'apply:projects:download' pk=object.pk export_type='pdf' %}">
-                                        {% trans 'Download as PDF' %}</a>
-                                    <a class="dropdown-item" href="{% url 'apply:projects:download' pk=object.pk export_type='docx' %}">
-                                        {% trans 'Download as DOCX' %}</a>
-                                </div>
-                            </div>
-                            {% user_can_update_paf_approvers object user request as can_update_paf_approvers %}
-                            {% if can_update_paf_approvers %}
-                                {% if user != project.lead %}
-                                    <a data-fancybox
-                                       data-src="#change-assigned-paf-approvers"
-                                       class="button button--bottom-space button--white button--full-width"
-                                       href="#">
-                                        {% trans "Change approver" %}
-                                    </a>
-                                    <div class="modal" id="change-assigned-paf-approvers">
-                                        <h4 class="modal__project-header-bar">{% trans "Change Approver" %}</h4>
-                                        <p>{% trans "Selected approver will be notified. On unselecting, every listed member here will be notified." %} </p>
-                                        {% trans "Submit" as submit %}
-                                        {% include 'funds/includes/delegated_form_base.html' with form=assign_approvers_form value=submit %}
+                                {% if object.output_answers %}
+                                    <div class="simplified__paf_answers">
+                                        {{ object.output_answers }}
                                     </div>
                                 {% endif %}
-                            {% endif %}
-                            {% user_can_assign_approvers_to_project object user request as can_assign_paf_approvers %}
-                            {% if can_assign_paf_approvers %}
-                                <a data-fancybox data-src="#assign-paf-approvers" class="button button--bottom-space button--primary button--full-width" href="#">
-                                    {% trans "Assign approver" %}
-                                </a>
-                                <div class="modal" id="assign-paf-approvers">
-                                    <h4 class="modal__project-header-bar">{% trans "Assign Approver" %}</h4>
-                                    <p>{% trans "Selected approver will be notified. On unselecting, every listed member here will be notified." %} </p>
-                                    {% trans "Submit" as submit %}
-                                    {% include 'funds/includes/delegated_form_base.html' with form=assign_approvers_form value=submit %}
-                                </div>
-                            {% endif %}
-                            {% if can_update_paf_status %}
-                                <a data-fancybox data-src="#change-status" class="button button--primary button--full-width {% if user_can_approve %} is-disabled {% endif %}" href="#">{% trans "Update Status" %}</a>
-                                <div class="modal" id="change-status">
-                                    <h4 class="modal__project-header-bar">{% trans "Update status" %}</h4>
-                                    <p>{% trans "Project's current status" %}: {{ object.get_status_display }}</p>
-                                    {% trans "Update Status" as update %}
-                                    {% include 'funds/includes/delegated_form_base.html' with form=change_paf_status value=update %}
-                                </div>
-                            {% endif %}
-                        </div>
 
-                    </aside>
-                {% endif %}
+                                {% has_project_sow_form object as project_sow %}
+                                {% if project_sow and object.sow.output_answers %}
+                                    <div class="simplified__paf_answers">
+                                        {{ object.sow.output_answers }}
+                                    </div>
+                                {% endif %}
+                            </div>
+
+                            <h4 class="mb-2">{% trans "Approvals" %}</h4>
+                            <div class="card card--solid">
+                                {% for approval in project.paf_approvals.all %}
+                                    {% if approval.approved %}
+                                        <p><b>{{ approval.paf_reviewer_role.label }}</b> - {{ approval.user }} ({{ approval.approved_at|date:"DATE_FORMAT" }})</p>
+                                    {% else %}
+                                        <p><b>{{ approval.paf_reviewer_role.label }}</b> {% trans " - Pending" %}</p>
+                                    {% endif %}
+                                {% endfor %}
+                            </div>
+
+                            <h4 class="mb-2">{% trans "Review" %}</h4>
+                            <div class="card card--solid">
+                                <p class="font-bold mb-0 mt-0">{% trans "Submission lead" %}</p>
+                                <p class="mt-2 mb-0">{{ project.submission.lead }}</p>
+
+                                <p class="font-bold mt-6 mb-0">{% trans "Staff reviewers" %}</p>
+                                {% for review in project.submission.reviews.by_staff %}
+                                    <p class="mt-2 mb-0">
+                                        {{ review.author }}
+                                        {% if review.author.role %}
+                                            {% trans "as" %} {{ review.author.role }}
+                                        {% endif %}
+                                        - {{ review.created_at|date:"DATE_FORMAT" }}
+                                    </p>
+                                {% empty %}
+                                    <p class="mt-2 mb-0">{% trans "No reviews" %}</p>
+                                {% endfor %}
+                                <p class="font-bold mb-0 mt-6">{% trans "Advisory council" %}</p>
+                                {% for review in project.submission.reviews.by_reviewers %}
+                                    <p class="mt-2 mb-0">
+                                        {{ review.author }} - {{ review.created_at|date:"DATE_FORMAT" }}
+                                    </p>
+                                {% empty %}
+                                    <p class="mt-2 mb-0">{% trans "No reviews" %}</p>
+                                {% endfor %}
+                            </div>
+
+                            <h4 class="mb-2">{% trans "Supporting Documents" %}</h4>
+                            <div class="card card--solid">
+                                <p><a href="{% url 'apply:submissions:simplified' pk=object.submission_id %}">{% trans "Submission" %}</a></p>
+                                {% for packet_file in object.packet_files.all %}
+                                    <p><a href="{% url 'apply:projects:document' pk=object.pk file_pk=packet_file.pk %}">{{ packet_file.title }}</a></p>
+                                {% endfor %}
+                            </div>
+                        </article>
+                        {% user_can_update_paf_status object user request=request as can_update_paf_status %}
+                        {% user_can_take_actions object user as can_take_actions %}
+                        {% if can_take_actions %}
+                            <aside class="sidebar sidebar__project">
+                                {% if mobile %}
+                                    <a class="js-actions-toggle button button--white button--full-width button--actions">{% trans "Actions to take" %}</a>
+                                {% endif %}
+
+                                <div class="js-actions-sidebar sidebar__inner sidebar__inner--light-blue sidebar__inner--actions {% if mobile %}sidebar__inner--mobile{% endif %}">
+                                    <h5>{% trans "Actions to take" %}</h5>
+                                    {% user_can_edit_project object user as can_edit_project %}
+                                    {% if can_edit_project %}
+                                        <a class="button button--bottom-space button--primary button--full-width {% if user_can_approve %} is-disabled {% endif %}" href="{% url 'apply:projects:edit' pk=object.pk %}">{% trans "Edit PAF" %}</a>
+                                    {% endif %}
+                                    <div class="dropdown">
+                                        <button class="button button--project-action--paf-download dropbtn button--bottom-space button--full-width" type="button" data-dropdown-target="#dropdown-content-download">
+                                            {% trans 'Download Approval Form' %}
+                                        </button>
+                                        <div id="dropdown-content-download" class="dropdown-content">
+                                            <a class="dropdown-item" href="{% url 'apply:projects:download' pk=object.pk export_type='pdf' %}">
+                                                {% trans 'Download as PDF' %}</a>
+                                            <a class="dropdown-item" href="{% url 'apply:projects:download' pk=object.pk export_type='docx' %}">
+                                                {% trans 'Download as DOCX' %}</a>
+                                        </div>
+                                    </div>
+                                    {% user_can_update_paf_approvers object user request as can_update_paf_approvers %}
+                                    {% if can_update_paf_approvers %}
+                                        {% if user != project.lead %}
+                                            <a data-fancybox
+                                               data-src="#change-assigned-paf-approvers"
+                                               class="button button--bottom-space button--white button--full-width"
+                                               href="#">
+                                                {% trans "Change approver" %}
+                                            </a>
+                                            <div class="modal" id="change-assigned-paf-approvers">
+                                                <h4 class="modal__project-header-bar">{% trans "Change Approver" %}</h4>
+                                                <p>{% trans "Selected approver will be notified. On unselecting, every listed member here will be notified." %} </p>
+                                                {% trans "Submit" as submit %}
+                                                {% include 'funds/includes/delegated_form_base.html' with form=assign_approvers_form value=submit %}
+                                            </div>
+                                        {% endif %}
+                                    {% endif %}
+                                    {% user_can_assign_approvers_to_project object user request as can_assign_paf_approvers %}
+                                    {% if can_assign_paf_approvers %}
+                                        <a data-fancybox data-src="#assign-paf-approvers" class="button button--bottom-space button--primary button--full-width" href="#">
+                                            {% trans "Assign approver" %}
+                                        </a>
+                                        <div class="modal" id="assign-paf-approvers">
+                                            <h4 class="modal__project-header-bar">{% trans "Assign Approver" %}</h4>
+                                            <p>{% trans "Selected approver will be notified. On unselecting, every listed member here will be notified." %} </p>
+                                            {% trans "Submit" as submit %}
+                                            {% include 'funds/includes/delegated_form_base.html' with form=assign_approvers_form value=submit %}
+                                        </div>
+                                    {% endif %}
+                                    {% if can_update_paf_status %}
+                                        <a data-fancybox data-src="#change-status" class="button button--primary button--full-width {% if user_can_approve %} is-disabled {% endif %}" href="#">{% trans "Update Status" %}</a>
+                                        <div class="modal" id="change-status">
+                                            <h4 class="modal__project-header-bar">{% trans "Update status" %}</h4>
+                                            <p>{% trans "Project's current status" %}: {{ object.get_status_display }}</p>
+                                            {% trans "Update Status" as update %}
+                                            {% include 'funds/includes/delegated_form_base.html' with form=change_paf_status value=update %}
+                                        </div>
+                                    {% endif %}
+                                </div>
+
+                            </aside>
+                        {% endif %}
+                    </div>
+                </div>
             </div>
-        </div>
-    </div>
-{% endblock content %}
+        {% endblock content %}
+    </main>
+{% endblock content_wrapper %}
 
 {% block extra_js %}
     {{ block.super }}

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -12,6 +12,7 @@ module.exports = {
                 "dark-blue": "#0c72a0",
                 tomato: "#f05e54",
                 "mid-grey": "#cfcfcf",
+                "light-grey": "#f7f7f7",
                 arsenic: "#404041",
                 "fg-muted": "var(--color-fg-muted)",
                 "fg-default": "var(--color-fg-default)",


### PR DESCRIPTION
Fixes #3650 
The PAF page contains multiple cards/boxes, so we want its background as grey to enhance the visibility of those boxes.

How it looks right now:
![image](https://github.com/HyphaApp/hypha/assets/23638629/c4122dbb-592a-4814-871f-8001e0aa0ed4)

With this PR:
![image](https://github.com/HyphaApp/hypha/assets/23638629/29a6d4ce-3835-43e8-a15d-705cfd8c3cc5)


