### PR TITLE
Update django-bleech to 3.1.0 remove bleach

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -3,7 +3,6 @@ scout-apm==2.26.1
 sentry-sdk==1.16.0
 
 # Production dependencies
-bleach==5.0.0
 Babel==2.13.1
 boto3==1.28.82
 celery==5.2.7
@@ -11,7 +10,7 @@ click==8.1.7
 dj-database-url==2.1.0
 django-anymail==10.2
 django-basic-auth-ip-whitelist==0.5
-django-bleach==3.0.1
+django-bleach==3.1.0
 django-countries==7.5.1
 django-elevate==2.0.3
 django-extensions==3.2.3


### PR DESCRIPTION
Bleach==5.0.1 is installed as part of django-bleech dependency.