### PR TITLE
Update 'Waiting for' content for contract upload 

### DIFF
--- a/hypha/apply/projects/templatetags/project_tags.py
+++ b/hypha/apply/projects/templatetags/project_tags.py
@@ -146,6 +146,11 @@ def user_next_step_on_project(project, user, request=None):
                         org_short_name=settings.ORG_SHORT_NAME
                     ),
                 }
+            if settings.STAFF_UPLOAD_CONTRACT:
+                return {
+                    "heading": _("Waiting for"),
+                    "text": _("Awaiting signed contract from Staff/Contracting team"),
+                }
             return {
                 "heading": _("Waiting for"),
                 "text": _("Awaiting signed contract from Contracting team"),


### PR DESCRIPTION
Fixes #3644 

![image](https://github.com/HyphaApp/hypha/assets/23638629/e10027e3-d9c2-4808-be2f-b75027694443)

As of now, staff can upload contracts, so the 'waiting for' text is also updated accordingly from "Awaiting signed contract from Contracting team" to "Awaiting signed contract from Staff/Contracting team"(depends on the settings)