### PR TITLE
Fixes and enhancements to project invoice detail page

### DIFF
--- a/hypha/apply/projects/templates/application_projects/invoice_detail.html
+++ b/hypha/apply/projects/templates/application_projects/invoice_detail.html
@@ -1,17 +1,18 @@
 {% extends "base-apply.html" %}
 {% load i18n humanize invoice_tools %}
 
-{% block title %}{% trans "Invoice" %}: {{ object.project.title }}{% endblock %}
+{% block title %}{% trans "Invoice" %}: {{ object.invoice_number }} - {{ object.project.title }}{% endblock %}
+{% block body_class %}bg-light-grey{% endblock %}
 {% block content %}
     {% display_invoice_status_for_user user object as invoice_status %}
 
     {% adminbar %}
         {% slot back_link %}
-            <a class="simplified__projects-link" href="{{ object.project.get_absolute_url }}">
+            <a class="simplified__projects-link" href="{% url 'apply:projects:detail' object.project.id %}">
                 {% trans "View project page" %}
             </a>
         {% endslot %}
-        {% slot header %}{% trans "Invoice" %}{% endslot %}
+        {% slot header %}{% trans "Invoice" %}: {{ object.invoice_number }}{% endslot %}
         {% slot sub_heading %}{% trans "For" %}: {{ object.project.title }}{% endslot %}
     {% endadminbar %}
 
@@ -66,12 +67,14 @@
                     <p class="card__text"><a target="_blank" href="{% url "apply:projects:invoice-document" pk=object.project.pk invoice_pk=object.pk %}">{{object.filename}}</a></p>
                     <embed src="{% url "apply:projects:invoice-document" pk=object.project.pk invoice_pk=object.pk %}" width="800px" height="800px" />
                 </div>
-                <div class="card__inner">
-                    <h5 class="card__heading">{% trans "Supporting Documents" %}</h5>
-                    {% for document in object.supporting_documents.all %}
-                        <p class="card__text"><a href="{% url "apply:projects:invoice-supporting-document" pk=object.project.pk invoice_pk=object.pk file_pk=document.pk %}">{{document.filename}}</a></p>
-                    {% endfor %}
-                </div>
+                {% if object.supporting_documents.exists %}
+                    <div class="card__inner">
+                        <h5 class="card__heading">{% trans "Supporting Documents" %}</h5>
+                        {% for document in object.supporting_documents.all %}
+                            <p class="card__text"><a href="{% url "apply:projects:invoice-supporting-document" pk=object.project.pk invoice_pk=object.pk file_pk=document.pk %}">{{document.filename}}</a></p>
+                        {% endfor %}
+                    </div>
+                {% endif %}
             </div>
         </div>
         <aside class="sidebar">

--- a/hypha/static_src/src/sass/apply/components/_wrapper.scss
+++ b/hypha/static_src/src/sass/apply/components/_wrapper.scss
@@ -202,7 +202,7 @@
         }
 
         .card:first-child {
-            margin-top: 20px;
+            margin-top: 0;
         }
     }
 


### PR DESCRIPTION
1. Fix link to "view project page"
2. Add bg-light-grey as there are a log of white cards
3. Fix margin top on the top-most card.
4. Do not show supporting documents section if they are not present

## Before

![Screenshot 2023-11-26 at 6  39 02@2x](https://github.com/HyphaApp/hypha/assets/236356/2e8c2aab-4af5-40f3-93c9-780c72daea59)


## After
![Screenshot 2023-11-26 at 6  36 37@2x](https://github.com/HyphaApp/hypha/assets/236356/f9a952fc-fcda-4786-afd7-b147d40cb2e0)

