### PR TITLE
Enabled validation of determination draft saving

### DIFF
--- a/hypha/apply/determinations/forms.py
+++ b/hypha/apply/determinations/forms.py
@@ -520,8 +520,11 @@ class DeterminationModelForm(StreamBaseForm, forms.ModelForm, metaclass=MixedMet
             self.fields[field].disabled = True
 
         if self.draft_button_name in self.data:
-            for field in self.fields.values():
-                field.required = False
+            # A determination must be set for saving a draft,
+            # this forces outcome to be validated.
+            unreq_fields = [name for name in self.fields if name != "outcome"]
+            for name in unreq_fields:
+                self.fields[name].required = False
 
         if edit:
             self.fields.pop("outcome")
@@ -548,8 +551,8 @@ class DeterminationModelForm(StreamBaseForm, forms.ModelForm, metaclass=MixedMet
             self.instance.outcome = int(
                 self.cleaned_data[self.instance.determination_field.id]
             )
-            # Need to catch KeyError as outcome field would not exist in case of edit.
         except KeyError:
+            # Need to catch KeyError as outcome field would not exist in case of edit.
             pass
         self.instance.is_draft = self.draft_button_name in self.data
         self.instance.form_data = self.cleaned_data["form_data"]

--- a/hypha/apply/determinations/templates/determinations/base_determination_form.html
+++ b/hypha/apply/determinations/templates/determinations/base_determination_form.html
@@ -39,7 +39,7 @@
                 {% block form_buttons %}
                     <div class="form__group">
                         {% if form.draft_button_name %}
-                            <button class="button button--submit button--white" type="submit" name="{{ form.draft_button_name }}" formnovalidate>{% trans "Save draft" %}</button>
+                            <button class="button button--submit button--white" type="submit" name="{{ form.draft_button_name }}">{% trans "Save draft" %}</button>
                         {% endif %}
                         <button class="button button--submit button--primary" :disabled="isFormSubmitting" type="submit" name="submit">{% trans "Submit" %}</button>
                     </div>


### PR DESCRIPTION
Fixes #3706

A draft determination shouldn't be able to be saved without setting an outcome, as there isn't a valid state to store it in (and if a determination is being drafted, an outcome has been reached). This enforces partial form validation when a determination draft is saved to ensure an outcome is set.

## Test Steps

- [ ] Ensure user is a *Staff* role
- [ ] Create or navigate to a Concept Note (ensure there is no determination made)
- [ ] In the panel on the right, select `Add Determination`
- [ ] Leave the `Determination` dropdown at `-- No determination selected --`
- [ ] Attempt to select "Save draft" at the bottom of the page
- [ ] Confirm `Please select an item in the list` is shown at the dropdown prompt, not allowing for a draft to be saved. 
