### PR TITLE
Remove public "search promotions" app

### DIFF
--- a/hypha/settings/django.py
+++ b/hypha/settings/django.py
@@ -37,7 +37,6 @@ INSTALLED_APPS = [
     "django_web_components",
     "wagtail.contrib.modeladmin",
     "wagtail.contrib.settings",
-    "wagtail.contrib.search_promotions",
     "wagtail.contrib.forms",
     "wagtail.contrib.redirects",
     "wagtail.embeds",


### PR DESCRIPTION
This app is used for improving the ranking of the pages in the wagtail search, as the
public site with all it's pages are being remove this app of no use in
hypha now.


https://docs.wagtail.org/en/stable/reference/contrib/searchpromotions.html