### PR TITLE
Fix visibility of last item of status bar on submission detail page

### DIFF
--- a/hypha/static_src/src/sass/apply/components/_status-bar.scss
+++ b/hypha/static_src/src/sass/apply/components/_status-bar.scss
@@ -4,6 +4,7 @@
     $root: &;
     display: none;
     padding: 30px 10px 80px;
+    margin-right: 16px;
 
     @include media-query(tablet-portrait) {
         display: flex;


### PR DESCRIPTION
Fixes #3655 

How it was before:

<img width="1280" alt="image" src="https://github.com/HyphaApp/hypha/assets/23638629/87093ac4-a5c8-45d6-adf1-a9da8ea1eb7c">

How it will look now:

<img width="1280" alt="image" src="https://github.com/HyphaApp/hypha/assets/23638629/86d6c174-b0ab-4b3b-987a-99375ea0fd0e">
