### PR TITLE
z-index fixes to ensure the status bar items aren't weirdly overlayed

### DIFF
--- a/hypha/static_src/src/sass/apply/components/_messages.scss
+++ b/hypha/static_src/src/sass/apply/components/_messages.scss
@@ -3,7 +3,7 @@
     top: 0;
     left: 0;
     right: 0;
-    z-index: 25;
+    z-index: 30;
     pointer-events: none;
 
     &__actions {

--- a/hypha/static_src/src/sass/apply/components/_status-bar.scss
+++ b/hypha/static_src/src/sass/apply/components/_status-bar.scss
@@ -35,7 +35,7 @@
         position: absolute;
         top: -10px;
         left: 0;
-        z-index: 30;
+        z-index: 4;
         display: none;
         width: 20px;
         height: 20px;
@@ -136,7 +136,7 @@
         // tooltip hover area - not visibile
         position: absolute;
         top: -10px;
-        z-index: 100;
+        z-index: 4;
         width: 20px;
         height: 20px;
         border-radius: 50%;


### PR DESCRIPTION
Fixes #3700

Quick fix to dial back the status bar items' z-index, and increase the debug message pop-ups to ensure they're on top.

**Before**:
![Screenshot 2023-12-21 at 09 17 19](https://github.com/HyphaApp/hypha/assets/145372368/cf1e2457-7b2f-41af-904d-5b5aa52b1365)

**After**:
![Screenshot 2023-12-21 at 09 35 25](https://github.com/HyphaApp/hypha/assets/145372368/8f90f7db-8b52-4dbc-9914-b80eab1b6e0f)
