### PR TITLE
Remove unused tomd from dependency

### DIFF
--- a/hypha/apply/funds/templatetags/markdown_tags.py
+++ b/hypha/apply/funds/templatetags/markdown_tags.py
@@ -1,4 +1,3 @@
-import tomd
 from django import template
 
 from hypha.core.utils import markdown_to_html
@@ -9,11 +8,3 @@ register = template.Library()
 @register.filter
 def markdown(value):
     return markdown_to_html(value)
-
-
-@register.filter
-def to_markdown(value):
-    # pass through markdown to ensure comment is a
-    # fully formed HTML block
-    value = markdown_to_html(value)
-    return tomd.convert(value)

--- a/requirements.txt
+++ b/requirements.txt
@@ -55,7 +55,6 @@ qrcode==7.4.2
 reportlab==3.6.13
 social_auth_app_django==5.0.0
 tablib==3.5.0
-tomd==0.1.3
 wagtail-cache==2.3.0
 wagtail-purge==0.3.0
 wagtail==5.1.3


### PR DESCRIPTION
IT's use by to_markdown template tag, which is not in use anywhere in
the codebass. Removing this as it's no longer used
