### PR TITLE
Remove dependency of invoice delete on PROJECT_ENABLED Flag

### DIFF
--- a/hypha/apply/projects/models/project.py
+++ b/hypha/apply/projects/models/project.py
@@ -388,9 +388,7 @@ class Project(BaseStreamForm, AccessFormData, models.Model):
         return False
 
     def get_absolute_url(self):
-        if settings.PROJECTS_ENABLED:
-            return reverse("apply:projects:detail", args=[self.id])
-        return "#"
+        return reverse("apply:projects:detail", args=[self.id])
 
     @property
     def can_make_approval(self):


### PR DESCRIPTION
If the PROJECT_ENABLED=False then the invoice should not be created at
the first place. But somehow at some point projects where enabled and
there are project and invoices in the system. The system should function
as expected compared to lacking functionality in/between.

This PR remove the PROJECT_ENABLED check on the project's
get_absolute_url, which is used while deleting invoices or potentially
at the other places.

closes #3663
