### PR TITLE
docs: update fetch-depth=0 and update copyright year

### DIFF
--- a/.github/workflows/deploy-docs.yml
+++ b/.github/workflows/deploy-docs.yml
@@ -18,6 +18,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
 
       - name: Deploy docs
         uses: mhausenblas/mkdocs-deploy-gh-pages@master

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,7 +1,7 @@
 site_name: Hypha Documentation
 site_url: https://docs.hypha.app/
 site_description: "Documentation for Hypha, an open source submission management platform."
-copyright: Copyright &copy; 2018 - 2023 - Open Technology Fund
+copyright: Copyright &copy; 2018 - 2024 - Open Technology Fund
 repo_name: HyphaApp/hypha
 repo_url: https://github.com/HyphaApp/hypha
 edit_uri: edit/main/docs/


### PR DESCRIPTION
Fetch the full-history to that the last edited information is displayed
correctly for all the pages. Right now, all the pages get the last build
time.

Also, update the copyright year from 2023 to 2024 (Easy way to triggers a build for docs)
