### PR TITLE
Remove public site from management commands

### DIFF
--- a/docker/entrypoint.dev.sh
+++ b/docker/entrypoint.dev.sh
@@ -8,9 +8,9 @@ npm run dev:build
 python3 manage.py createcachetable
 #python3 manage.py collectstatic --noinput --verbosity=0
 python3 manage.py migrate
-python3 manage.py wagtailsiteupdate hypha.test apply.hypha.test 8090
+python3 manage.py wagtailsiteupdate apply.hypha.test 8090
 
 # Start gunicorn server.
-gunicorn hypha.wsgi:application --env DJANGO_SETTINGS_MODULE=hypha.settings.dev --reload  --bind 0.0.0.0:9001
+gunicorn hypha.wsgi:application --env DJANGO_SETTINGS_MODULE=hypha.settings.dev --threads 3 --reload --bind 0.0.0.0:9001
 
 exec "$@"

--- a/hypha/apply/home/migrations/0002_add_apply_homepage.py
+++ b/hypha/apply/home/migrations/0002_add_apply_homepage.py
@@ -29,7 +29,7 @@ def create_homepage(apps, schema_editor):
 
     # Create a site with the new homepage set as the root
     Site.objects.create(
-        hostname="apply.localhost", root_page=applyhomepage, is_default_site=False
+        id=2, hostname="apply.localhost", root_page=applyhomepage, is_default_site=False
     )
 
 

--- a/hypha/core/management/commands/initialize.py
+++ b/hypha/core/management/commands/initialize.py
@@ -16,9 +16,6 @@ class Command(BaseCommand):
             "Provide the details below to initialize Hypha. Press enter to keep the default value.\n"
         )
 
-        PUBLIC_SITE_DOMAIN = click.prompt(
-            "Domain of public site ", default="hypha.test"
-        )
         APPLY_SITE_DOMAIN = click.prompt(
             "Domain of apply site ", default="apply.hypha.test"
         )
@@ -42,19 +39,10 @@ class Command(BaseCommand):
             f">>> Created superuser with email {SUPER_ADMIN_EMAIL}.", fg="green"
         )
 
-        # Set site port and domain
-        click.secho(
-            f">>> Set public site to {PUBLIC_SITE_DOMAIN}:{SITE_PORT}", fg="green"
-        )
-        site_public = Site.objects.get(id=2)
-        site_public.hostname = PUBLIC_SITE_DOMAIN
-        site_public.port = SITE_PORT
-        site_public.save()
-
         click.secho(
             f">>> Set apply site to {APPLY_SITE_DOMAIN}:{SITE_PORT}", fg="green"
         )
-        site_apply = Site.objects.get(id=3)
+        site_apply = Site.objects.get(id=2)
         site_apply.hostname = APPLY_SITE_DOMAIN
         site_apply.port = SITE_PORT
         site_apply.save()

--- a/hypha/core/management/commands/wagtailsiteupdate.py
+++ b/hypha/core/management/commands/wagtailsiteupdate.py
@@ -7,7 +7,6 @@ class Command(BaseCommand):
     help = "Wagtail site update script. Requires a public hostname, a apply hostname and a port number in that order."
 
     def add_arguments(self, parser):
-        parser.add_argument("public", type=str, help="Hostname for the public site.")
         parser.add_argument("apply", type=str, help="Hostname for the apply site.")
         parser.add_argument("port", type=int, help="Port to use for all sites.")
 
@@ -18,11 +17,6 @@ class Command(BaseCommand):
         site_apply.port = options["port"]
         site_apply.save()
 
-        site_public = Site.objects.get(id=3)
-        site_public.hostname = options["public"]
-        site_public.port = options["port"]
-        site_public.save()
-
         self.stdout.write(
-            f"Updated the public site to {options['public']}:{options['port']} and the apply site to {options['apply']}:{options['port']}."
+            f"Updated the apply site to {options['apply']}:{options['port']}."
         )

--- a/hypha/core/management/commands/wagtailsiteupdate.py
+++ b/hypha/core/management/commands/wagtailsiteupdate.py
@@ -4,7 +4,7 @@ from wagtail.models import Site
 
 
 class Command(BaseCommand):
-    help = "Wagtail site update script. Requires a public hostname, a apply hostname and a port number in that order."
+    help = "Wagtail site update script. Requires an apply hostname and a port number in that order."
 
     def add_arguments(self, parser):
         parser.add_argument("apply", type=str, help="Hostname for the apply site.")

--- a/hypha/public/home/migrations/0002_create_homepage.py
+++ b/hypha/public/home/migrations/0002_create_homepage.py
@@ -32,7 +32,9 @@ def create_homepage(apps, schema_editor):
     )
 
     # Create a site with the new homepage set as the root
-    Site.objects.create(hostname="localhost", root_page=homepage, is_default_site=True)
+    Site.objects.create(
+        id=3, hostname="localhost", root_page=homepage, is_default_site=True
+    )
 
 
 class Migration(migrations.Migration):


### PR DESCRIPTION
This PR will remove the public site from management commands and fix the IDs that are used when the apply site is used to reflect that of production.