### PR TITLE
Break title in max three lines with expandable on hover

### DIFF
--- a/hypha/apply/dashboard/templates/dashboard/applicant_dashboard.html
+++ b/hypha/apply/dashboard/templates/dashboard/applicant_dashboard.html
@@ -33,8 +33,8 @@
                 {% for submission in my_active_submissions %}
                     <div class="wrapper wrapper--status-bar-outer">
                         <div class="wrapper wrapper--status-bar-inner">
-                            <div class="mt-5 ml-4">
-                                <h4 class="heading mb-2 font-bold"><a class="link" href="{% url 'funds:submissions:detail' submission.id %}">{{ submission.title }}</a></h4>
+                            <div class="mt-5 ml-4 lg:max-w-[30%]">
+                                <h4 class="heading mb-2 font-bold line-clamp-2 hover:line-clamp-none"><a class="link" href="{% url 'funds:submissions:detail' submission.id %}">{{ submission.title }}</a></h4>
                                 <p class="m-0 text-gray-400">{% trans "Submitted on " %} {{ submission.submit_time.date }} {% trans "by" %} {{ submission.user.get_full_name }}</p>
                             </div>
                             {% status_bar submission.workflow submission.phase request.user css_class="status-bar--small" %}

--- a/hypha/apply/dashboard/templates/dashboard/applicant_dashboard.html
+++ b/hypha/apply/dashboard/templates/dashboard/applicant_dashboard.html
@@ -34,7 +34,7 @@
                     <div class="wrapper wrapper--status-bar-outer">
                         <div class="wrapper wrapper--status-bar-inner">
                             <div class="mt-5 ml-4 lg:max-w-[30%]">
-                                <h4 class="heading mb-2 font-bold line-clamp-2 hover:line-clamp-none"><a class="link" href="{% url 'funds:submissions:detail' submission.id %}">{{ submission.title }}</a></h4>
+                                <h4 class="heading mb-2 font-bold line-clamp-3 hover:line-clamp-none"><a class="link" href="{% url 'funds:submissions:detail' submission.id %}">{{ submission.title }}</a></h4>
                                 <p class="m-0 text-gray-400">{% trans "Submitted on " %} {{ submission.submit_time.date }} {% trans "by" %} {{ submission.user.get_full_name }}</p>
                             </div>
                             {% status_bar submission.workflow submission.phase request.user css_class="status-bar--small" %}
@@ -63,8 +63,8 @@
                 {% for project in active_projects.data %}
                     <div class="wrapper wrapper--status-bar-outer">
                         <div class="wrapper wrapper--status-bar-inner">
-                            <div class="mt-5 ml-4">
-                                <h4 class="heading mb-2 font-bold"><a class="link" href="{% url 'apply:projects:detail' project.id %}">{{ project.title }}</a></h4>
+                            <div class="mt-5 ml-4 lg:max-w-[30%]">
+                                <h4 class="heading mb-2 font-bold line-clamp-3 hover:line-clamp-none"><a class="link" href="{% url 'apply:projects:detail' project.id %}">{{ project.title }}</a></h4>
                                 <p class="m-0 text-gray-400">{% trans "Project start date: " %} {{ project.created_at.date }}</p>
                             </div>
                             {% project_status_bar project.status request.user css_class="status-bar--small" %}

--- a/hypha/static_src/src/sass/apply/components/_status-bar.scss
+++ b/hypha/static_src/src/sass/apply/components/_status-bar.scss
@@ -18,8 +18,8 @@
 
     &--small {
         width: 100%;
-        max-width: 800px;
-        margin-right: 40px;
+        max-width: 750px;
+        margin-right: 30px;
     }
 
     &__subheading {

--- a/hypha/static_src/src/sass/apply/components/_status-bar.scss
+++ b/hypha/static_src/src/sass/apply/components/_status-bar.scss
@@ -20,6 +20,7 @@
         width: 100%;
         max-width: 750px;
         margin-right: 30px;
+        margin-left: 16px;
     }
 
     &__subheading {


### PR DESCRIPTION
Fixes #3631 

Right now, big titles look like this on the applicant dashboard:
![image](https://github.com/HyphaApp/hypha/assets/23638629/71e323ae-c5f9-47da-8f7e-454f41646884)

It looks like this after the fix:
On large screen/laptop:
![image](https://github.com/HyphaApp/hypha/assets/23638629/bbe3e9b7-d78f-4a2c-9d93-15f22d6c0099)
on hover(above screen):
![image](https://github.com/HyphaApp/hypha/assets/23638629/797c6883-b397-47b8-ae76-937efaca9fc0)

For smaller screen like tablet/ipad mini:
<img width="1004" alt="image" src="https://github.com/HyphaApp/hypha/assets/23638629/3bc20dbe-c9ff-4a96-a35d-1bd9677a0a7e">
