### PR TITLE
Add scroll to top button

### DIFF
--- a/hypha/core/components.py
+++ b/hypha/core/components.py
@@ -14,3 +14,8 @@ class DropdownMenu(component.Component):
 
     def get_context_data(self, **kwargs) -> dict:
         return {"id": str(uuid.uuid4())}
+
+
+@component.register("scroll-to-top")
+class ScrollToTop(component.Component):
+    template_name = "components/scroll-to-top.html"

--- a/hypha/core/templates/components/scroll-to-top.html
+++ b/hypha/core/templates/components/scroll-to-top.html
@@ -1,0 +1,14 @@
+{% load heroicons %}
+
+<template x-teleport="body" x-data="{scrollBackTop: false}">
+    <button
+        x-show="scrollBackTop"
+        x-transition
+        x-transition:enter-end="opacity-70 scale-100"
+        x-on:scroll.window.throttle.50ms="scrollBackTop = (window.pageYOffset > window.outerHeight * 0.5) ? true : false"
+        @click="window.scrollTo({top: 0, behavior: 'smooth'})"
+        aria-label="Back to top"
+        class="fixed top-0 right-1/2 px-3 py-2 mt-10 -mr-[64px] text-white bg-light-blue/80 hover:bg-light-blue hover:text-white duration-500 hover:shadow-lg transition-all focus:outline-none cursor-pointer shadow rounded-2xl">
+        {% heroicon_mini "arrow-long-up" class="inline align-text-bottom" size=18 %} Back to top
+    </button>
+</template>

--- a/hypha/core/templates/components/scroll-to-top.html
+++ b/hypha/core/templates/components/scroll-to-top.html
@@ -9,6 +9,6 @@
         @click="window.scrollTo({top: 0, behavior: 'smooth'})"
         aria-label="Back to top"
         class="fixed top-0 right-1/2 px-3 py-2 mt-10 -mr-[64px] text-white bg-light-blue/80 hover:bg-light-blue hover:text-white duration-500 hover:shadow-lg transition-all focus:outline-none cursor-pointer shadow rounded-2xl">
-        {% heroicon_mini "arrow-long-up" class="inline align-text-bottom" size=18 %} Back to top
+        {% heroicon_mini "arrow-long-up" class="inline align-text-bottom" size=18 aria_hidden=true %} Back to top
     </button>
 </template>

--- a/hypha/core/templates/components/scroll-to-top.html
+++ b/hypha/core/templates/components/scroll-to-top.html
@@ -8,7 +8,7 @@
         x-on:scroll.window.throttle.50ms="scrollBackTop = (window.pageYOffset < lastScrollTop && window.pageYOffset > window.outerHeight * 0.4) ? true : false; lastScrollTop = window.pageYOffset;"
         @click="window.scrollTo({top: 0, behavior: 'smooth'})"
         aria-label="Back to top"
-        class="fixed top-0 right-1/2 px-3 py-2 mt-10 -mr-[64px] text-white bg-light-blue/80 hover:bg-light-blue hover:text-white hover:shadow-lg transition-all focus:outline-none cursor-pointer shadow-lg rounded-2xl">
+        class="fixed top-0 right-1/2 px-3 py-2 mt-10 -mr-[64px] text-white bg-light-blue/80 z-30 hover:bg-light-blue hover:text-white hover:shadow-lg transition-all focus:outline-none cursor-pointer shadow-lg rounded-2xl">
         {% heroicon_mini "arrow-long-up" class="inline align-text-bottom" size=18 aria_hidden=true %} Back to top
     </button>
 </template>

--- a/hypha/core/templates/components/scroll-to-top.html
+++ b/hypha/core/templates/components/scroll-to-top.html
@@ -1,14 +1,14 @@
 {% load heroicons %}
 
-<template x-teleport="body" x-data="{scrollBackTop: false}">
+<template x-teleport="body" x-data="{scrollBackTop: false, lastScrollTop: 0}">
     <button
         x-show="scrollBackTop"
         x-transition
-        x-transition:enter-end="opacity-70 scale-100"
-        x-on:scroll.window.throttle.50ms="scrollBackTop = (window.pageYOffset > window.outerHeight * 0.5) ? true : false"
+        x-transition.duration.500ms
+        x-on:scroll.window.throttle.50ms="scrollBackTop = (window.pageYOffset < lastScrollTop && window.pageYOffset > window.outerHeight * 0.4) ? true : false; lastScrollTop = window.pageYOffset;"
         @click="window.scrollTo({top: 0, behavior: 'smooth'})"
         aria-label="Back to top"
-        class="fixed top-0 right-1/2 px-3 py-2 mt-10 -mr-[64px] text-white bg-light-blue/80 hover:bg-light-blue hover:text-white duration-500 hover:shadow-lg transition-all focus:outline-none cursor-pointer shadow rounded-2xl">
+        class="fixed top-0 right-1/2 px-3 py-2 mt-10 -mr-[64px] text-white bg-light-blue/80 hover:bg-light-blue hover:text-white hover:shadow-lg transition-all focus:outline-none cursor-pointer shadow-lg rounded-2xl">
         {% heroicon_mini "arrow-long-up" class="inline align-text-bottom" size=18 aria_hidden=true %} Back to top
     </button>
 </template>

--- a/hypha/templates/base-apply.html
+++ b/hypha/templates/base-apply.html
@@ -199,6 +199,8 @@
 
         <footer class="footer"></footer>
 
+        {% #scroll-to-top %}
+
         {% cookie_banner %}
 
         <script src="{% static 'js/main.js' %}"></script>

--- a/hypha/templates/base-apply.html
+++ b/hypha/templates/base-apply.html
@@ -199,7 +199,9 @@
 
         <footer class="footer"></footer>
 
-        {% #scroll-to-top %}
+        {% block scroll_to_top %}
+            {% #scroll-to-top %}
+        {% endblock scroll_to_top %}
 
         {% cookie_banner %}
 


### PR DESCRIPTION
Adds a scroll to top button to all the pages, it shows only if the user scroll past a decent screen size. It's put on the center top so that it's easily accessible. 

**Edit:** Show only when the user is scrolling towards the top.

![Screenshot 2023-11-27 at 5  42 39@2x](https://github.com/HyphaApp/hypha/assets/236356/22ae31da-1454-426d-a638-80215a5eb540)


closes #3642 