### PR TITLE
Improve rtl support with modern css

### DIFF
--- a/hypha/apply/activity/templates/activity/include/listing_base.html
+++ b/hypha/apply/activity/templates/activity/include/listing_base.html
@@ -4,7 +4,7 @@
     <div class="feed__pre-content hidden lg:block">
         <p class="feed__label lg:py-2 feed__label--{{ activity.type }}">
             {% if  activity.type == 'comment' %}
-                {% heroicon_mini "chat-bubble-left" class="inline align-text-bottom mr-2" aria_hidden=true %}
+                {% heroicon_mini "chat-bubble-left" class="inline align-text-bottom me-2" aria_hidden=true %}
             {% else %}
                 {{ activity.type|capfirst }}
             {% endif %}
@@ -12,7 +12,7 @@
     </div>
     <div class="feed__content js-feed-content">
         <div class="feed__meta js-feed-meta py-2 bg-slate-50 shadow-sm">
-            <p class="feed__meta-item pl-3">
+            <p class="feed__meta-item ps-3">
                 <span>{{ activity|display_author:request.user }}</span>
                 <relative-time class="text-fg-muted text-sm" data-tippy-content="{{ activity.timestamp|date:"SHORT_DATETIME_FORMAT" }}" datetime={{ activity.timestamp|date:"c" }}>{{ activity.timestamp|date:"SHORT_DATETIME_FORMAT" }}</relative-time>
                 {% if activity.edited %}
@@ -57,7 +57,7 @@
                         }
                     }
                 </style>
-                <div class="js-edit-block pr-3" aria-live="polite"></div>
+                <div class="js-edit-block pe-3" aria-live="polite"></div>
             {% else %}
                 <div class="px-3 prose">
                     {{ activity|display_for:request.user|submission_links|markdown|bleach }}

--- a/hypha/apply/dashboard/templates/dashboard/applicant_dashboard.html
+++ b/hypha/apply/dashboard/templates/dashboard/applicant_dashboard.html
@@ -46,7 +46,7 @@
                 {% for submission in my_active_submissions %}
                     <div class="wrapper wrapper--status-bar-outer">
                         <div class="wrapper wrapper--status-bar-inner">
-                            <div class="mt-5 ml-4 lg:max-w-[30%]">
+                            <div class="mt-5 ms-4 lg:max-w-[30%]">
                                 <h4 class="heading mb-2 font-bold line-clamp-3 hover:line-clamp-none"><a class="link" href="{% url 'funds:submissions:detail' submission.id %}">{{ submission.title }}</a></h4>
                                 <p class="m-0 text-gray-400">
                                     {% if submission.is_draft %}
@@ -60,7 +60,7 @@
                             {% status_bar submission.workflow submission.phase request.user css_class="status-bar--small" %}
                         </div>
                         {% if request.user|has_edit_perm:submission %}
-                            <a class="button button--primary ml-4" href="{% url 'funds:submissions:edit' submission.id %}">
+                            <a class="button button--primary ms-4" href="{% url 'funds:submissions:edit' submission.id %}">
                                 {% if submission.status == 'draft_proposal' %}
                                     {% trans "Start your" %} {{ submission.stage }} {% trans "application" %}
                                 {% else %}
@@ -83,7 +83,7 @@
                 {% for project in active_projects.data %}
                     <div class="wrapper wrapper--status-bar-outer">
                         <div class="wrapper wrapper--status-bar-inner">
-                            <div class="mt-5 ml-4 lg:max-w-[30%]">
+                            <div class="mt-5 ms-4 lg:max-w-[30%]">
                                 <h4 class="heading mb-2 font-bold line-clamp-3 hover:line-clamp-none"><a class="link" href="{% url 'apply:projects:detail' project.id %}">{{ project.title }}</a></h4>
                                 <p class="m-0 text-gray-400">{% trans "Project start date: " %} {{ project.created_at.date }}</p>
                             </div>
@@ -103,8 +103,8 @@
                 </div>
                 {% for invoice in active_invoices.data %}
                     <div class="wrapper wrapper--status-bar-outer">
-                        <div class="wrapper wrapper--status-bar-inner pl-4 pr-4">
-                            <div class="max-w-[33%] w-full text-left my-auto">
+                        <div class="wrapper wrapper--status-bar-inner ps-4 pe-4">
+                            <div class="max-w-[33%] w-full text-start my-auto">
                                 <h4 class="heading heading--no-margin font-bold"><a class="link" href="{{ invoice.get_absolute_url }}">
                                     {% if invoice.invoice_number %}{{ invoice.invoice_number }}{% else %}{{ invoice.vendor_document_number }}{% endif %}
                                 </a></h4>
@@ -116,7 +116,7 @@
                             <div class="max-w-[33%] w-full flex my-auto">
                                 {% display_invoice_table_status_for_user invoice.status request.user as invoice_status %}
                                 <div class="w-full flex-1"></div>
-                                <div class="max-w-fit w-full text-right">
+                                <div class="max-w-fit w-full text-end">
                                     <p class="{{ invoice_status|invoice_status_bg_color }} text-base py-2 px-3 {{ invoice_status|invoice_status_fg_color }}">{{ invoice_status }}</p>
                                 </div>
                             </div>

--- a/hypha/apply/dashboard/templates/dashboard/community_dashboard.html
+++ b/hypha/apply/dashboard/templates/dashboard/community_dashboard.html
@@ -21,7 +21,7 @@
 
         <div class="wrapper wrapper--bottom-space">
             <h2 class="text-xl mb-2">
-                {% trans "Community review submissions" %} <span class="bg-blue-100 text-blue-800 text-sm font-medium mr-2 px-2.5 py-0.5 rounded">{{ my_community_review_count }}</span>
+                {% trans "Community review submissions" %} <span class="bg-blue-100 text-blue-800 text-sm font-medium me-2 px-2.5 py-0.5 rounded">{{ my_community_review_count }}</span>
             </h2>
 
             {% if my_community_review.data %}

--- a/hypha/apply/dashboard/templates/dashboard/includes/submissions-waiting-for-review.html
+++ b/hypha/apply/dashboard/templates/dashboard/includes/submissions-waiting-for-review.html
@@ -2,7 +2,7 @@
 {% load i18n %}
 
 <h2 class="text-xl mb-2">
-    {% trans "Submissions waiting for your review" %} <span class="bg-blue-100 text-blue-800 text-sm font-medium mr-2 px-2.5 py-0.5 rounded">{{ in_review_count }}</span>
+    {% trans "Submissions waiting for your review" %} <span class="bg-blue-100 text-blue-800 text-sm font-medium me-2 px-2.5 py-0.5 rounded">{{ in_review_count }}</span>
 </h2>
 
 {% if my_review.data %}

--- a/hypha/apply/dashboard/templates/dashboard/partner_dashboard.html
+++ b/hypha/apply/dashboard/templates/dashboard/partner_dashboard.html
@@ -17,7 +17,7 @@
 
         <div class="wrapper wrapper--bottom-space">
             <h4 class="heading heading--normal">
-                {% trans "You are the partner of these submissions" %} <span class="bg-blue-100 text-blue-800 text-sm font-medium mr-2 px-2.5 py-0.5 rounded dark:bg-blue-900 dark:text-blue-300">{{ partner_submissions_count }}</span>
+                {% trans "You are the partner of these submissions" %} <span class="bg-blue-100 text-blue-800 text-sm font-medium me-2 px-2.5 py-0.5 rounded dark:bg-blue-900 dark:text-blue-300">{{ partner_submissions_count }}</span>
             </h4>
 
             {% if partner_submissions.data %}

--- a/hypha/apply/determinations/templates/determinations/determination_detail.html
+++ b/hypha/apply/determinations/templates/determinations/determination_detail.html
@@ -24,7 +24,7 @@
         {% if request.user.is_apply_staff %}
             <a class="text-blue-500 hover:underline" href="{% url 'apply:submissions:determinations:edit' submission_pk=determination.submission.id pk=determination.id %}">
                 <span class="whitespace-nowrap">
-                    {% trans "Edit" %}{% heroicon_mini "pencil-square" size=18 class="inline ml-1 align-text-bottom" aria_hidden=true %}
+                    {% trans "Edit" %}{% heroicon_mini "pencil-square" size=18 class="inline ms-1 align-text-bottom" aria_hidden=true %}
                 </span>
             </a>
         {% endif %}

--- a/hypha/apply/funds/templates/funds/includes/submission-list-item.html
+++ b/hypha/apply/funds/templates/funds/includes/submission-list-item.html
@@ -4,7 +4,7 @@
 <div class="relative border-t md:flex flex-wrap md:flex-nowrap hover:bg-gray-100 w-full px-2">
 
     {% comment %} Select {% endcomment %}
-    <label class="hidden pl-1 py-2.5 sm:inline-flex">
+    <label class="hidden ps-1 py-2.5 sm:inline-flex">
         <input id="submission-{{ s.id }}"
                type="checkbox"
                value="{{ s.id }}"
@@ -16,7 +16,7 @@
     </label>
 
     {% comment %} Screening, and Archived icons {% endcomment %}
-    <span class="pt-2 sm:pl-2 select-none inline-block" tabindex="-1">
+    <span class="pt-2 sm:ps-2 select-none inline-block" tabindex="-1">
         {% if s.is_archive %}
             {% trans "Archived Submission" as text_archived %}
             {% heroicon_outline "lock-closed" aria_hidden="true" size=21 class="inline stroke-red-800 stroke-1.5 -mt-1 align-text-bottom" data_tippy_placement='right' data_tippy_content=text_archived data_tippy_delay=200 %}
@@ -50,7 +50,7 @@
                 hx-push-url="true"
                 hx-swap="outerHTML"
                 href="{% modify_query "page" status=s.phase.display_slug %}"
-                class="{{ s.phase.bg_color }} hover:opacity-70 transition-opacity rounded-full whitespace-nowrap inline-block ml-1 px-2 pt-0.5 pb-1 text-xs font-medium text-gray-800"
+                class="{{ s.phase.bg_color }} hover:opacity-70 transition-opacity rounded-full whitespace-nowrap inline-block ms-1 px-2 pt-0.5 pb-1 text-xs font-medium text-gray-800"
             >{{ s.phase.display_name }}</a>
 
             {% for meta_term in s.get_assigned_meta_terms %}
@@ -62,7 +62,7 @@
                     hx-swap="outerHTML"
                     data-tippy-content="Meta Term: {{meta_term.name}}"
                     data-tippy-placement="top"
-                    class="hover:opacity-70 transition-opacity rounded-full whitespace-nowrap inline-block ml-1 px-2 pt-0.5 pb-1 text-xs font-medium text-white bg-blue-600"
+                    class="hover:opacity-70 transition-opacity rounded-full whitespace-nowrap inline-block ms-1 px-2 pt-0.5 pb-1 text-xs font-medium text-white bg-blue-600"
                 >{{meta_term.name}}</a>
             {% endfor %}
         </span>
@@ -143,7 +143,7 @@
                 </span>
 
                 <div
-                    class="review-hovercard bg-white border z-10 bottom-6 -right-1/2 md:-right-4 w-64 shadow-lg p-2 rounded  absolute hidden group-hover:block"
+                    class="review-hovercard bg-white border z-10 bottom-6 -end-1/2 md:-end-4 w-64 shadow-lg p-2 rounded  absolute hidden group-hover:block"
                 >
                     {% comment %} pre-loading animation {% endcomment %}
                     <div class="animate-pulse min-h-30">

--- a/hypha/apply/funds/templates/submissions/all.html
+++ b/hypha/apply/funds/templates/submissions/all.html
@@ -33,7 +33,7 @@
                 hx-push-url="true"
                 hx-target="#main"
                 hx-swap="outerHTML"
-                class="flex {% if request.GET.query == "lead:@me" %}pl-2 font-medium bg-gray-100{% else %}pl-8 font-normal{% endif %} pr-3 py-2 text-gray-800 border-b items-center hover:bg-gray-100 focus:bg-gray-100">
+                class="flex {% if request.GET.query == "lead:@me" %}ps-2 font-medium bg-gray-100{% else %}ps-8 font-normal{% endif %} pe-3 py-2 text-gray-800 border-b items-center hover:bg-gray-100 focus:bg-gray-100">
                 {% if request.GET.query == "lead:@me" %}
                     {% heroicon_mini "check" aria_hidden="true" size=16 class="stroke-2 me-1" %}
                 {% endif %}
@@ -45,7 +45,7 @@
                 hx-push-url="true"
                 hx-target="#main"
                 hx-swap="outerHTML"
-                class="flex {% if request.GET.query == "flagged:@me" %}pl-2 font-medium bg-gray-100{% else %}pl-8 font-normal{% endif %} pr-3 py-2 text-gray-800 border-b items-center hover:bg-gray-100 focus:bg-gray-100">
+                class="flex {% if request.GET.query == "flagged:@me" %}ps-2 font-medium bg-gray-100{% else %}ps-8 font-normal{% endif %} pe-3 py-2 text-gray-800 border-b items-center hover:bg-gray-100 focus:bg-gray-100">
                 {% if request.GET.query == "flagged:@me" %}
                     {% heroicon_mini "check" aria_hidden="true" size=16 class="stroke-2 me-1" %}
                 {% endif %}
@@ -57,7 +57,7 @@
                 hx-push-url="true"
                 hx-target="#main"
                 hx-swap="outerHTML"
-                class="flex {% if request.GET.query == "reviewer:@me" %}pl-2 font-medium bg-gray-100{% else %}pl-8 font-normal{% endif %} pr-3 py-2 text-gray-800 border-b items-center hover:bg-gray-100 focus:bg-gray-100">
+                class="flex {% if request.GET.query == "reviewer:@me" %}ps-2 font-medium bg-gray-100{% else %}ps-8 font-normal{% endif %} pe-3 py-2 text-gray-800 border-b items-center hover:bg-gray-100 focus:bg-gray-100">
                 {% if request.GET.query == "reviewer:@me" %}
                     {% heroicon_mini "check" aria_hidden="true" size=16 class="stroke-2 me-1" %}
                 {% endif %}
@@ -66,13 +66,13 @@
         {% enddropdown_menu %}
 
         <label class="relative flex-auto">
-            <span class="absolute inset-y-0 left-0 flex items-center pl-3 pointer-events-none">
+            <span class="absolute inset-y-0 start-0 flex items-center ps-3 pointer-events-none">
                 {% heroicon_mini "magnifying-glass" size=20 class="text-fg-muted" %}
             </span>
             <input
                 type="search"
                 id="search-navbar"
-                class="block w-full p-2 pl-10 text-sm text-gray-900 border border-gray-300 rounded-sm bg-gray-50 focus:ring-blue-500 focus:border-blue-500"
+                class="block w-full p-2 ps-10 text-sm text-gray-900 border border-gray-300 rounded-sm bg-gray-50 focus:ring-blue-500 focus:border-blue-500"
                 placeholder="Search..."
                 name="query"
                 hx-trigger="search"
@@ -100,9 +100,9 @@
                            hx-target="#main"
                     >
                     <div
-                        class="w-11 h-6 bg-gray-200 peer-focus:outline-none peer-focus:ring-4 peer-focus:ring-blue-300 dark:peer-focus:ring-blue-800 rounded-full peer dark:bg-gray-700 peer-checked:after:translate-x-full peer-checked:after:border-white after:content-[''] after:absolute after:top-[2px] after:left-[2px] after:bg-white after:border-gray-300 after:border after:rounded-full after:h-5 after:w-5 after:transition-all dark:border-gray-600 peer-checked:bg-blue-600">
+                        class="w-11 h-6 bg-gray-200 peer-focus:outline-none peer-focus:ring-4 peer-focus:ring-blue-300 dark:peer-focus:ring-blue-800 rounded-full peer dark:bg-gray-700 peer-checked:after:translate-x-full peer-checked:after:border-white after:content-[''] after:absolute after:top-[2px] after:start-[2px] after:bg-white after:border-gray-300 after:border after:rounded-full after:h-5 after:w-5 after:transition-all dark:border-gray-600 peer-checked:bg-blue-600">
                     </div>
-                    <span class="ml-3 text-sm font-medium text-gray-600">Archived</span>
+                    <span class="ms-3 text-sm font-medium text-gray-600">Archived</span>
                 </label>
             </span>
         {% endif %}
@@ -120,97 +120,97 @@
                 href="./"
                 hx-get="./"
                 title="Remove all Filters"
-                class="inline-flex items-center px-2 py-1 mr-2 text-xs font-medium text-blue-400 bg-blue-100 rounded hover:bg-blue-200 hover:text-blue-900"
+                class="inline-flex items-center px-2 py-1 me-2 text-xs font-medium text-blue-400 bg-blue-100 rounded hover:bg-blue-200 hover:text-blue-900"
             >
                 {% heroicon_mini "x-mark" aria_hidden="true" fill="currentColor" %}
                 <span class="sr-only">Remove all filters</span>
             </a>
 
             {% if selected_statuses %}
-                <span class="inline-flex items-center px-2 py-1 mr-2 text-xs select-none font-medium text-blue-800 bg-blue-100 rounded">
+                <span class="inline-flex items-center px-2 py-1 me-2 text-xs select-none font-medium text-blue-800 bg-blue-100 rounded">
                     status:{% for s in selected_statuses %}{{ s }}{% endfor %}
-                    <a href="{% remove_from_query "status" %}" role="button" class="inline-flex items-center p-0.5 ml-1 text-xs text-blue-400 bg-transparent rounded-sm hover:bg-blue-200 hover:text-blue-900" aria-label="Remove">
+                    <a href="{% remove_from_query "status" %}" role="button" class="inline-flex items-center p-0.5 ms-1 text-xs text-blue-400 bg-transparent rounded-sm hover:bg-blue-200 hover:text-blue-900" aria-label="Remove">
                         {% heroicon_mini "x-mark" aria_hidden="true" fill="currentColor" %}
                         <span class="sr-only">Remove Status Filter</span>
                     </a>
                 </span>
             {% endif %}
             {% if selected_fund_objects %}
-                <span class="inline-flex items-center px-2 py-1 mr-2 text-xs select-none font-medium text-blue-800 bg-blue-100 rounded">
+                <span class="inline-flex items-center px-2 py-1 me-2 text-xs select-none font-medium text-blue-800 bg-blue-100 rounded">
                     fund:{% for s in selected_fund_objects %}"{{ s }}"{% endfor %}
-                    <a href="{% remove_from_query "fund" %}" role="button" class="inline-flex items-center p-0.5 ml-1 text-xs text-blue-400 bg-transparent rounded-sm hover:bg-blue-200 hover:text-blue-900 dark:hover:bg-blue-800 dark:hover:text-blue-300" aria-label="Remove">
+                    <a href="{% remove_from_query "fund" %}" role="button" class="inline-flex items-center p-0.5 ms-1 text-xs text-blue-400 bg-transparent rounded-sm hover:bg-blue-200 hover:text-blue-900 dark:hover:bg-blue-800 dark:hover:text-blue-300" aria-label="Remove">
                         {% heroicon_mini "x-mark" aria_hidden="true" fill="currentColor" %}
                         <span class="sr-only">Remove Fund Filter</span>
                     </a>
                 </span>
             {% endif %}
             {% if selected_round_objects %}
-                <span class="inline-flex items-center px-2 py-1 mr-2 text-xs select-none font-medium text-blue-800 bg-blue-100 rounded">
+                <span class="inline-flex items-center px-2 py-1 me-2 text-xs select-none font-medium text-blue-800 bg-blue-100 rounded">
                     round:{% for s in selected_round_objects %}"{{ s }}"{% endfor %}
-                    <a href="{% remove_from_query "round" %}" role="button" class="inline-flex items-center p-0.5 ml-1 text-xs text-blue-400 bg-transparent rounded-sm hover:bg-blue-200 hover:text-blue-900 dark:hover:bg-blue-800 dark:hover:text-blue-300" aria-label="Remove">
+                    <a href="{% remove_from_query "round" %}" role="button" class="inline-flex items-center p-0.5 ms-1 text-xs text-blue-400 bg-transparent rounded-sm hover:bg-blue-200 hover:text-blue-900 dark:hover:bg-blue-800 dark:hover:text-blue-300" aria-label="Remove">
                         {% heroicon_mini "x-mark" aria_hidden="true" fill="currentColor" %}
                         <span class="sr-only">Remove Round Filter</span>
                     </a>
                 </span>
             {% endif %}
             {% if selected_leads %}
-                <span class="inline-flex items-center px-2 py-1 mr-2 text-xs select-none font-medium text-blue-800 bg-blue-100 rounded">
+                <span class="inline-flex items-center px-2 py-1 me-2 text-xs select-none font-medium text-blue-800 bg-blue-100 rounded">
                     Lead:{% for s in selected_leads %}{{ s }}{% endfor %}
-                    <a href="{% remove_from_query "lead" %}" role="button" class="inline-flex items-center p-0.5 ml-1 text-xs text-blue-400 bg-transparent rounded-sm hover:bg-blue-200 hover:text-blue-900 dark:hover:bg-blue-800 dark:hover:text-blue-300" aria-label="Remove">
+                    <a href="{% remove_from_query "lead" %}" role="button" class="inline-flex items-center p-0.5 ms-1 text-xs text-blue-400 bg-transparent rounded-sm hover:bg-blue-200 hover:text-blue-900 dark:hover:bg-blue-800 dark:hover:text-blue-300" aria-label="Remove">
                         {% heroicon_mini "x-mark" aria_hidden="true" fill="currentColor" %}
                         <span class="sr-only">Remove Leads Filter</span>
                     </a>
                 </span>
             {% endif %}
             {% if selected_applicants %}
-                <span class="inline-flex items-center px-2 py-1 mr-2 text-xs select-none font-medium text-blue-800 bg-blue-100 rounded">
+                <span class="inline-flex items-center px-2 py-1 me-2 text-xs select-none font-medium text-blue-800 bg-blue-100 rounded">
                     Applicant:{% for s in selected_applicants %}{{ s }}{% endfor %}
-                    <a href="{% remove_from_query "applicants" %}" role="button" class="inline-flex items-center p-0.5 ml-1 text-xs text-blue-400 bg-transparent rounded-sm hover:bg-blue-200 hover:text-blue-900 dark:hover:bg-blue-800 dark:hover:text-blue-300" aria-label="Remove">
+                    <a href="{% remove_from_query "applicants" %}" role="button" class="inline-flex items-center p-0.5 ms-1 text-xs text-blue-400 bg-transparent rounded-sm hover:bg-blue-200 hover:text-blue-900 dark:hover:bg-blue-800 dark:hover:text-blue-300" aria-label="Remove">
                         {% heroicon_mini "x-mark" aria_hidden="true" fill="currentColor" %}
                         <span class="sr-only">Remove Applicant Filter</span>
                     </a>
                 </span>
             {% endif %}
             {% for s in selected_reviewers %}
-                <span class="inline-flex items-center px-2 py-1 mr-2 text-xs select-none font-medium text-blue-800 bg-blue-100 rounded">
+                <span class="inline-flex items-center px-2 py-1 me-2 text-xs select-none font-medium text-blue-800 bg-blue-100 rounded">
                     Reviewer:{{ s }}
-                    <a href="{% remove_from_query reviewers=s %}" role="button" class="inline-flex items-center p-0.5 ml-1 text-xs text-blue-400 bg-transparent rounded-sm hover:bg-blue-200 hover:text-blue-900 dark:hover:bg-blue-800 dark:hover:text-blue-300" aria-label="Remove">
+                    <a href="{% remove_from_query reviewers=s %}" role="button" class="inline-flex items-center p-0.5 ms-1 text-xs text-blue-400 bg-transparent rounded-sm hover:bg-blue-200 hover:text-blue-900 dark:hover:bg-blue-800 dark:hover:text-blue-300" aria-label="Remove">
                         {% heroicon_mini "x-mark" aria_hidden="true" fill="currentColor" %}
                         <span class="sr-only">Remove Reviewer filter</span>
                     </a>
                 </span>
             {% endfor %}
             {% for s in selected_meta_terms %}
-                <span class="inline-flex items-center px-2 py-1 mr-2 text-xs select-none font-medium text-blue-800 bg-blue-100 rounded">
+                <span class="inline-flex items-center px-2 py-1 me-2 text-xs select-none font-medium text-blue-800 bg-blue-100 rounded">
                     Meta Term:{{ s }}
-                    <a href="{% remove_from_query meta_terms=s %}" role="button" class="inline-flex items-center p-0.5 ml-1 text-xs text-blue-400 bg-transparent rounded-sm hover:bg-blue-200 hover:text-blue-900 dark:hover:bg-blue-800 dark:hover:text-blue-300" aria-label="Remove">
+                    <a href="{% remove_from_query meta_terms=s %}" role="button" class="inline-flex items-center p-0.5 ms-1 text-xs text-blue-400 bg-transparent rounded-sm hover:bg-blue-200 hover:text-blue-900 dark:hover:bg-blue-800 dark:hover:text-blue-300" aria-label="Remove">
                         {% heroicon_mini "x-mark" aria_hidden="true" fill="currentColor" %}
                         <span class="sr-only">Remove Meta Term filter</span>
                     </a>
                 </span>
             {% endfor %}
             {% for s in selected_category_options %}
-                <span class="inline-flex items-center px-2 py-1 mr-2 text-xs select-none font-medium text-blue-800 bg-blue-100 rounded">
+                <span class="inline-flex items-center px-2 py-1 me-2 text-xs select-none font-medium text-blue-800 bg-blue-100 rounded">
                     Category:{{ s }}
-                    <a href="{% remove_from_query category_options=s %}" role="button" class="inline-flex items-center p-0.5 ml-1 text-xs text-blue-400 bg-transparent rounded-sm hover:bg-blue-200 hover:text-blue-900 dark:hover:bg-blue-800 dark:hover:text-blue-300" aria-label="Remove">
+                    <a href="{% remove_from_query category_options=s %}" role="button" class="inline-flex items-center p-0.5 ms-1 text-xs text-blue-400 bg-transparent rounded-sm hover:bg-blue-200 hover:text-blue-900 dark:hover:bg-blue-800 dark:hover:text-blue-300" aria-label="Remove">
                         {% heroicon_mini "x-mark" aria_hidden="true" fill="currentColor" %}
                         <span class="sr-only">Remove category filter</span>
                     </a>
                 </span>
             {% endfor %}
             {% for s in selected_screening_statuses_objects %}
-                <span class="inline-flex items-center px-2 py-1 mr-2 text-xs select-none font-medium text-blue-800 bg-blue-100 rounded">
+                <span class="inline-flex items-center px-2 py-1 me-2 text-xs select-none font-medium text-blue-800 bg-blue-100 rounded">
                     screening:"{{ s.title }}"
-                    <a href="{% remove_from_query screening_statuses=s.slug %}" role="button" class="inline-flex items-center p-0.5 ml-1 text-xs text-blue-400 bg-transparent rounded-sm hover:bg-blue-200 hover:text-blue-900 dark:hover:bg-blue-800 dark:hover:text-blue-300" aria-label="Remove">
+                    <a href="{% remove_from_query screening_statuses=s.slug %}" role="button" class="inline-flex items-center p-0.5 ms-1 text-xs text-blue-400 bg-transparent rounded-sm hover:bg-blue-200 hover:text-blue-900 dark:hover:bg-blue-800 dark:hover:text-blue-300" aria-label="Remove">
                         {% heroicon_mini "x-mark" aria_hidden="true" fill="currentColor" %}
                         <span class="sr-only">Remove screening decisions filter</span>
                     </a>
                 </span>
             {% endfor %}
             {% if selected_sort %}
-                <span class="inline-flex items-center px-2 py-1 mr-2 text-xs select-none font-medium text-blue-800 bg-blue-100 rounded">
+                <span class="inline-flex items-center px-2 py-1 me-2 text-xs select-none font-medium text-blue-800 bg-blue-100 rounded">
                     sort:{{ selected_sort }}
-                    <a href="{% remove_from_query "sort" %}" role="button" class="inline-flex items-center p-0.5 ml-1 text-xs text-blue-400 bg-transparent rounded-sm hover:bg-blue-200 hover:text-blue-900 dark:hover:bg-blue-800 dark:hover:text-blue-300" aria-label="Remove">
+                    <a href="{% remove_from_query "sort" %}" role="button" class="inline-flex items-center p-0.5 ms-1 text-xs text-blue-400 bg-transparent rounded-sm hover:bg-blue-200 hover:text-blue-900 dark:hover:bg-blue-800 dark:hover:text-blue-300" aria-label="Remove">
                         {% heroicon_mini "x-mark" aria_hidden="true" fill="currentColor" %}
                         <span class="sr-only">Remove Sort filter</span>
                     </a>
@@ -276,15 +276,15 @@
                 <label
                     for="id_select_all"
                     x-show="!showSelectedSubmissions"
-                    class="ml-2">Select all</label>
-                <span x-cloak class="ml-2" x-show="showSelectedSubmissions"> <span x-text="selectedSubmissionCount"></span> selected</span>
+                    class="ms-2">Select all</label>
+                <span x-cloak class="ms-2" x-show="showSelectedSubmissions"> <span x-text="selectedSubmissionCount"></span> selected</span>
             </span>
 
             <nav x-show="!showSelectedSubmissions"
                  class="menu-filters flex flex-wrap gap-2 items-center"
             >
                 <div id="filterupdated" aria-label="Filter by Updated" class="flex items-center">
-                    <button class="flex cursor-pointer items-center justify-between w-full py-1 pl-2 pr-2 border md:pr-4 md:border-none font-medium text-gray-600 hover:bg-gray-50 md:hover:bg-transparent md:hover:text-blue-700 md:p-0">
+                    <button class="flex cursor-pointer items-center justify-between w-full py-1 ps-2 pe-2 border md:pe-4 md:border-none font-medium text-gray-600 hover:bg-gray-50 md:hover:bg-transparent md:hover:text-blue-700 md:p-0">
                         {% trans "Updated" %}
                         {% heroicon_mini "chevron-down" aria_hidden="true" width=18 height=18 class="hidden md:inline-block" %}
                     </button>
@@ -313,10 +313,10 @@
                                         href="{% modify_query "page" status=s.slug %}"
                                     {% endif %}
                                     role="menuitemradio" aria-checked="{{ s.selected }}"
-                                    class="flex {% if s.selected %}bg-gray-100 pl-2 font-medium{% else %}pl-8{% endif %} pr-3 py-2 text-gray-600 items-center hover:bg-gray-100 focus:bg-gray-100"
+                                    class="flex {% if s.selected %}bg-gray-100 ps-2 font-medium{% else %}ps-8{% endif %} pe-3 py-2 text-gray-600 items-center hover:bg-gray-100 focus:bg-gray-100"
                                 >
                                     {% if s.selected %}
-                                        {% heroicon_mini "check" aria_hidden="true" size=16 class="stroke-2 mr-2" %}
+                                        {% heroicon_mini "check" aria_hidden="true" size=16 class="stroke-2 me-2" %}
                                     {% endif %}
                                     <span class="select-none inline-block rounded-full {{ s.bg_color }} w-3 h-3 me-1" aria-hidden=true></span>
                                     <span>
@@ -362,10 +362,10 @@
                                         href="{% modify_query "page" screening_statuses=s.slug %}"
                                     {% endif %}
                                     role="menuitemradio" aria-checked="{{ s.selected }}"
-                                    class="flex {% if s.selected %}bg-gray-100 pl-2 font-medium{% else %}pl-8{% endif %} pr-3 py-2 text-gray-600 items-center hover:bg-gray-100 focus:bg-gray-100"
+                                    class="flex {% if s.selected %}bg-gray-100 ps-2 font-medium{% else %}ps-8{% endif %} pe-3 py-2 text-gray-600 items-center hover:bg-gray-100 focus:bg-gray-100"
                                 >
                                     {% if s.selected %}
-                                        {% heroicon_mini "check" aria_hidden="true" size=16 class="stroke-2 mr-2" %}
+                                        {% heroicon_mini "check" aria_hidden="true" size=16 class="stroke-2 me-2" %}
                                     {% endif %}
                                     <span>
                                         {{ s.title }} {% if s.count %}({{ s.count }}){% endif %}
@@ -393,7 +393,7 @@
                             {% endif %}
                             hx-push-url="true"
                             aria-selected="{% if sort_option.selected %}true{% else %}false{% endif %}"
-                            class="flex {% if sort_option.selected %}pl-3 font-bold{% else %}pl-8{% endif %} pr-3 py-2 text-gray-600 border-b items-center hover:bg-gray-100 focus:bg-gray-100">
+                            class="flex {% if sort_option.selected %}ps-3 font-bold{% else %}ps-8{% endif %} pe-3 py-2 text-gray-600 border-b items-center hover:bg-gray-100 focus:bg-gray-100">
                             {% if sort_option.selected %}
                                 {% heroicon_mini "check" aria_hidden="true" size=16 class="stroke-2 me-1" %}
                             {% endif %}

--- a/hypha/apply/funds/templates/submissions/submenu/bulk-update-lead.html
+++ b/hypha/apply/funds/templates/submissions/submenu/bulk-update-lead.html
@@ -9,13 +9,13 @@
                 hx-include="[name=selectedSubmissionIds]"
                 hx-confirm='{% blocktrans with user_title=user.title %}Are you sure you want to assign "{{ user_title }}" as lead of the selected submissions?{% endblocktrans %}'
                 title="{% blocktrans with user_title=user.title %}Assign {{ user_title }} as lead.{% endblocktrans %}"
-                class="flex pl-8 pr-3 py-2 text-gray-600 items-center hover:bg-gray-100 focus:bg-gray-100">
+                class="flex ps-8 pe-3 py-2 text-gray-600 items-center hover:bg-gray-100 focus:bg-gray-100">
                 <strong class="font-bold">{{ user.title }}</strong>
-                {% if user.slack %} <span class="text-fg-muted font-light ml-1">{{ user.slack }}</span>{% endif %}
+                {% if user.slack %} <span class="text-fg-muted font-light ms-1">{{ user.slack }}</span>{% endif %}
             </a>
         </li>
     {% empty %}
-        <li class="pl-4 pr-3 py-2 text-gray-600 max-w-xs">
+        <li class="ps-4 pe-3 py-2 text-gray-600 max-w-xs">
             {% trans "No lead found. Sorry about that." %}
         </li>
     {% endfor %}

--- a/hypha/apply/funds/templates/submissions/submenu/category.html
+++ b/hypha/apply/funds/templates/submissions/submenu/category.html
@@ -25,9 +25,9 @@
                     title="Add {{ item.title }} to current filters"
                 {% endif %}
                 hx-push-url="true"
-                class="flex {% if item.selected %}pl-2 font-medium bg-gray-100{% else %}pl-8{% endif %} pr-3 py-2 text-gray-600 border-b items-center hover:bg-gray-100 focus:bg-gray-100">
+                class="flex {% if item.selected %}ps-2 font-medium bg-gray-100{% else %}ps-8{% endif %} pe-3 py-2 text-gray-600 border-b items-center hover:bg-gray-100 focus:bg-gray-100">
                 {% if item.selected %}
-                    <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor" class="w-4 h-4 mr-2">
+                    <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor" class="w-4 h-4 me-2">
                         <path fill-rule="evenodd"
                               d="M16.704 4.153a.75.75 0 01.143 1.052l-8 10.5a.75.75 0 01-1.127.075l-4.5-4.5a.75.75 0 011.06-1.06l3.894 3.893 7.48-9.817a.75.75 0 011.05-.143z"
                               clip-rule="evenodd" />
@@ -37,7 +37,7 @@
             </a>
         </li>
     {% empty %}
-        <li class="pl-4 pr-3 py-2 text-gray-600 max-w-xs">
+        <li class="ps-4 pe-3 py-2 text-gray-600 max-w-xs">
             {% trans "No categories found." %}
         </li>
     {% endfor %}

--- a/hypha/apply/funds/templates/submissions/submenu/change-status.html
+++ b/hypha/apply/funds/templates/submissions/submenu/change-status.html
@@ -9,12 +9,12 @@
                 hx-include="[name=selectedSubmissionIds]"
                 hx-confirm='{% blocktrans %}Are you sure you want to change the status of the selected submissions to "{{ value }}"?{% endblocktrans %}'
                 title="Change status to {{ value }}"
-                class="flex pl-4 pr-3 py-2 text-gray-600 items-center hover:bg-gray-100 focus:bg-gray-100">
+                class="flex ps-4 pe-3 py-2 text-gray-600 items-center hover:bg-gray-100 focus:bg-gray-100">
                 <strong class="font-bold">{{ value }}</strong>
             </a>
         </li>
     {% empty %}
-        <li class="pl-4 pr-3 py-2 text-gray-600 max-w-xs">
+        <li class="ps-4 pe-3 py-2 text-gray-600 max-w-xs">
             {% trans "No status found for currently selected submissions." %}
         </li>
     {% endfor %}

--- a/hypha/apply/funds/templates/submissions/submenu/funds.html
+++ b/hypha/apply/funds/templates/submissions/submenu/funds.html
@@ -23,7 +23,7 @@
                     hx-get="{% url "apply:submissions:list-beta" %}{% modify_query "only_query_string" "page" fund=f.id %}"
                 {% endif %}
                 hx-push-url="true"
-                class="flex {% if f.selected %}pl-2 font-medium{% else %}pl-8{% endif %} pr-3 py-2 text-gray-600 items-center hover:bg-gray-100 focus:bg-gray-100{% if f.selected %}bg-gray-100{% endif %}">
+                class="flex {% if f.selected %}ps-2 font-medium{% else %}ps-8{% endif %} pe-3 py-2 text-gray-600 items-center hover:bg-gray-100 focus:bg-gray-100{% if f.selected %}bg-gray-100{% endif %}">
                 {% if f.selected %}
                     {% heroicon_mini "check" aria_hidden="true" size=16 class="stroke-2 me-1" %}
                 {% endif %}
@@ -31,7 +31,7 @@
             </a>
         </li>
     {% empty %}
-        <li class="pl-4 pr-3 py-2 text-gray-600 max-w-xs">
+        <li class="ps-4 pe-3 py-2 text-gray-600 max-w-xs">
             {% trans "No funds found." %}
         </li>
     {% endfor %}

--- a/hypha/apply/funds/templates/submissions/submenu/leads.html
+++ b/hypha/apply/funds/templates/submissions/submenu/leads.html
@@ -17,18 +17,18 @@
                 href="{% url "apply:submissions:list-beta" %}{% modify_query "only_query_string" "page" lead=user.id %}"
                 hx-get="{% url "apply:submissions:list-beta" %}{% modify_query "only_query_string" "page" lead=user.id %}"
                 hx-push-url="true"
-                class="flex {% if user.selected %}pl-2 font-medium bg-gray-100{% else %}pl-8{% endif %} pr-3 py-2 text-gray-600 items-center hover:bg-gray-100 focus:bg-gray-100"
+                class="flex {% if user.selected %}ps-2 font-medium bg-gray-100{% else %}ps-8{% endif %} pe-3 py-2 text-gray-600 items-center hover:bg-gray-100 focus:bg-gray-100"
                 aria-selected="{% if user.selected %}true{% else %}false{% endif %}"
             >
                 {% if user.selected %}
                     {% heroicon_mini "check" aria_hidden="true" size=16 class="stroke-2 me-1" %}
                 {% endif %}
                 <strong class="font-bold">{{ user.title }}</strong>
-                {% if user.slack %} <span class="text-fg-muted font-light ml-1">{{ user.slack }}</span>{% endif %}
+                {% if user.slack %} <span class="text-fg-muted font-light ms-1">{{ user.slack }}</span>{% endif %}
             </a>
         </li>
     {% empty %}
-        <li class="pl-4 pr-3 py-2 text-gray-600 max-w-xs">
+        <li class="ps-4 pe-3 py-2 text-gray-600 max-w-xs">
             {% trans "No leads found." %}
         </li>
     {% endfor %}

--- a/hypha/apply/funds/templates/submissions/submenu/meta-terms.html
+++ b/hypha/apply/funds/templates/submissions/submenu/meta-terms.html
@@ -24,9 +24,9 @@
                     title="Add {{ meta_term.title }} to current filters"
                 {% endif %}
                 hx-push-url="true"
-                class="flex {% if meta_term.selected %}pl-2 font-medium bg-gray-100{% else %}pl-8{% endif %} pr-3 py-2 text-gray-600 items-center hover:bg-gray-100 focus:bg-gray-100">
+                class="flex {% if meta_term.selected %}ps-2 font-medium bg-gray-100{% else %}ps-8{% endif %} pe-3 py-2 text-gray-600 items-center hover:bg-gray-100 focus:bg-gray-100">
                 {% if meta_term.selected %}
-                    <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor" class="w-4 h-4 mr-2">
+                    <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor" class="w-4 h-4 me-2">
                         <path fill-rule="evenodd"
                               d="M16.704 4.153a.75.75 0 01.143 1.052l-8 10.5a.75.75 0 01-1.127.075l-4.5-4.5a.75.75 0 011.06-1.06l3.894 3.893 7.48-9.817a.75.75 0 011.05-.143z"
                               clip-rule="evenodd" />
@@ -38,7 +38,7 @@
             </a>
         </li>
     {% empty %}
-        <li class="pl-4 pr-3 py-2 text-gray-600 max-w-xs">
+        <li class="ps-4 pe-3 py-2 text-gray-600 max-w-xs">
             {% trans "No meta terms found." %}
         </li>
     {% endfor %}

--- a/hypha/apply/funds/templates/submissions/submenu/reviewers.html
+++ b/hypha/apply/funds/templates/submissions/submenu/reviewers.html
@@ -24,20 +24,20 @@
                     title="Add {{ user.title }} to current filters"
                 {% endif %}
                 hx-push-url="true"
-                class="flex {% if user.selected %}pl-2 font-medium bg-gray-100{% else %}pl-8{% endif %} pr-3 py-2 text-gray-600 items-center hover:bg-gray-100 focus:bg-gray-100">
+                class="flex {% if user.selected %}ps-2 font-medium bg-gray-100{% else %}ps-8{% endif %} pe-3 py-2 text-gray-600 items-center hover:bg-gray-100 focus:bg-gray-100">
                 {% if user.selected %}
-                    <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor" class="w-4 h-4 mr-2">
+                    <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor" class="w-4 h-4 me-2">
                         <path fill-rule="evenodd"
                               d="M16.704 4.153a.75.75 0 01.143 1.052l-8 10.5a.75.75 0 01-1.127.075l-4.5-4.5a.75.75 0 011.06-1.06l3.894 3.893 7.48-9.817a.75.75 0 011.05-.143z"
                               clip-rule="evenodd" />
                     </svg>
                 {% endif %}
                 <strong class="font-bold">{{ user.title }}</strong>
-                {% if user.slack %} <span class="text-fg-muted font-light ml-1">{{ user.slack }}</span>{% endif %}
+                {% if user.slack %} <span class="text-fg-muted font-light ms-1">{{ user.slack }}</span>{% endif %}
             </a>
         </li>
     {% empty %}
-        <li class="pl-4 pr-3 py-2 text-gray-600 max-w-xs">
+        <li class="ps-4 pe-3 py-2 text-gray-600 max-w-xs">
             {% trans "No reviewers found." %}
         </li>
     {% endfor %}

--- a/hypha/apply/funds/templates/submissions/submenu/rounds.html
+++ b/hypha/apply/funds/templates/submissions/submenu/rounds.html
@@ -48,7 +48,7 @@
                                href="{% url "apply:submissions:list-beta" %}{% modify_query "only_query_string" "page" round=f.id %}"
                                hx-get="{% url "apply:submissions:list-beta" %}{% modify_query "only_query_string" "page" round=f.id %}"
                                hx-push-url="true"
-                               class="flex {% if f.selected %}pl-2 font-medium{% else %}pl-8{% endif %} pr-3 py-2 text-gray-600 items-center hover:bg-gray-100 focus:bg-gray-100{% if f.selected %}bg-gray-100{% endif %}">
+                               class="flex {% if f.selected %}ps-2 font-medium{% else %}ps-8{% endif %} pe-3 py-2 text-gray-600 items-center hover:bg-gray-100 focus:bg-gray-100{% if f.selected %}bg-gray-100{% endif %}">
                                 {% if f.selected %}
                                     {% heroicon_mini "check" aria_hidden="true" size=16 class="stroke-2 me-1" %}
                                 {% endif %}
@@ -70,7 +70,7 @@
                                 href="{% url "apply:submissions:list-beta" %}{% modify_query "only_query_string" "page" round=f.id %}"
                                 hx-get="{% url "apply:submissions:list-beta" %}{% modify_query "only_query_string" "page" round=f.id %}"
                                 hx-push-url="true"
-                                class="flex {% if f.selected %}pl-2 font-medium{% else %}pl-8{% endif %} pr-3 py-2 text-gray-600 items-center hover:bg-gray-100 focus:bg-gray-100{% if f.selected %}bg-gray-100{% endif %}">
+                                class="flex {% if f.selected %}ps-2 font-medium{% else %}ps-8{% endif %} pe-3 py-2 text-gray-600 items-center hover:bg-gray-100 focus:bg-gray-100{% if f.selected %}bg-gray-100{% endif %}">
                                 {% if f.selected %}
                                     {% heroicon_mini "check" aria_hidden="true" size=16 class="stroke-2 me-1" %}
                                 {% endif %}

--- a/hypha/apply/projects/templates/application_projects/includes/contracting_documents.html
+++ b/hypha/apply/projects/templates/application_projects/includes/contracting_documents.html
@@ -9,7 +9,7 @@
             </h2>
 
             {% if collapsible_header %}
-                <button class="align-middle ml-1 transform transition-transform" x-bind:class="collapsed ? '': '-rotate-90' ">
+                <button class="align-middle ms-1 transform transition-transform" x-bind:class="collapsed ? '': '-rotate-90' ">
                     {% heroicon_outline 'chevron-left' size=20 stroke_width=2 aria_hidden=true %}
 
                     <span class="sr-only" x-text="collapsed ? 'expand' : 'collapse'">expand</span>
@@ -61,13 +61,13 @@
                 </div>
                 {% if contract_uploaded %}
                     <div class="docs-block__row-inner">
-                        <a class="font-bold flex items-center w-auto text-left bg-white text-light-blue mr-0 mb-1 p-2.5 border-solid border border-light-blue focus:text-light-blue hover:bg-light-blue hover:text-white" href="{% url 'apply:projects:contract' pk=project.pk file_pk=contract.pk %}" target="_blank">
+                        <a class="font-bold flex items-center w-auto text-start bg-white text-light-blue me-0 mb-1 p-2.5 border-solid border border-light-blue focus:text-light-blue hover:bg-light-blue hover:text-white" href="{% url 'apply:projects:contract' pk=project.pk file_pk=contract.pk %}" target="_blank">
                             {% heroicon_micro "eye" class="inline me-1 w-4 h-4" aria_hidden=true %}
                             {% trans "View" %}
                         </a>
                     </div>
                     {% if not is_contract_approved %}
-                        <ul class="mt-0 w-full pl-9">
+                        <ul class="mt-0 w-full ps-9">
                             <li class="docs-block__document">
                                 <div class="docs-block__row-inner">
                                 </div>
@@ -85,7 +85,7 @@
                 {% show_contract_upload_row object user as show_contract_row %}
                 {% if show_contract_row %}
                     {% contract_reuploaded_by_applicant object as contract_reuploaded %}
-                    <ul class="mt-2 w-full pl-9">
+                    <ul class="mt-2 w-full ps-9">
                         <li class="docs-block__document">
                             <div class="docs-block__row-inner">
                                 <p class="docs-block__title">
@@ -95,7 +95,7 @@
                             {% user_can_initiate_contract user as can_initiate_contract %}
                             {% if can_upload_contract and can_initiate_contract  %}
                                 <div class="docs-block__row-inner docs-block__row-inner__contract-upload-row">
-                                    <a data-fancybox class="font-bold flex items-center w-auto text-left bg-light-blue text-white mr-0 p-2.5 border-none" href="#" data-src="#upload-contract">
+                                    <a data-fancybox class="font-bold flex items-center w-auto text-start bg-light-blue text-white me-0 p-2.5 border-none" href="#" data-src="#upload-contract">
                                         {% heroicon_micro "arrow-up-tray" size=18 class="inline me-1" aria_hidden="true" %}
                                         {% if not contract %}
                                             {% trans "Upload" %}
@@ -114,7 +114,7 @@
                             </div>
                             {% if can_upload_contract and user.is_applicant %}
                                 <div class="docs-block__row-inner docs-block__row-inner__contract-upload-row">
-                                    <a data-fancybox class="font-bold flex items-center w-auto text-left bg-light-blue text-white mr-0 p-2.5 border-none" href="#" data-src="#upload-contract">
+                                    <a data-fancybox class="font-bold flex items-center w-auto text-start bg-light-blue text-white me-0 p-2.5 border-none" href="#" data-src="#upload-contract">
                                         {% heroicon_mini "arrow-up-tray" size=18 class="inline me-1" aria_hidden="true" %}
                                         {% if not contract.signed_by_applicant %}
                                             {% trans "Upload" %}
@@ -143,7 +143,7 @@
 
                     {% if all_contract_document_categories %}
 
-                        <div class="w-full pl-9">
+                        <div class="w-full ps-9">
                             <p></p>
                             <ul>
                                 {% for document_category in all_contract_document_categories %}
@@ -169,7 +169,7 @@
                                         </div>
                                         {% if document_category in remaining_contract_document_categories and can_update_documents %}
                                             <div class="docs-block__document-inner__actions">
-                                                <a data-fancybox data-src="#upload-contracting-doc" class="font-bold flex items-center mr-0" onclick="handleCategory({{ document_category.id }})" href="#">
+                                                <a data-fancybox data-src="#upload-contracting-doc" class="font-bold flex items-center me-0" onclick="handleCategory({{ document_category.id }})" href="#">
                                                     {% heroicon_mini "arrow-up-tray" size=18 class="inline me-1" aria_hidden="true" %}
                                                     {% trans "Upload" %}
                                                 </a>

--- a/hypha/apply/projects/templates/application_projects/includes/supporting_documents.html
+++ b/hypha/apply/projects/templates/application_projects/includes/supporting_documents.html
@@ -10,7 +10,7 @@
             </h2>
 
             {% if collapsible_header %}
-                <button class="align-middle ml-1 transform transition-transform" x-bind:class="collapsed ? '': '-rotate-90' ">
+                <button class="align-middle ms-1 transform transition-transform" x-bind:class="collapsed ? '': '-rotate-90' ">
                     {% heroicon_outline 'chevron-left' size=20 stroke_width=2 aria_hidden=true %}
                     <span class="sr-only" x-text="collapsed ? 'expand' : 'collapse'">expand</span>
                 </button>
@@ -36,14 +36,14 @@
                 {% if user == project.lead %}
                     <a data-fancybox
                        data-src="#update-paf-approvers"
-                       class="button button--project-action button--project-action--white ml-2"
+                       class="button button--project-action button--project-action--white ms-2"
                        href="#">
                         {% trans "View/Update Approvers" %}
                     </a>
                 {% else %}
                     <a data-fancybox
                        data-src="#change-assigned-paf-approvers"
-                       class="button button--project-action button--project-action--white ml-2"
+                       class="button button--project-action button--project-action--white ms-2"
                        href="#">
                         {% trans "Change approver" %}
                     </a>
@@ -52,7 +52,7 @@
             {% if can_assign_paf_approvers %}
                 <a data-fancybox
                    data-src="#assign-paf-approvers"
-                   class="button button--project-action ml-2"
+                   class="button button--project-action ms-2"
                    href="#">
                     {% trans "Assign approver" %}
                 </a>
@@ -61,7 +61,7 @@
             {% if object.can_make_approval and can_update_paf_status %}
                 <a data-fancybox
                    data-src="#update-paf-status"
-                   class="button button--project-action ml-2"
+                   class="button button--project-action ms-2"
                    href="#">
                     {% trans "Update Status" %}
                 </a>
@@ -174,7 +174,7 @@
 
                     {% if all_document_categories %}
 
-                        <div class="w-full pl-9">
+                        <div class="w-full ps-9">
                             <p></p>
                             <ul>
                                 {% for document_category in all_document_categories %}
@@ -201,7 +201,7 @@
                                         {% if document_category in remaining_document_categories %}
                                             <div class="docs-block__document-inner__actions">
                                                 <a data-fancybox data-src="#upload-supporting-doc"
-                                                   class="font-bold flex items-center mr-0 hover:opacity-70 transition-opacity"
+                                                   class="font-bold flex items-center me-0 hover:opacity-70 transition-opacity"
                                                    onclick="handleCategory({{ document_category.id }})"
                                                    href="#"
                                                 >
@@ -281,7 +281,7 @@
 
             <p>{% trans "By default all the members are notified when an approver is not selected. Optionally, you may select specific approvers to assign and notify them." %}</p>
             <div class="flex items-center text-sm">
-                <p class="flex-shrink font-bold text-slate-500 pr-2 mb-0">Optional</p>
+                <p class="flex-shrink font-bold text-slate-500 pe-2 mb-0">Optional</p>
                 <p class="flex-grow h-px bg-mid-grey mb-0"></p>
             </div>
 

--- a/hypha/apply/projects/templates/application_projects/invoice_detail.html
+++ b/hypha/apply/projects/templates/application_projects/invoice_detail.html
@@ -30,7 +30,7 @@
                 <div class="flex-none">
                     <p><b>{% trans "Status" %}: </b></p>
                 </div>
-                <div class="pl-2">
+                <div class="ps-2">
                     {% extract_status latest_activity user as latest_activity_status %}
                     {% get_comment_for_invoice_action object latest_activity as latest_activity_comment %}
                     <p>{{ latest_activity_status }} {% if user.is_applicant and latest_activity.user != user %} ({{ ORG_SHORT_NAME }}){% else %}({{ latest_activity.user }}){% endif %}
@@ -54,7 +54,7 @@
                 </div>
                 <button
                     type="button"
-                    class="font-bold text-light-blue flex-1 text-right hover:opacity-70 transition-opacity"
+                    class="font-bold text-light-blue flex-1 text-end hover:opacity-70 transition-opacity"
                     x-on:click="collapsed = ! collapsed"
                 >
                     <span x-show="collapsed">

--- a/hypha/apply/projects/templates/application_projects/project_approval_form.html
+++ b/hypha/apply/projects/templates/application_projects/project_approval_form.html
@@ -19,7 +19,7 @@
             {% include "forms/includes/form_errors.html" with form=sow_form %}
         {% endif %}
 
-        <div class="wrapper wrapper--light-grey-bg wrapper--sidebar pt-8 pl-20 pb-8 mt-4 mb-12 mx-auto ">
+        <div class="wrapper wrapper--light-grey-bg wrapper--sidebar pt-8 ps-20 pb-8 mt-4 mb-12 mx-auto ">
             <div class="wrapper--sidebar--inner">
                 <form class="form application-form" action="" method="post" enctype="multipart/form-data">
                     {% csrf_token %}

--- a/hypha/apply/projects/templates/application_projects/project_detail.html
+++ b/hypha/apply/projects/templates/application_projects/project_detail.html
@@ -43,7 +43,7 @@
                            href="#"
                         >
                             <u>{% trans "Lead" %}: {{ object.lead }}</u>
-                            {% heroicon_micro "pencil-square" class="inline ml-1" aria_hidden=true %}
+                            {% heroicon_micro "pencil-square" class="inline ms-1" aria_hidden=true %}
                         </a>
                         <div class="modal" id="assign-lead">
                             <h4 class="modal__project-header-bar">{% trans "Assign Lead" %}</h4>

--- a/hypha/apply/review/templates/review/review_detail.html
+++ b/hypha/apply/review/templates/review/review_detail.html
@@ -56,7 +56,7 @@
                 {% endif %}
             </div>
             {% comment %} {% if not review.for_latest %} {% endcomment %}
-            <div class="text-right">
+            <div class="text-end">
                 <p class="text-xs">
                     * {% trans "Review was not against the latest version" %}<br>
                 </p>

--- a/hypha/apply/users/templates/elevate/elevate.html
+++ b/hypha/apply/users/templates/elevate/elevate.html
@@ -50,7 +50,7 @@
             {% if request.user.has_usable_password %}
                 <section data-test-id="section-send-email" class="px-4 border pt-2 pb-4">
                     <p>{% trans "Having problems?" %}</p>
-                    <ul class="list-disc ml-4">
+                    <ul class="list-disc ms-4">
                         <li>
                             <a
                                 class="m-0"

--- a/hypha/apply/users/templates/two_factor/core/backup_tokens.html
+++ b/hypha/apply/users/templates/two_factor/core/backup_tokens.html
@@ -14,7 +14,7 @@
                   cols="8"
                   rows="{{ device.token_set.count }}"
                   id="list-backup-tokens"
-                  class="font-mono pr-0 font-medium leading-tight bg-orange-100 resize-none"
+                  class="font-mono pe-0 font-medium leading-tight bg-orange-100 resize-none"
         >{% for token in device.token_set.all %}{{ token.token }}{% if not forloop.last %}&#013;&#010;{% endif %}{% endfor %}</textarea>
 
         <form method="post" class="actions actions-footer">{% csrf_token %}{{ form }}

--- a/hypha/apply/users/templates/users/activation/invalid.html
+++ b/hypha/apply/users/templates/users/activation/invalid.html
@@ -14,7 +14,7 @@
             {% url 'users:password_reset' as password_reset %}
             <div class="wrapper wrapper--small wrapper--bottom-space">
                 <p><strong>{% trans "Two possible reasons:" %}</strong></p>
-                <ol class="list-decimal pl-6">
+                <ol class="list-decimal ps-6">
                     <li>{% trans "The activation link has expired." %}</li>
                     <li>{% trans "The account has already been activated." %}</li>
                 </ol>

--- a/hypha/apply/users/templates/users/login.html
+++ b/hypha/apply/users/templates/users/login.html
@@ -47,7 +47,7 @@
                             <div class="relative max-w-sm {% if field.auto_id == "id_auth-password" %}mb-4{% endif %}">
                                 {% include "forms/includes/field.html" %}
                                 {% if field.auto_id == "id_auth-password" %}
-                                    <div class="text-right">
+                                    <div class="text-end">
                                         <a class="link text-sm hover:opacity-75" href="{% url 'users:password_reset' %}{% if redirect_url %}?next={{ redirect_url }}{% endif %}" hx-boost="true">{% trans "Forgot your password?" %}</a>
                                     </div>
                                 {% endif %}

--- a/hypha/apply/users/templates/users/partials/confirmation_code_sent.html
+++ b/hypha/apply/users/templates/users/partials/confirmation_code_sent.html
@@ -57,7 +57,7 @@
 {% if request.user.has_usable_password %}
     <section data-test-id="section-send-email" class="px-4 border pt-2 pb-4">
         <p>{% trans "Having problems?" %}</p>
-        <ul class="list-disc ml-4">
+        <ul class="list-disc ms-4">
             <li>
                 <a
                     class="m-0"

--- a/hypha/core/templates/components/dropdown-menu.html
+++ b/hypha/core/templates/components/dropdown-menu.html
@@ -22,7 +22,7 @@
 >
     <button
         type="button"
-        class="flex cursor-pointer items-center justify-between w-full py-1 pl-2 pr-2 border md:border-none font-medium text-gray-600 hover:bg-gray-50 md:hover:bg-transparent md:hover:text-blue-700"
+        class="flex cursor-pointer items-center justify-between w-full py-1 ps-2 pe-2 border md:border-none font-medium text-gray-600 hover:bg-gray-50 md:hover:bg-transparent md:hover:text-blue-700"
         x-ref="button"
         @click="toggle()"
         :aria-expanded="open"
@@ -40,7 +40,7 @@
     </button>
 
     <!-- Panel -->
-    <div class="m-4 z-20 border min-w-max fixed top-0 left-0 right-0 md:text-sm md:m-0 md:mt-1 md:absolute md:left-auto {% if attributes.position == 'right' %}md:right-0{% else %} md:right-auto{% endif %} md:top-auto md:bottom-auto bg-white divide-y divide-gray-100 rounded-lg shadow-lg"
+    <div class="m-4 z-20 border min-w-max fixed top-0 start-0 end-0 md:text-sm md:m-0 md:mt-1 md:absolute md:start-auto {% if attributes.position == 'right' %}md:end-0{% else %} md:end-auto{% endif %} md:top-auto md:bottom-auto bg-white divide-y divide-gray-100 rounded-lg shadow-lg"
          role="menu"
          x-ref="panel"
          x-show="open"
@@ -78,7 +78,7 @@
             {% render_slot slots.inner_block %}
             {% if slots.url %}
                 <div role="status" class="flex justify-center items-center py-4">
-                    <svg aria-hidden="true" width="8" height="8" class="w-8 h-8 mr-2 text-gray-200 animate-spin dark:text-gray-600 fill-blue-600"
+                    <svg aria-hidden="true" width="8" height="8" class="w-8 h-8 me-2 text-gray-200 animate-spin dark:text-gray-600 fill-blue-600"
                          viewBox="0 0 100 101" fill="none" xmlns="http://www.w3.org/2000/svg">
                         <path
                             d="M100 50.5908C100 78.2051 77.6142 100.591 50 100.591C22.3858 100.591 0 78.2051 0 50.5908C0 22.9766 22.3858 0.59082 50 0.59082C77.6142 0.59082 100 22.9766 100 50.5908ZM9.08144 50.5908C9.08144 73.1895 27.4013 91.5094 50 91.5094C72.5987 91.5094 90.9186 73.1895 90.9186 50.5908C90.9186 27.9921 72.5987 9.67226 50 9.67226C27.4013 9.67226 9.08144 27.9921 9.08144 50.5908Z"

--- a/hypha/core/templates/components/scroll-to-top.html
+++ b/hypha/core/templates/components/scroll-to-top.html
@@ -8,7 +8,7 @@
         x-on:scroll.window.throttle.50ms="scrollBackTop = (window.pageYOffset < lastScrollTop && window.pageYOffset > window.outerHeight * 0.4) ? true : false; lastScrollTop = window.pageYOffset;"
         @click="window.scrollTo({top: 0, behavior: 'smooth'})"
         aria-label="Back to top"
-        class="fixed top-0 right-1/2 px-3 py-2 mt-10 -mr-[64px] text-white bg-light-blue/80 z-30 hover:bg-light-blue hover:text-white hover:shadow-lg transition-all focus:outline-none cursor-pointer shadow-lg rounded-2xl">
+        class="fixed top-0 end-1/2 px-3 py-2 mt-10 -me-[64px] text-white bg-light-blue/80 z-30 hover:bg-light-blue hover:text-white hover:shadow-lg transition-all focus:outline-none cursor-pointer shadow-lg rounded-2xl">
         {% heroicon_mini "arrow-long-up" class="inline align-text-bottom" size=18 aria_hidden=true %} Back to top
     </button>
 </template>

--- a/hypha/static_src/src/sass/apply/abstracts/_mixins.scss
+++ b/hypha/static_src/src/sass/apply/abstracts/_mixins.scss
@@ -173,18 +173,18 @@
     $perpendicular-borders: $size solid transparent;
 
     @if $direction == top or $direction == bottom {
-        border-right: $perpendicular-borders;
-        border-left: $perpendicular-borders;
+        border-inline-end: $perpendicular-borders;
+        border-inline-start: $perpendicular-borders;
     } @else if $direction == right or $direction == left {
-        border-top: $perpendicular-borders;
-        border-bottom: $perpendicular-borders;
+        border-block-start: $perpendicular-borders;
+        border-block-end: $perpendicular-borders;
     }
 }
 
 // used for the submission list items in the react app
 @mixin submission-list-item {
-    border-bottom: 2px solid $color--light-mid-grey;
-    border-right: 2px solid $color--light-mid-grey;
+    border-block-end: 2px solid $color--light-mid-grey;
+    border-inline-end: 2px solid $color--light-mid-grey;
 }
 
 @mixin table-ordering-styles {
@@ -198,8 +198,8 @@
 
                 &::after {
                     position: absolute;
-                    top: 50%;
-                    margin-left: 3px;
+                    inset-block-start: 50%;
+                    margin-inline-start: 3px;
                 }
 
                 a {

--- a/hypha/static_src/src/sass/apply/base/_base.scss
+++ b/hypha/static_src/src/sass/apply/base/_base.scss
@@ -28,7 +28,7 @@ p {
 
 details > summary {
     cursor: pointer;
-    margin-bottom: 10px;
+    margin-block-end: 10px;
 
     &:focus {
         outline: none;
@@ -76,13 +76,13 @@ details > summary {
 .off-screen,
 %off-screen {
     position: absolute;
-    left: -9999px;
+    inset-inline-start: -9999px;
 }
 
 .on-screen,
 %on-screen {
     position: relative;
-    left: 0;
+    inset-inline-start: 0;
 }
 
 .mid-grey-text {

--- a/hypha/static_src/src/sass/apply/components/_actions-bar.scss
+++ b/hypha/static_src/src/sass/apply/components/_actions-bar.scss
@@ -8,7 +8,7 @@
 
     &__inner {
         & > * {
-            margin-bottom: 20px;
+            margin-block-end: 20px;
         }
 
         @include media-query(tablet-landscape) {
@@ -19,7 +19,7 @@
                 margin: 0 0 0 20px;
 
                 &:first-child {
-                    margin-left: 0;
+                    margin-inline-start: 0;
                 }
             }
         }

--- a/hypha/static_src/src/sass/apply/components/_activity-notifications.scss
+++ b/hypha/static_src/src/sass/apply/components/_activity-notifications.scss
@@ -6,9 +6,9 @@
 
     &__content {
         position: absolute;
-        right: 1em;
-        margin-top: 0.5rem;
-        padding-bottom: 0.25rem;
+        inset-inline-end: 1em;
+        margin-block-start: 0.5rem;
+        padding-block-end: 0.25rem;
         background-color: $color--white;
         border: 1px solid $color--light-grey;
         min-width: 400px;
@@ -21,7 +21,7 @@
         padding: 0.75rem 1rem;
         display: flex;
         justify-content: space-between;
-        border-bottom: 1px solid $color--light-grey;
+        border-block-end: 1px solid $color--light-grey;
         font-weight: $weight--semibold;
         background-color: $color--light-grey;
     }
@@ -33,11 +33,11 @@
     &__item {
         margin: 0;
         padding: 0.75rem 1rem;
-        border-bottom: 1px solid $color--light-grey;
+        border-block-end: 1px solid $color--light-grey;
 
         &:last-child {
-            margin-bottom: 0;
-            border-bottom: 0;
+            margin-block-end: 0;
+            border-block-end: 0;
         }
     }
 
@@ -49,16 +49,16 @@
 
         label {
             font-weight: $weight--semibold;
-            padding-right: 1em;
+            padding-inline-end: 1em;
         }
 
         select {
-            padding-right: 1em;
+            padding-inline-end: 1em;
         }
 
         .form {
             &__select {
-                margin-right: 1em;
+                margin-inline-end: 1em;
             }
         }
     }

--- a/hypha/static_src/src/sass/apply/components/_admin-bar.scss
+++ b/hypha/static_src/src/sass/apply/components/_admin-bar.scss
@@ -1,11 +1,11 @@
 .admin-bar {
     position: relative;
-    right: 50%;
-    left: 50%;
+    inset-inline-end: 50%;
+    inset-inline-start: 50%;
     width: 100vw;
     padding: $mobile-gutter;
-    margin-right: -50vw;
-    margin-left: -50vw;
+    margin-inline-end: -50vw;
+    margin-inline-start: -50vw;
     color: $color--white;
     background-color: $color--dark-grey;
 
@@ -24,7 +24,7 @@
     }
 
     &__heading {
-        margin-bottom: 0;
+        margin-block-end: 0;
     }
 
     &__meta {
@@ -43,7 +43,7 @@
 
         &::before {
             @include triangle(top, currentColor, 5px);
-            margin-right: 0.5rem;
+            margin-inline-end: 0.5rem;
             transform: rotate(-90deg);
         }
     }

--- a/hypha/static_src/src/sass/apply/components/_alert.scss
+++ b/hypha/static_src/src/sass/apply/components/_alert.scss
@@ -10,7 +10,7 @@
         width: 25px;
         height: 25px;
         fill: $color--light-blue;
-        margin-right: 0.8rem;
+        margin-inline-end: 0.8rem;
     }
 
     &__text {

--- a/hypha/static_src/src/sass/apply/components/_all-reviews-table.scss
+++ b/hypha/static_src/src/sass/apply/components/_all-reviews-table.scss
@@ -24,8 +24,8 @@
         td {
             &.title {
                 position: relative;
-                padding-top: 15px;
-                padding-left: 10px;
+                padding-block-start: 15px;
+                padding-inline-start: 10px;
                 font-weight: $weight--bold;
 
                 @include media-query($table-breakpoint) {

--- a/hypha/static_src/src/sass/apply/components/_all-submissions-table.scss
+++ b/hypha/static_src/src/sass/apply/components/_all-submissions-table.scss
@@ -44,7 +44,7 @@
 
                 @include media-query($table-breakpoint) {
                     width: 50px;
-                    padding-right: 0;
+                    padding-inline-end: 0;
                 }
             }
 
@@ -79,7 +79,7 @@
             // project title
             &.title {
                 position: relative;
-                padding-top: 15px;
+                padding-block-start: 15px;
                 font-weight: $weight--bold;
 
                 @include media-query($table-breakpoint) {
@@ -136,7 +136,7 @@
             &.selected {
                 @include table-checkbox;
                 display: none;
-                padding-right: 0;
+                padding-inline-end: 0;
 
                 @include media-query($table-breakpoint) {
                     display: table-cell;
@@ -151,7 +151,7 @@
 
             &.organization_name {
                 @include media-query($table-breakpoint) {
-                    padding-left: 15px;
+                    padding-inline-start: 15px;
                 }
             }
 
@@ -161,7 +161,7 @@
                     @include triangle(right, $color--primary, 6px);
                     position: relative;
                     display: inline-block;
-                    margin-right: 10px;
+                    margin-inline-end: 10px;
                     transform: rotate(0);
                     transition: transform $transition;
 
@@ -191,10 +191,10 @@
     &__parent {
         &.is-expanded {
             background-color: $color--mist;
-            border-bottom: 1px solid $color--light-mid-grey;
+            border-block-end: 1px solid $color--light-mid-grey;
 
             + #{$root}__child {
-                border-bottom: 1px solid $color--light-mid-grey;
+                border-block-end: 1px solid $color--light-mid-grey;
             }
 
             + #{$root}__child,
@@ -215,7 +215,7 @@
         vertical-align: top;
         background-color: $color--mist;
         border: 0;
-        border-bottom: 2px solid $color--light-grey;
+        border-block-end: 2px solid $color--light-grey;
 
         &:hover {
             box-shadow: none;
@@ -254,9 +254,9 @@
         background-color: $color--white;
         padding: 20px 25px;
         min-height: auto;
-        border-bottom: 1px solid $color--light-mid-grey;
-        border-left: 1px solid $color--light-mid-grey;
-        border-right: 1px solid $color--light-mid-grey;
+        border-block-end: 1px solid $color--light-mid-grey;
+        border-inline-start: 1px solid $color--light-mid-grey;
+        border-inline-end: 1px solid $color--light-mid-grey;
 
         a {
             margin: 0;

--- a/hypha/static_src/src/sass/apply/components/_button.scss
+++ b/hypha/static_src/src/sass/apply/components/_button.scss
@@ -69,7 +69,7 @@
     }
 
     &--left-space {
-        margin-left: 20px;
+        margin-inline-start: 20px;
     }
 
     &--transparent {
@@ -163,8 +163,8 @@
 
     &--search {
         position: absolute;
-        top: 0.65em;
-        right: 10px;
+        inset-block-start: 0.65em;
+        inset-inline-end: 10px;
 
         svg {
             fill: $color--primary;
@@ -181,18 +181,18 @@
         width: 50%;
         padding: 10px;
         text-align: center;
-        margin-right: 20px;
+        margin-inline-end: 20px;
 
         &:last-child {
-            margin-right: 0;
+            margin-inline-end: 0;
         }
     }
 
     &--bottom-space {
-        margin-bottom: 10px;
+        margin-block-end: 10px;
 
         &:last-child {
-            margin-bottom: 0;
+            margin-block-end: 0;
         }
     }
 
@@ -207,8 +207,8 @@
 
         &::after {
             position: absolute;
-            top: 0;
-            right: 15px;
+            inset-block-start: 0;
+            inset-inline-end: 15px;
             font-size: 30px;
             content: "+";
             line-height: 1.2;
@@ -219,7 +219,7 @@
             background: $color--light-blue-90;
 
             &::after {
-                top: -12px;
+                inset-block-start: -12px;
                 content: "_";
             }
         }
@@ -230,19 +230,19 @@
     }
 
     &--top-space {
-        margin-top: 20px;
+        margin-block-start: 20px;
     }
 
     &--submit {
         min-width: 200px;
-        margin-right: 10px;
+        margin-inline-end: 10px;
         text-align: center;
     }
 
     &--compare {
         width: 75px;
         padding: 3px;
-        margin-top: 10px;
+        margin-block-start: 10px;
         font-size: 12px;
         font-weight: $weight--bold;
         text-align: center;
@@ -251,7 +251,7 @@
         transition: background-color, color, border, $quick-transition;
 
         @include media-query(tablet-portrait) {
-            margin-top: 0;
+            margin-block-start: 0;
         }
 
         &:focus,
@@ -269,7 +269,7 @@
         svg {
             width: 10px;
             height: 14px;
-            margin-left: 10px;
+            margin-inline-start: 10px;
             fill: $color--white;
         }
     }
@@ -304,8 +304,8 @@
                 background: $color--light-blue;
                 opacity: 0;
                 transition: opacity $transition;
-                bottom: 45px;
-                left: 50%;
+                inset-block-end: 45px;
+                inset-inline-start: 50%;
                 transform: translateX(-50%);
                 color: $color--white;
                 text-align: left;
@@ -317,8 +317,8 @@
             &::after {
                 @include triangle(bottom, $color--primary, 7px);
                 position: absolute;
-                top: -22px;
-                left: 50%;
+                inset-block-start: -22px;
+                inset-inline-start: 50%;
                 transform: translateX(-50%);
                 opacity: 0;
                 transition: opacity $transition;
@@ -349,7 +349,7 @@
             fill: $color--light-blue;
             width: 1em;
             height: 1em;
-            margin-right: 0.5rem;
+            margin-inline-end: 0.5rem;
             pointer-events: none;
         }
     }
@@ -379,8 +379,8 @@
                 content: "\2691";
                 color: $color--tomato;
                 position: absolute;
-                top: 4px;
-                padding-left: 5px;
+                inset-block-start: 4px;
+                padding-inline-start: 5px;
                 font-size: map-get($font-sizes, delta);
                 line-height: 1;
             }
@@ -390,16 +390,16 @@
     &--unflag {
         @include button($color--light-blue, $color--dark-blue);
         @include button--small;
-        padding-right: 18px;
+        padding-inline-end: 18px;
 
         @include media-query(tablet-landscape) {
-            padding-right: 18px;
+            padding-inline-end: 18px;
         }
 
         &.flagged {
             &::after {
-                top: 2px;
-                padding-left: 3px;
+                inset-block-start: 2px;
+                padding-inline-start: 3px;
                 font-size: map-get($font-sizes, zeta);
             }
         }
@@ -407,8 +407,8 @@
 
     &--float {
         position: absolute;
-        top: 2px;
-        right: 2px;
+        inset-block-start: 2px;
+        inset-inline-end: 2px;
     }
 
     // Two-factor

--- a/hypha/static_src/src/sass/apply/components/_card.scss
+++ b/hypha/static_src/src/sass/apply/components/_card.scss
@@ -1,6 +1,6 @@
 .card {
     padding: 20px;
-    margin-bottom: 20px;
+    margin-block-end: 20px;
     border: 1px solid $color--mid-grey;
 
     &--solid {
@@ -16,28 +16,28 @@
     }
 
     &__inner {
-        margin-bottom: 1rem;
+        margin-block-end: 1rem;
 
         &:last-child {
-            margin-bottom: 0;
+            margin-block-end: 0;
         }
     }
 
     &__heading {
-        margin-bottom: 0;
+        margin-block-end: 0;
     }
 
     &__reviewer-outcome {
         display: flex;
         align-items: center;
-        margin-bottom: 1rem;
+        margin-block-end: 1rem;
 
         @include media-query(small-tablet) {
-            margin-left: 1rem;
+            margin-inline-start: 1rem;
         }
     }
 
     &__reviewer {
-        margin-left: 10px;
+        margin-inline-start: 10px;
     }
 }

--- a/hypha/static_src/src/sass/apply/components/_comment.scss
+++ b/hypha/static_src/src/sass/apply/components/_comment.scss
@@ -1,20 +1,20 @@
 .comment {
-    padding-bottom: 20px;
-    margin-bottom: 20px;
-    border-bottom: 1px solid $color--light-mid-grey;
+    padding-block-end: 20px;
+    margin-block-end: 20px;
+    border-block-end: 1px solid $color--light-mid-grey;
 
     @include media-query(tablet-portrait) {
         max-width: 60%;
     }
 
     &:first-of-type {
-        margin-top: 20px;
+        margin-block-start: 20px;
     }
 
     &:last-of-type {
-        padding-bottom: 0;
-        margin-bottom: 0;
-        border-bottom: 0;
+        padding-block-end: 0;
+        margin-block-end: 0;
+        border-block-end: 0;
     }
 
     &__time,

--- a/hypha/static_src/src/sass/apply/components/_cookieconsent.scss
+++ b/hypha/static_src/src/sass/apply/components/_cookieconsent.scss
@@ -1,9 +1,9 @@
 .cookieconsent {
     position: fixed;
-    bottom: 0;
+    inset-block-end: 0;
     color: $color--white;
     background-color: $color--dark-blue;
-    border-top: 4px solid $color--light-blue;
+    border-block-start: 4px solid $color--light-blue;
     transform: translateY(100vh);
     transition: all $transition;
 

--- a/hypha/static_src/src/sass/apply/components/_dashboard-table.scss
+++ b/hypha/static_src/src/sass/apply/components/_dashboard-table.scss
@@ -18,8 +18,8 @@
 
                 &::after {
                     position: absolute;
-                    top: 40%;
-                    margin-left: 5px;
+                    inset-block-start: 40%;
+                    margin-inline-start: 5px;
                 }
             }
 
@@ -29,8 +29,8 @@
 
                 &::after {
                     position: absolute;
-                    top: 50%;
-                    margin-left: 5px;
+                    inset-block-start: 50%;
+                    margin-inline-start: 5px;
                 }
             }
         }

--- a/hypha/static_src/src/sass/apply/components/_data-block.scss
+++ b/hypha/static_src/src/sass/apply/components/_data-block.scss
@@ -1,6 +1,6 @@
 .data-block {
     $root: &;
-    margin-bottom: 1rem;
+    margin-block-end: 1rem;
     border: 1px solid $color--light-blue;
 
     &__header {
@@ -46,10 +46,10 @@
         }
 
         #{$root}__links & {
-            margin-right: 1rem;
+            margin-inline-end: 1rem;
 
             &:only-child {
-                margin-right: 0;
+                margin-inline-end: 0;
             }
         }
     }
@@ -86,7 +86,7 @@
     &__table {
         thead {
             display: none;
-            border-top: 2px solid $color--light-mid-grey;
+            border-block-start: 2px solid $color--light-mid-grey;
 
             @include media-query(tablet-landscape) {
                 display: table-header-group;
@@ -112,7 +112,7 @@
 
         tr {
             border: 0;
-            border-bottom: 2px solid $color--light-grey;
+            border-block-end: 2px solid $color--light-grey;
 
             &:hover {
                 box-shadow: none;
@@ -152,7 +152,7 @@
         font-size: map-get($font-sizes, zeta);
         font-weight: $weight--bold;
         display: inline-block;
-        margin-right: 1rem;
+        margin-inline-end: 1rem;
         text-decoration: underline;
         color: $color--primary;
         word-break: normal;
@@ -173,7 +173,7 @@
         font-weight: $weight--bold;
         display: flex;
         align-items: center;
-        margin-right: 1rem;
+        margin-inline-end: 1rem;
         word-break: normal;
 
         transition-property: opacity;
@@ -193,7 +193,7 @@
     }
 
     &__list-item {
-        border-bottom: 2px solid $color--light-grey;
+        border-block-end: 2px solid $color--light-grey;
         padding: 1rem 0;
 
         @include media-query(tablet-landscape) {
@@ -203,11 +203,11 @@
         }
 
         &:first-child {
-            padding-top: 0;
+            padding-block-start: 0;
         }
 
         &:last-child {
-            border-bottom: 0;
+            border-block-end: 0;
         }
 
         &:only-child {
@@ -234,9 +234,9 @@
     }
 
     &__card {
-        padding-bottom: 1rem;
+        padding-block-end: 1rem;
         position: relative;
-        margin-bottom: 2rem;
+        margin-block-end: 2rem;
 
         &::after {
             content: "";
@@ -245,12 +245,12 @@
             height: 2px;
             display: block;
             background: $color--mid-grey;
-            left: -1rem;
-            bottom: 0;
+            inset-inline-start: -1rem;
+            inset-block-end: 0;
 
             @include media-query(mob-landscape) {
                 width: calc(100% + 4rem);
-                left: -2rem;
+                inset-inline-start: -2rem;
             }
         }
     }

--- a/hypha/static_src/src/sass/apply/components/_determination.scss
+++ b/hypha/static_src/src/sass/apply/components/_determination.scss
@@ -1,4 +1,4 @@
 .determination-outcome {
     display: inline;
-    padding-right: 8px;
+    padding-inline-end: 8px;
 }

--- a/hypha/static_src/src/sass/apply/components/_docs-block.scss
+++ b/hypha/static_src/src/sass/apply/components/_docs-block.scss
@@ -21,9 +21,9 @@
     }
 
     &__row {
-        padding-bottom: 1rem;
-        margin-bottom: 1rem;
-        border-bottom: 1px solid $color--mid-grey;
+        padding-block-end: 1rem;
+        margin-block-end: 1rem;
+        border-block-end: 1px solid $color--mid-grey;
 
         @include media-query(tablet-portrait) {
             display: flex;
@@ -33,9 +33,9 @@
         }
 
         &:last-child {
-            border-bottom: 0;
-            padding-bottom: 0;
-            margin-bottom: 0;
+            border-block-end: 0;
+            padding-block-end: 0;
+            margin-block-end: 0;
         }
     }
 
@@ -44,7 +44,7 @@
         align-items: center;
 
         &:first-child {
-            margin-bottom: 1rem;
+            margin-block-end: 1rem;
         }
 
         @include media-query(tablet-portrait) {
@@ -72,16 +72,16 @@
         height: 20px;
         stroke: $color--mid-grey;
         fill: transparent;
-        margin-right: 0.5rem;
+        margin-inline-end: 0.5rem;
 
         @include media-query(tablet-landscape) {
-            margin-right: 1rem;
+            margin-inline-end: 1rem;
         }
     }
 
     &__link {
         font-weight: $weight--bold;
-        margin-right: 1rem;
+        margin-inline-end: 1rem;
 
         &:disabled,
         &.is-disabled {
@@ -90,7 +90,7 @@
         }
 
         &:last-child {
-            margin-right: 0;
+            margin-inline-end: 0;
         }
     }
 
@@ -98,7 +98,7 @@
         font-weight: $weight--bold;
         display: flex;
         align-items: center;
-        margin-right: 1rem;
+        margin-inline-end: 1rem;
 
         &:disabled,
         &.is-disabled {
@@ -107,14 +107,14 @@
         }
 
         &:last-child {
-            margin-right: 0;
+            margin-inline-end: 0;
         }
     }
 
     &__info-text {
         @include media-query(tablet-landscape) {
             max-width: 65%;
-            margin-left: 3rem;
+            margin-inline-start: 3rem;
         }
     }
 
@@ -133,21 +133,21 @@
 
     &__document-list {
         width: 100%;
-        margin-top: 1rem;
-        padding-left: 0;
+        margin-block-start: 1rem;
+        padding-inline-start: 0;
     }
 
     &__document {
         display: flex;
         align-items: center;
         justify-content: space-between;
-        padding-bottom: 1rem;
+        padding-block-end: 1rem;
         flex-wrap: wrap;
 
         &:last-child {
-            padding-bottom: 0;
+            padding-block-end: 0;
             margin: 0;
-            border-bottom: 0;
+            border-block-end: 0;
         }
     }
 
@@ -173,10 +173,10 @@
     }
 
     &__document-link {
-        margin-right: 1rem;
+        margin-inline-end: 1rem;
 
         &:last-child {
-            margin-right: 0;
+            margin-inline-end: 0;
         }
     }
 

--- a/hypha/static_src/src/sass/apply/components/_editor.scss
+++ b/hypha/static_src/src/sass/apply/components/_editor.scss
@@ -5,7 +5,7 @@
     overflow: hidden; /* prevent collapsing margins */
 
     ul {
-        padding-left: 20px;
+        padding-inline-start: 20px;
         list-style: outside disc;
     }
 

--- a/hypha/static_src/src/sass/apply/components/_feed.scss
+++ b/hypha/static_src/src/sass/apply/components/_feed.scss
@@ -2,10 +2,10 @@
     &__item {
         position: relative;
         display: flex;
-        margin-bottom: 1.5em;
+        margin-block-end: 1.5em;
 
         &:last-child {
-            border-bottom: 0;
+            border-block-end: 0;
         }
 
         &--collaps {
@@ -15,7 +15,7 @@
         }
 
         ul {
-            padding-left: 20px;
+            padding-inline-start: 20px;
             list-style: outside disc;
         }
 
@@ -57,7 +57,7 @@
 
         &--mobile {
             display: block;
-            margin-right: 10px;
+            margin-inline-end: 10px;
 
             @include media-query(small-tablet) {
                 display: none;
@@ -80,7 +80,7 @@
         flex-wrap: wrap;
 
         @include media-query(small-tablet) {
-            margin-bottom: 10px;
+            margin-block-end: 10px;
         }
     }
 
@@ -96,12 +96,12 @@
         }
 
         &--edit-button {
-            border-left: 2px solid $color--mid-grey;
-            padding-left: 15px;
+            border-inline-start: 2px solid $color--mid-grey;
+            padding-inline-start: 15px;
         }
 
         &--last-edited {
-            margin-right: 5px;
+            margin-inline-end: 5px;
             color: $color--mid-dark-grey;
 
             span {
@@ -110,7 +110,7 @@
         }
 
         &--right {
-            margin-left: auto;
+            margin-inline-start: auto;
 
             span {
                 font-weight: $weight--normal;
@@ -152,14 +152,14 @@
         svg {
             width: 10px;
             height: 14px;
-            margin-left: 10px;
-            margin-top: 0.35em;
+            margin-inline-start: 10px;
+            margin-block-start: 0.35em;
             fill: $color--dark-blue;
         }
     }
 
     &__heading {
-        margin-bottom: 0;
+        margin-block-end: 0;
 
         @include media-query(small-tablet) {
             width: 90%;
@@ -183,8 +183,8 @@
 
     &__show-button {
         position: absolute;
-        bottom: 0;
-        left: 0;
+        inset-block-end: 0;
+        inset-inline-start: 0;
         width: 100%;
         text-align: center;
         margin: 0;

--- a/hypha/static_src/src/sass/apply/components/_filters.scss
+++ b/hypha/static_src/src/sass/apply/components/_filters.scss
@@ -3,10 +3,10 @@
 
     &.filters-open {
         position: fixed;
-        top: 0;
-        right: 0;
-        bottom: 0;
-        left: 0;
+        inset-inline-start: 0;
+        inset-inline-end: 0;
+        inset-block-start: 0;
+        inset-block-end: 0;
         z-index: 9;
         display: block;
         width: 100%;
@@ -23,10 +23,10 @@
 
         &.filters-open {
             position: relative;
-            top: auto;
-            left: auto;
-            right: auto;
-            bottom: auto;
+            inset-inline-start: auto;
+            inset-inline-end: auto;
+            inset-block-start: auto;
+            inset-block-end: auto;
             height: auto;
             background: transparent;
             max-height: 85px;

--- a/hypha/static_src/src/sass/apply/components/_form.scss
+++ b/hypha/static_src/src/sass/apply/components/_form.scss
@@ -11,20 +11,20 @@
 
             label {
                 display: block;
-                margin-bottom: 0.5em;
+                margin-block-end: 0.5em;
                 font-weight: $weight--bold;
             }
         }
 
         button {
-            margin-top: 1.5rem;
+            margin-block-start: 1.5rem;
         }
     }
 
     &--search-desktop {
         position: relative;
         max-width: 300px;
-        margin-top: $mobile-gutter;
+        margin-block-start: $mobile-gutter;
 
         @include media-query(tablet-landscape) {
             max-width: 280px;
@@ -46,17 +46,17 @@
 
     &__group {
         position: relative;
-        margin-top: 0.5rem;
-        margin-bottom: 1.5rem;
+        margin-block-start: 0.5rem;
+        margin-block-end: 1.5rem;
 
         &:nth-of-type(1) {
-            margin-top: 0;
+            margin-block-start: 0;
         }
 
         &:last-child {
             .locality & {
                 // remove margin from last item in address field set
-                margin-bottom: 0;
+                margin-block-end: 0;
             }
         }
 
@@ -137,13 +137,13 @@
 
         &--boolean_field {
             display: inline;
-            margin-bottom: 0;
+            margin-block-end: 0;
         }
         // stylelint-enable selector-class-pattern
     }
 
     &__file-label {
-        padding-bottom: 0.5rem;
+        padding-block-end: 0.5rem;
     }
 
     &__file-list {
@@ -165,7 +165,7 @@
     &__filters {
         #{$filter-dropdown} {
             border: 0;
-            border-top: 1px solid $color--mid-grey;
+            border-block-start: 1px solid $color--mid-grey;
 
             &.is-active {
                 font-weight: $weight--normal;
@@ -211,7 +211,7 @@
                 flex-basis: 225px;
 
                 &:not(:last-child) {
-                    margin-right: 10px;
+                    margin-inline-end: 10px;
                 }
             }
         }
@@ -298,7 +298,7 @@
         line-height: 1.25rem;
 
         .profile & {
-            margin-top: 0;
+            margin-block-start: 0;
         }
     }
 
@@ -323,7 +323,7 @@
 
     &__item {
         position: relative;
-        padding-top: 0.5rem;
+        padding-block-start: 0.5rem;
     }
 
     &__select {
@@ -334,7 +334,7 @@
         }
 
         .form--scoreable & {
-            margin-top: 20px;
+            margin-block-start: 20px;
         }
 
         .form {
@@ -405,15 +405,15 @@
 
         @include media-query(tablet-landscape) {
             position: absolute;
-            top: 0;
-            right: 0;
+            inset-block-start: 0;
+            inset-inline-end: 0;
             max-width: auto;
             margin: 0;
 
             &::before {
                 position: absolute;
-                top: 12px;
-                left: -10px;
+                inset-block-start: 12px;
+                inset-inline-start: -10px;
                 border-color: transparent $color--error transparent transparent;
                 border-style: solid;
                 border-width: 5px 10px 5px 0;
@@ -472,7 +472,7 @@
                 .wmd-input,
                 .wmd-preview {
                     max-width: 100%;
-                    margin-bottom: 0;
+                    margin-block-end: 0;
                 }
             }
 
@@ -508,7 +508,7 @@
 
     .errorlist {
         padding: 5px;
-        margin-bottom: 0.2em;
+        margin-block-end: 0.2em;
         background: $color--light-pink;
         border: 1px solid $color--tomato;
     }
@@ -520,17 +520,17 @@
 
         // stylelint-disable-next-line selector-class-pattern
         .form__group {
-            margin-top: 0.5rem;
+            margin-block-start: 0.5rem;
         }
 
         // stylelint-disable-next-line selector-class-pattern
         .form__question {
-            margin-bottom: 0.25rem;
+            margin-block-end: 0.25rem;
             font-size: 1rem;
             line-height: 1.25rem;
 
             &:nth-of-type(1) {
-                margin-top: 0;
+                margin-block-start: 0;
             }
         }
     }
@@ -549,7 +549,7 @@
     }
 
     .password-reset {
-        margin-top: -1em;
+        margin-block-start: -1em;
     }
 }
 

--- a/hypha/static_src/src/sass/apply/components/_funding-block.scss
+++ b/hypha/static_src/src/sass/apply/components/_funding-block.scss
@@ -2,7 +2,7 @@
     background-color: $color--light-blue;
     color: $color--white;
     padding: 1rem;
-    margin-bottom: 1rem;
+    margin-block-end: 1rem;
 
     @include media-query(mob-landscape) {
         padding: 2rem;

--- a/hypha/static_src/src/sass/apply/components/_grid.scss
+++ b/hypha/static_src/src/sass/apply/components/_grid.scss
@@ -27,7 +27,7 @@
 @supports (display: grid) {
     .grid {
         display: grid;
-        margin-bottom: 1rem;
+        margin-block-end: 1rem;
         gap: 10px;
         grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
 

--- a/hypha/static_src/src/sass/apply/components/_heading.scss
+++ b/hypha/static_src/src/sass/apply/components/_heading.scss
@@ -6,7 +6,7 @@
     &--meta {
         display: flex;
         flex-wrap: wrap;
-        margin-top: 0.25rem;
+        margin-block-start: 0.25rem;
 
         span {
             &::after {
@@ -25,17 +25,17 @@
     &--submission-meta {
         display: flex;
         flex-direction: column;
-        margin-top: 20px;
+        margin-block-start: 20px;
         font-weight: $weight--normal;
         color: transparentize($color--dark-grey, 0.5);
 
         @include media-query(tablet-landscape) {
             flex-direction: row;
-            margin-top: 0;
+            margin-block-start: 0;
         }
 
         span {
-            margin-right: 15px;
+            margin-inline-end: 15px;
         }
     }
 
@@ -55,7 +55,7 @@
         font-weight: 500;
         font-size: 1.25rem;
         line-height: 1.75rem;
-        margin-bottom: 0.25rem;
+        margin-block-end: 0.25rem;
     }
 
     &--bold {

--- a/hypha/static_src/src/sass/apply/components/_icon.scss
+++ b/hypha/static_src/src/sass/apply/components/_icon.scss
@@ -13,7 +13,7 @@
     &--person {
         width: 15px;
         height: 15px;
-        margin-right: 5px;
+        margin-inline-end: 5px;
         transition: fill $transition;
 
         .button:hover & {
@@ -25,7 +25,7 @@
         width: 40px;
         height: 40px;
         padding: 10px;
-        margin-right: 5px;
+        margin-inline-end: 5px;
     }
 
     &--close {
@@ -54,13 +54,13 @@
 
         // stylelint-disable-next-line selector-class-pattern
         .activity-feed__header & {
-            margin-left: 10px;
+            margin-inline-start: 10px;
         }
     }
 
     &--eye {
         position: relative;
-        top: 0.25em;
+        inset-block-start: 0.25em;
         align-self: center;
         width: 1em;
         height: 1em;
@@ -68,8 +68,8 @@
     }
 
     &--dashboard-tasks {
-        margin-left: 4px;
-        margin-right: 8px;
+        margin-inline-start: 4px;
+        margin-inline-end: 8px;
         width: 24px;
         height: 24px;
     }
@@ -86,7 +86,7 @@
         align-self: center;
         width: 1em;
         height: 1em;
-        margin-right: 2px;
+        margin-inline-end: 2px;
         stroke: $color--light-blue;
 
         .border:hover & {
@@ -98,7 +98,7 @@
         position: relative;
         align-self: center;
         height: 1.4em;
-        margin-right: 3px;
+        margin-inline-end: 3px;
         fill: $color--light-blue;
         stroke: $color--light-blue;
 
@@ -110,7 +110,7 @@
     &--request-changes {
         width: 20px;
         height: 20px;
-        margin-right: 4px;
-        margin-top: 2px;
+        margin-inline-end: 4px;
+        margin-block-start: 2px;
     }
 }

--- a/hypha/static_src/src/sass/apply/components/_invoice-block.scss
+++ b/hypha/static_src/src/sass/apply/components/_invoice-block.scss
@@ -1,6 +1,6 @@
 .invoice-block {
     padding: 1rem;
-    margin-bottom: 1rem;
+    margin-block-end: 1rem;
     border: 1px solid $color--dark-blue;
 
     @include media-query(mob-landscape) {
@@ -10,7 +10,7 @@
     }
 
     &__item {
-        margin-bottom: 1rem;
+        margin-block-end: 1rem;
 
         &:last-child {
             margin: 0;

--- a/hypha/static_src/src/sass/apply/components/_link.scss
+++ b/hypha/static_src/src/sass/apply/components/_link.scss
@@ -27,7 +27,7 @@
     }
 
     &--left-space {
-        margin-left: 20px;
+        margin-inline-start: 20px;
     }
 
     &--download {
@@ -35,7 +35,7 @@
         align-items: center;
         justify-content: space-between;
         padding: 15px 20px;
-        margin-top: 5px;
+        margin-block-start: 5px;
         color: $color--white;
         background: $color--light-blue;
         transition: background-color, $transition;
@@ -52,7 +52,7 @@
 
         span {
             @extend %h5;
-            margin-left: 10px;
+            margin-inline-start: 10px;
             font-weight: $weight--bold;
         }
 
@@ -147,14 +147,14 @@
     }
 
     &--delete-submission {
-        margin-right: 1rem;
-        padding-right: 1rem;
-        border-right: 2px solid $color--mid-grey;
+        margin-inline-end: 1rem;
+        padding-inline-end: 1rem;
+        border-inline-end: 2px solid $color--mid-grey;
 
         &:only-child {
-            border-right: 0;
-            padding-right: 0;
-            margin-right: 0;
+            border-inline-end: 0;
+            padding-inline-end: 0;
+            margin-inline-end: 0;
         }
     }
 
@@ -170,7 +170,7 @@
 
         &::before {
             @include triangle(top, $color--dark-blue, 7px);
-            margin-right: 0.7rem;
+            margin-inline-end: 0.7rem;
             transition: transform $transition;
             transform: rotate(180deg);
         }
@@ -184,6 +184,6 @@
 
     &--secondary-change {
         font-size: 95%;
-        margin-left: 5px;
+        margin-inline-start: 5px;
     }
 }

--- a/hypha/static_src/src/sass/apply/components/_list-reveal.scss
+++ b/hypha/static_src/src/sass/apply/components/_list-reveal.scss
@@ -3,7 +3,7 @@
 
     &--determination {
         background-color: $color--white;
-        margin-bottom: $mobile-gutter;
+        margin-block-end: $mobile-gutter;
 
         @include media-query(tablet-portrait) {
             max-width: 70%;
@@ -14,7 +14,7 @@
         display: block;
         font-size: map-get($font-sizes, zeta);
         padding: 0.75em 1em;
-        border-bottom: 2px solid $color--light-mid-grey;
+        border-block-end: 2px solid $color--light-mid-grey;
         margin: 0;
         color: $color--default;
 
@@ -37,19 +37,19 @@
         overflow: scroll;
         margin: 0 -24px $mobile-gutter;
         padding: 0;
-        border-bottom: 2px solid $color--light-mid-grey;
+        border-block-end: 2px solid $color--light-mid-grey;
         box-shadow: inset 0 -10px 20px -10px $color--mid-grey;
         transition: max-height $transition;
 
         &--determination {
-            border-left: 1px solid $color--light-mid-grey;
-            border-right: 1px solid $color--light-mid-grey;
+            border-inline-start: 1px solid $color--light-mid-grey;
+            border-inline-end: 1px solid $color--light-mid-grey;
             margin: 0;
         }
 
         &.is-closed {
             max-height: 0;
-            border-bottom: 0;
+            border-block-end: 0;
         }
     }
 

--- a/hypha/static_src/src/sass/apply/components/_list.scss
+++ b/hypha/static_src/src/sass/apply/components/_list.scss
@@ -9,8 +9,8 @@
     &--opinion {
         position: relative;
         font-size: 14px;
-        border-top: 1px solid $color--mid-grey;
-        border-bottom: 1px solid $color--mid-grey;
+        border-block-start: 1px solid $color--mid-grey;
+        border-block-end: 1px solid $color--mid-grey;
         margin: 10px 0;
         padding: 5px 0;
 
@@ -19,13 +19,13 @@
                 &::before,
                 &::after {
                     position: absolute;
-                    top: -15px;
-                    right: 5px;
+                    inset-block-start: -15px;
+                    inset-inline-end: 5px;
                 }
 
                 &::after {
                     @include triangle(top, $color--mist, 6px);
-                    top: -13px;
+                    inset-block-start: -13px;
                 }
 
                 &::before {
@@ -50,7 +50,7 @@
             align-items: center;
 
             > img {
-                margin-left: 10px;
+                margin-inline-start: 10px;
             }
 
             // show truncated emails on hover

--- a/hypha/static_src/src/sass/apply/components/_messages.scss
+++ b/hypha/static_src/src/sass/apply/components/_messages.scss
@@ -1,8 +1,8 @@
 .messages {
     position: fixed;
-    top: 2px;
-    left: 0;
-    right: 0;
+    inset-block-start: 2px;
+    inset-inline-start: 0;
+    inset-inline-end: 0;
     z-index: 25;
     pointer-events: none;
 
@@ -55,14 +55,14 @@
     }
 
     &__copy {
-        padding-right: 20px;
+        padding-inline-end: 20px;
         margin: 0;
         flex: 1;
         word-break: break-word;
     }
 
     &__button {
-        margin-left: auto;
+        margin-inline-start: auto;
         color: $color--dark-blue;
         background-color: $color--white;
         display: inline-block;

--- a/hypha/static_src/src/sass/apply/components/_modal.scss
+++ b/hypha/static_src/src/sass/apply/components/_modal.scss
@@ -17,7 +17,7 @@
         text-align: center;
 
         &--no-bottom-space {
-            margin-bottom: 0;
+            margin-block-end: 0;
         }
     }
 
@@ -29,7 +29,7 @@
         text-align: left;
 
         &--no-bottom-space {
-            margin-bottom: 0;
+            margin-block-end: 0;
         }
     }
 
@@ -38,13 +38,13 @@
         overflow: scroll;
         margin: 0 -24px 20px;
         padding: 0;
-        border-bottom: 2px solid $color--light-mid-grey;
+        border-block-end: 2px solid $color--light-mid-grey;
         box-shadow: inset 0 -10px 20px -10px $color--mid-grey;
         transition: max-height $transition;
 
         &.is-closed {
             max-height: 0;
-            border-bottom: 0;
+            border-block-end: 0;
         }
     }
 
@@ -52,7 +52,7 @@
         display: block;
         font-size: map-get($font-sizes, zeta);
         padding: 12px 28px;
-        border-bottom: 2px solid $color--light-mid-grey;
+        border-block-end: 2px solid $color--light-mid-grey;
         margin: 0;
         color: $color--default;
 

--- a/hypha/static_src/src/sass/apply/components/_nav.scss
+++ b/hypha/static_src/src/sass/apply/components/_nav.scss
@@ -8,7 +8,7 @@
 
     @include media-query(tablet-portrait) {
         flex-direction: row;
-        padding-top: 0;
+        padding-block-start: 0;
     }
 
     &--primary {
@@ -18,7 +18,7 @@
             flex-direction: row;
             justify-content: center;
             gap: 2rem;
-            margin-top: 0;
+            margin-block-start: 0;
             text-transform: none;
         }
 
@@ -30,7 +30,7 @@
     &__item {
         @include media-query(tablet-portrait) {
             &:last-child {
-                margin-right: 0;
+                margin-inline-end: 0;
             }
         }
     }
@@ -61,8 +61,8 @@
         &--active {
             &::after {
                 position: absolute;
-                bottom: 0;
-                left: 0;
+                inset-block-end: 0;
+                inset-inline-start: 0;
                 width: 100%;
                 height: 5px;
                 background-color: $color--dark-blue;

--- a/hypha/static_src/src/sass/apply/components/_nprogress.scss
+++ b/hypha/static_src/src/sass/apply/components/_nprogress.scss
@@ -8,8 +8,8 @@
 
         position: fixed;
         z-index: 1031;
-        top: 0;
-        left: 0;
+        inset-block-start: 0;
+        inset-inline-start: 0;
 
         width: 100%;
         height: 2px;
@@ -19,7 +19,7 @@
     .peg {
         display: block;
         position: absolute;
-        right: 0px;
+        inset-inline-end: 0px;
         width: 100px;
         height: 100%;
         box-shadow:
@@ -35,8 +35,8 @@
         display: block;
         position: fixed;
         z-index: 1031;
-        top: 15px;
-        right: 15px;
+        inset-block-start: 15px;
+        inset-inline-end: 15px;
     }
 
     .spinner-icon {

--- a/hypha/static_src/src/sass/apply/components/_pagination.scss
+++ b/hypha/static_src/src/sass/apply/components/_pagination.scss
@@ -2,8 +2,8 @@
     display: flex;
     justify-content: space-between;
     align-items: center;
-    margin-bottom: 60px;
-    margin-top: 30px;
+    margin-block-end: 60px;
+    margin-block-start: 30px;
 
     .per-page {
         a.current {
@@ -42,8 +42,8 @@
 
             &::after {
                 position: absolute;
-                top: 18.5px;
-                left: 22.5px;
+                inset-block-start: 18.5px;
+                inset-inline-start: 22.5px;
             }
         }
     }

--- a/hypha/static_src/src/sass/apply/components/_profile.scss
+++ b/hypha/static_src/src/sass/apply/components/_profile.scss
@@ -1,27 +1,27 @@
 .profile {
-    margin-top: $mobile-gutter;
+    margin-block-start: $mobile-gutter;
 
     @include media-query(tablet-portrait) {
         display: flex;
-        margin-top: 2rem;
+        margin-block-start: 2rem;
     }
 
     &__column {
-        padding-bottom: 2rem;
-        margin-bottom: 2rem;
-        border-bottom: 1px solid $color--light-mid-grey;
+        padding-block-end: 2rem;
+        margin-block-end: 2rem;
+        border-block-end: 1px solid $color--light-mid-grey;
 
         @include media-query(tablet-portrait) {
             width: 50%;
-            padding-right: 3rem;
+            padding-inline-end: 3rem;
             margin: 0 3rem 0 0;
-            border-right: 1px solid $color--light-mid-grey;
-            border-bottom: 0;
+            border-inline-end: 1px solid $color--light-mid-grey;
+            border-block-end: 0;
 
             &:last-child {
-                padding-right: 0;
-                margin-right: 0;
-                border-right: 0;
+                padding-inline-end: 0;
+                margin-inline-end: 0;
+                border-inline-end: 0;
             }
         }
     }

--- a/hypha/static_src/src/sass/apply/components/_projects-table.scss
+++ b/hypha/static_src/src/sass/apply/components/_projects-table.scss
@@ -27,7 +27,7 @@
 
     .reporting {
         .icon {
-            margin-right: 0.3rem;
+            margin-inline-end: 0.3rem;
             width: 25px;
             height: 25px;
             fill: $color--tomato;

--- a/hypha/static_src/src/sass/apply/components/_related-sidebar.scss
+++ b/hypha/static_src/src/sass/apply/components/_related-sidebar.scss
@@ -1,7 +1,7 @@
 .related-sidebar {
     ul {
         list-style-type: circle;
-        padding-left: 20px;
+        padding-inline-start: 20px;
     }
 
     &--collaps {
@@ -12,8 +12,8 @@
 
     &__show-button {
         position: absolute;
-        bottom: 0;
-        left: 0;
+        inset-block-end: 0;
+        inset-inline-start: 0;
         width: 100%;
         text-align: center;
         margin: 0;

--- a/hypha/static_src/src/sass/apply/components/_reminder-sidebar.scss
+++ b/hypha/static_src/src/sass/apply/components/_reminder-sidebar.scss
@@ -20,6 +20,6 @@
 
 .form {
     &__reminder {
-        padding-left: 70px;
+        padding-inline-start: 70px;
     }
 }

--- a/hypha/static_src/src/sass/apply/components/_responsive-table.scss
+++ b/hypha/static_src/src/sass/apply/components/_responsive-table.scss
@@ -16,7 +16,7 @@
     tbody {
         td {
             &.title {
-                padding-top: 15px;
+                padding-block-start: 15px;
             }
         }
     }

--- a/hypha/static_src/src/sass/apply/components/_reviews-list.scss
+++ b/hypha/static_src/src/sass/apply/components/_reviews-list.scss
@@ -1,6 +1,6 @@
 .reviews-list {
     position: relative;
-    margin-top: 40px;
+    margin-block-start: 40px;
     table-layout: auto;
 
     &__body {
@@ -18,8 +18,8 @@
     }
 
     &__tr {
-        border-top: 0;
-        border-bottom: 2px solid $color--light-grey;
+        border-block-start: 0;
+        border-block-end: 2px solid $color--light-grey;
     }
 
     &__td {
@@ -33,7 +33,7 @@
                 align-items: center;
 
                 img {
-                    margin-left: 7px;
+                    margin-inline-start: 7px;
                 }
             }
         }
@@ -53,7 +53,7 @@
 
     &__th--author {
         position: sticky;
-        top: 0;
+        inset-block-start: 0;
         background-color: $color--white;
     }
 }

--- a/hypha/static_src/src/sass/apply/components/_reviews-sidebar.scss
+++ b/hypha/static_src/src/sass/apply/components/_reviews-sidebar.scss
@@ -2,22 +2,22 @@
 
 .reviews-sidebar {
     $root: &;
-    margin-bottom: 20px;
+    margin-block-end: 20px;
     font-weight: $weight--bold;
 
     &__decision {
         position: relative;
         font-size: 14px;
-        border-top: 1px solid $color--mid-grey;
-        border-bottom: 1px solid $color--mid-grey;
-        margin-bottom: 20px;
-        padding-top: 10px;
+        border-block-start: 1px solid $color--mid-grey;
+        border-block-end: 1px solid $color--mid-grey;
+        margin-block-end: 20px;
+        padding-block-start: 10px;
     }
 
     &__item {
         display: flex;
         justify-content: space-between;
-        margin-bottom: 20px;
+        margin-block-end: 20px;
 
         @supports (display: grid) {
             display: grid;
@@ -26,7 +26,7 @@
         }
 
         &--decision {
-            margin-bottom: 10px;
+            margin-block-end: 10px;
             font-weight: $weight--semibold;
 
             &:first-child {
@@ -34,13 +34,13 @@
                     &::before,
                     &::after {
                         position: absolute;
-                        top: -23px;
-                        left: 5px;
+                        inset-block-start: -23px;
+                        inset-inline-start: 5px;
                     }
 
                     &::after {
                         @include triangle(top, $color--white, 8px);
-                        top: -21px;
+                        inset-block-start: -21px;
                     }
 
                     &::before {
@@ -94,7 +94,7 @@
         }
 
         img {
-            margin-left: 7px;
+            margin-inline-start: 7px;
         }
     }
 
@@ -111,6 +111,6 @@
     }
 
     &__split {
-        margin-bottom: 20px;
+        margin-block-end: 20px;
     }
 }

--- a/hypha/static_src/src/sass/apply/components/_reviews-summary.scss
+++ b/hypha/static_src/src/sass/apply/components/_reviews-summary.scss
@@ -8,7 +8,7 @@
 
     &__tr {
         vertical-align: top;
-        border-bottom: 0;
+        border-block-end: 0;
     }
 
     &__td {

--- a/hypha/static_src/src/sass/apply/components/_revision.scss
+++ b/hypha/static_src/src/sass/apply/components/_revision.scss
@@ -11,7 +11,7 @@
         flex-direction: column;
         padding: 15px;
         background: $color--white;
-        border-bottom: 1px dashed $color--mid-grey;
+        border-block-end: 1px dashed $color--mid-grey;
 
         @include media-query(tablet-portrait) {
             flex-direction: row;
@@ -23,7 +23,7 @@
         }
 
         &:last-child {
-            border-bottom: 0;
+            border-block-end: 0;
         }
     }
 

--- a/hypha/static_src/src/sass/apply/components/_rich-text.scss
+++ b/hypha/static_src/src/sass/apply/components/_rich-text.scss
@@ -1,5 +1,5 @@
 .rich-text {
-    margin-bottom: 2rem;
+    margin-block-end: 2rem;
     word-break: break-word;
     max-width: $max-text-line-length;
 
@@ -8,7 +8,7 @@
             margin: 0 0 2rem;
 
             p:first-of-type {
-                margin-top: 0;
+                margin-block-start: 0;
             }
 
             p:empty {
@@ -19,19 +19,19 @@
 
     h1 {
         font-size: 1.296rem;
-        margin-bottom: 1em;
+        margin-block-end: 1em;
         font-weight: 600;
         line-height: 1.3333;
     }
 
     h1:not(:first-child) {
-        margin-top: 2em;
+        margin-block-start: 2em;
     }
 
     h2 {
         font-size: 1.215rem;
-        margin-top: 1.6em;
-        margin-bottom: 0.6em;
+        margin-block-start: 1.6em;
+        margin-block-end: 0.6em;
         line-height: 1.6;
         font-weight: 600;
     }
@@ -39,16 +39,16 @@
     h3,
     h4:not(.question) {
         font-size: 1.138rem;
-        margin-top: 1.5em;
-        margin-bottom: 0.5em;
+        margin-block-start: 1.5em;
+        margin-block-end: 0.5em;
         line-height: 1.5;
     }
 
     h5,
     h6 {
         font-size: 1.067rem;
-        margin-top: 1.4em;
-        margin-bottom: 0.4em;
+        margin-block-start: 1.4em;
+        margin-block-end: 0.4em;
         line-height: 1.4;
     }
 
@@ -65,12 +65,12 @@
     // to the parent element, because the table is wrapped in a div with overflow: auto
     &__table {
         overflow: auto;
-        margin-top: 1.25em;
-        margin-bottom: 1.25em;
+        margin-block-start: 1.25em;
+        margin-block-end: 1.25em;
 
         > table {
-            margin-top: 0;
-            margin-bottom: 0;
+            margin-block-start: 0;
+            margin-block-end: 0;
         }
     }
 
@@ -84,8 +84,8 @@
 
 .tox-statusbar {
     &__wordcount {
-        padding-left: 10px;
-        padding-right: 10px;
+        padding-inline-start: 10px;
+        padding-inline-end: 10px;
 
         &::after {
             content: attr(data-after-word-count);

--- a/hypha/static_src/src/sass/apply/components/_round-block.scss
+++ b/hypha/static_src/src/sass/apply/components/_round-block.scss
@@ -9,13 +9,13 @@
         align-items: center;
         background-color: $color--white;
         border: 1px solid $color--light-mid-grey;
-        border-bottom: 0;
+        border-block-end: 0;
         padding: 25px;
         transition: background-color $quick-transition;
         min-height: 80px;
 
         &:last-child {
-            border-bottom: 1px solid $color--light-mid-grey;
+            border-block-end: 1px solid $color--light-mid-grey;
         }
 
         @include media-query(tablet-landscape) {
@@ -35,7 +35,7 @@
         &--more {
             padding: 20px 25px;
             justify-content: center;
-            border-bottom: 1px solid $color--light-mid-grey;
+            border-block-end: 1px solid $color--light-mid-grey;
             min-height: auto;
 
             &:hover {

--- a/hypha/static_src/src/sass/apply/components/_section.scss
+++ b/hypha/static_src/src/sass/apply/components/_section.scss
@@ -4,8 +4,8 @@
         margin: $mobile-gutter 0;
 
         @include media-query(tablet-portrait) {
-            padding-right: 20px;
-            margin-bottom: 0;
+            padding-inline-end: 20px;
+            margin-block-end: 0;
         }
     }
 

--- a/hypha/static_src/src/sass/apply/components/_select2.scss
+++ b/hypha/static_src/src/sass/apply/components/_select2.scss
@@ -25,13 +25,13 @@
             }
 
             .select2-selection__rendered {
-                padding-left: 15px;
-                padding-right: 30px;
+                padding-inline-start: 15px;
+                padding-inline-end: 30px;
                 line-height: $dropdown-height;
             }
 
             .select2-selection__arrow {
-                right: 15px;
+                inset-inline-end: 15px;
                 height: $dropdown-height;
                 pointer-events: none;
                 background: url("./../../images/dropdown.svg") transparent
@@ -64,7 +64,7 @@
 
     .select2-dropdown {
         border: 0;
-        border-bottom: 1px solid $color--mid-grey;
+        border-block-end: 1px solid $color--mid-grey;
         border-radius: 0;
 
         @include media-query(small-tablet) {
@@ -80,7 +80,7 @@
         &::before {
             min-width: 20px;
             height: 20px;
-            margin-right: 10px;
+            margin-inline-end: 10px;
             background: $color--white;
             border: 1px solid $color--mid-grey;
             content: "";

--- a/hypha/static_src/src/sass/apply/components/_sidebar.scss
+++ b/hypha/static_src/src/sass/apply/components/_sidebar.scss
@@ -5,7 +5,7 @@
 
     &__inner {
         padding: 20px;
-        margin-bottom: 20px;
+        margin-block-end: 20px;
         border: 1px solid $color--mid-grey;
 
         &--light-blue {
@@ -19,8 +19,8 @@
                 display: block;
 
                 &--instructions {
-                    margin-top: 10px;
-                    margin-left: 10px;
+                    margin-block-start: 10px;
+                    margin-inline-start: 10px;
                 }
             }
         }
@@ -30,7 +30,7 @@
 
             &.is-visible {
                 display: block;
-                border-top: 0;
+                border-block-start: 0;
             }
         }
     }
@@ -40,7 +40,7 @@
         position: -webkit-sticky; /* for Safari */
         position: sticky;
         align-self: flex-start;
-        top: 0;
+        inset-block-start: 0;
     }
 
     &__paf-approvals {
@@ -56,7 +56,7 @@
     &__screening-selected-options {
         display: flex;
         flex-wrap: wrap;
-        margin-bottom: 1em;
+        margin-block-end: 1em;
     }
 
     &__screening-option {
@@ -64,8 +64,8 @@
         border: 1px solid $color--black-20;
         border-radius: 16px;
         padding: 6px;
-        padding-right: 12px;
-        padding-left: 12px;
+        padding-inline-end: 12px;
+        padding-inline-start: 12px;
         font-size: 0.8125rem;
     }
 
@@ -78,8 +78,8 @@
 
         &::after {
             position: absolute;
-            top: 50%;
-            right: 0;
+            inset-block-start: 50%;
+            inset-inline-end: 0;
             width: calc(100% - 60px);
             height: 1px;
             background-color: $color--black-20;

--- a/hypha/static_src/src/sass/apply/components/_simplified.scss
+++ b/hypha/static_src/src/sass/apply/components/_simplified.scss
@@ -2,12 +2,12 @@
 .simplified {
     &__admin-bar {
         position: relative;
-        right: 50%;
-        left: 50%;
+        inset-inline-end: 50%;
+        inset-inline-start: 50%;
         width: 100vw;
         padding: $mobile-gutter;
-        margin-right: -50vw;
-        margin-left: -50vw;
+        margin-inline-end: -50vw;
+        margin-inline-start: -50vw;
         color: $color--white;
         background-color: $color--dark-grey;
     }
@@ -35,7 +35,7 @@
 
         &::before {
             @include triangle(top, currentColor, 5px);
-            margin-right: 0.5rem;
+            margin-inline-end: 0.5rem;
             transform: rotate(-90deg);
         }
     }
@@ -48,7 +48,7 @@
 
         &::before {
             @include triangle(top, currentColor, 5px);
-            margin-right: 0.5rem;
+            margin-inline-end: 0.5rem;
             transform: rotate(-90deg);
         }
     }
@@ -65,7 +65,7 @@
         margin: 0;
 
         @include media-query(tablet-portrait) {
-            margin-bottom: 1rem;
+            margin-block-end: 1rem;
         }
 
         span {
@@ -96,33 +96,33 @@
         @include font-size(zeta);
         display: flex;
         flex-direction: column;
-        margin-top: $mobile-gutter;
+        margin-block-start: $mobile-gutter;
         font-weight: $weight--normal;
         color: transparentize($color--dark-grey, 0.5);
 
         @include media-query(tablet-landscape) {
             flex-direction: row;
-            margin-top: 0;
+            margin-block-start: 0;
         }
     }
 
     &__meta-item {
-        margin-right: 15px;
+        margin-inline-end: 15px;
 
         &:last-child {
-            margin-right: 0;
+            margin-inline-end: 0;
         }
     }
 
     &__rich-text {
-        margin-bottom: 2rem;
+        margin-block-end: 2rem;
         word-break: break-word;
 
         > section {
             margin: 0 0 2rem;
 
             p:first-of-type {
-                margin-top: 0;
+                margin-block-start: 0;
             }
 
             p:empty {

--- a/hypha/static_src/src/sass/apply/components/_stat-block.scss
+++ b/hypha/static_src/src/sass/apply/components/_stat-block.scss
@@ -19,7 +19,7 @@
         }
 
         &:last-child {
-            margin-right: 0;
+            margin-inline-end: 0;
         }
 
         &:only-child {
@@ -53,8 +53,8 @@
 
         @include media-query(tablet-portrait) {
             position: absolute;
-            top: 1rem;
-            right: 1rem;
+            inset-block-start: 1rem;
+            inset-inline-end: 1rem;
             opacity: 0;
 
             #{$root}__item:hover & {

--- a/hypha/static_src/src/sass/apply/components/_status-bar.scss
+++ b/hypha/static_src/src/sass/apply/components/_status-bar.scss
@@ -6,7 +6,7 @@
     --triangle: 5px;
     --tooltip-padding: 10px;
     --tooltip-max-width: 12ch;
-    --tooltip-margin-top: 17px;
+    --tooltip-margin-block-start: 17px;
 
     $root: &;
     display: none;
@@ -25,8 +25,8 @@
         --tooltip-max-width: 10ch;
         width: 100%;
         max-width: 750px;
-        margin-right: 30px;
-        margin-left: 16px;
+        margin-inline-end: 30px;
+        margin-inline-start: 16px;
     }
 
     &__subheading {
@@ -54,8 +54,8 @@
             display: flex;
             place-items: center;
             position: absolute;
-            top: calc(-1 * var(--dot) / 2);
-            left: calc(-1 * var(--dot) / 2);
+            inset-block-start: calc(-1 * var(--dot) / 2);
+            inset-inline-start: calc(-1 * var(--dot) / 2);
             width: var(--dot);
             height: var(--dot);
             background: $color--dark-grey;
@@ -99,7 +99,7 @@
 
         &:first-of-type {
             &::before {
-                left: 0;
+                inset-inline-start: 0;
             }
         }
 
@@ -111,8 +111,8 @@
             flex: 0;
 
             &::before {
-                left: auto;
-                right: 0;
+                inset-inline-start: auto;
+                inset-inline-end: 0;
             }
         }
     }
@@ -141,17 +141,17 @@
             #{$root}__item--is-current & {
                 @include triangle(top, $color--tomato, 5px);
                 position: absolute;
-                top: calc(-1 * var(--triangle) - 2px);
-                left: calc(50% - var(--triangle));
+                inset-block-start: calc(-1 * var(--triangle) - 2px);
+                inset-inline-start: calc(50% - var(--triangle));
             }
 
             #{$root}__item--is-current:first-of-type & {
-                left: var(--triangle);
+                inset-inline-start: var(--triangle);
             }
 
             #{$root}__item--is-current:last-of-type & {
-                left: initial;
-                right: var(--triangle);
+                inset-inline-start: initial;
+                inset-inline-end: var(--triangle);
             }
         }
 

--- a/hypha/static_src/src/sass/apply/components/_status-block.scss
+++ b/hypha/static_src/src/sass/apply/components/_status-block.scss
@@ -9,13 +9,13 @@
 
     &__item {
         padding: 20px;
-        border-bottom: 1px solid $color--light-mid-grey;
+        border-block-end: 1px solid $color--light-mid-grey;
         background-color: $color--white;
         transition: background-color $quick-transition;
 
         @include media-query(tablet-landscape) {
-            border-bottom: 0;
-            border-right: 1px solid $color--light-mid-grey;
+            border-block-end: 0;
+            border-inline-end: 1px solid $color--light-mid-grey;
             width: 100%;
             padding: 10px;
             display: flex;
@@ -36,7 +36,7 @@
         }
 
         &:last-child {
-            border-right: 0;
+            border-inline-end: 0;
         }
     }
 
@@ -50,7 +50,7 @@
         color: $color--dark-blue;
 
         @include media-query(tablet-landscape) {
-            margin-top: auto;
+            margin-block-start: auto;
         }
     }
 

--- a/hypha/static_src/src/sass/apply/components/_table.scss
+++ b/hypha/static_src/src/sass/apply/components/_table.scss
@@ -40,13 +40,13 @@
             transition: box-shadow 0.15s ease;
 
             @include media-query($table-breakpoint) {
-                border-top: 0;
-                border-right: 0;
-                border-bottom: 1px solid $color--light-mid-grey;
-                border-left: 0;
+                border-block-start: 0;
+                border-inline-end: 0;
+                border-block-end: 1px solid $color--light-mid-grey;
+                border-inline-start: 0;
 
                 &.is-expanded {
-                    border-bottom: 1px solid $color--light-grey;
+                    border-block-end: 1px solid $color--light-grey;
 
                     .lead {
                         span {
@@ -78,7 +78,7 @@
                             position: relative;
                             z-index: 1;
                             display: block;
-                            padding-right: 5px;
+                            padding-inline-end: 5px;
                             overflow: hidden;
                             text-overflow: ellipsis;
 
@@ -108,7 +108,7 @@
             }
 
             &.title {
-                padding-left: 20px;
+                padding-inline-start: 20px;
             }
         }
     }

--- a/hypha/static_src/src/sass/apply/components/_tabs.scss
+++ b/hypha/static_src/src/sass/apply/components/_tabs.scss
@@ -54,7 +54,7 @@
             padding: 0.5rem 1rem;
             text-transform: none;
             display: inline-block;
-            border-bottom: 3px solid transparent;
+            border-block-end: 3px solid transparent;
             color: $color--mid-dark-grey;
             width: auto;
 
@@ -64,7 +64,7 @@
 
             &#{$root}--active {
                 background-color: transparent;
-                border-bottom: 3px solid $color--primary;
+                border-block-end: 3px solid $color--primary;
 
                 &:hover {
                     color: $color--default;
@@ -88,7 +88,7 @@
 
             @include media-query(small-tablet) {
                 display: block;
-                margin-left: auto;
+                margin-inline-start: auto;
             }
         }
     }

--- a/hypha/static_src/src/sass/apply/components/_tooltip.scss
+++ b/hypha/static_src/src/sass/apply/components/_tooltip.scss
@@ -13,8 +13,8 @@
     pointer-events: none;
     transition: opacity, bottom, $transition;
     position: absolute;
-    bottom: 110%;
-    margin-bottom: 5px;
+    inset-block-end: 110%;
+    margin-block-end: 5px;
     padding: 7px;
     background-color: $color--dark-grey;
     color: $color--white;
@@ -26,5 +26,5 @@
 [data-tooltip]:hover::before {
     visibility: visible;
     opacity: 1;
-    bottom: 130%;
+    inset-block-end: 130%;
 }

--- a/hypha/static_src/src/sass/apply/components/_two-factor.scss
+++ b/hypha/static_src/src/sass/apply/components/_two-factor.scss
@@ -5,7 +5,7 @@
 
     &__back {
         position: absolute;
-        top: 0.5rem;
+        inset-block-start: 0.5rem;
     }
 
     h1,
@@ -15,7 +15,7 @@
     }
 
     .mb-3 {
-        margin-bottom: 1rem;
+        margin-block-end: 1rem;
     }
 }
 

--- a/hypha/static_src/src/sass/apply/components/_wrapper.scss
+++ b/hypha/static_src/src/sass/apply/components/_wrapper.scss
@@ -3,20 +3,20 @@
 
     &--small {
         max-width: $wrapper--small;
-        margin-left: auto;
-        margin-right: auto;
+        margin-inline-start: auto;
+        margin-inline-end: auto;
     }
 
     &--medium {
         max-width: $wrapper--medium;
-        margin-left: auto;
-        margin-right: auto;
+        margin-inline-start: auto;
+        margin-inline-end: auto;
     }
 
     &--large {
         max-width: $site-width;
-        margin-left: auto;
-        margin-right: auto;
+        margin-inline-start: auto;
+        margin-inline-end: auto;
     }
 
     &--main {
@@ -30,14 +30,14 @@
 
     &--blockquote {
         padding: 1rem 0;
-        margin-top: 2rem;
-        margin-bottom: 2rem;
+        margin-block-start: 2rem;
+        margin-block-end: 2rem;
         background: $color--light-grey;
 
         @include media-query(tablet-portrait) {
             padding: 4rem 0;
-            margin-top: 4rem;
-            margin-bottom: 4rem;
+            margin-block-start: 4rem;
+            margin-block-end: 4rem;
         }
 
         svg {
@@ -52,14 +52,14 @@
             }
 
             &:first-child {
-                top: 0;
-                left: 0;
+                inset-block-start: 0;
+                inset-inline-start: 0;
                 transform: rotate(90deg);
             }
 
             &:last-child {
-                right: 0;
-                bottom: 0;
+                inset-inline-end: 0;
+                inset-block-end: 0;
                 transform: rotate(-90deg);
             }
         }
@@ -118,12 +118,12 @@
     }
 
     &--bottom-space {
-        padding-bottom: 20px;
-        margin-bottom: 20px;
+        padding-block-end: 20px;
+        margin-block-end: 20px;
 
         @include media-query(tablet-portrait) {
-            padding-bottom: 3rem;
-            margin-bottom: 0;
+            padding-block-end: 3rem;
+            margin-block-end: 0;
         }
     }
 
@@ -197,12 +197,12 @@
             flex: 1;
 
             @include media-query(tablet-portrait) {
-                padding-right: 20px;
+                padding-inline-end: 20px;
             }
         }
 
         .card:first-child {
-            margin-top: 0;
+            margin-block-start: 0;
         }
     }
 
@@ -237,17 +237,17 @@
     &--status-bar-outer {
         padding: 20px 0;
         background-color: $color--white;
-        border-bottom: 3px solid $color--light-grey;
+        border-block-end: 3px solid $color--light-grey;
     }
 
     &--status-bar-inner {
         display: flex;
         flex-wrap: wrap;
         justify-content: space-between;
-        margin-bottom: 20px;
+        margin-block-end: 20px;
 
         @include media-query(tablet-portrait) {
-            margin-bottom: 0;
+            margin-block-end: 0;
         }
     }
 
@@ -257,21 +257,21 @@
 
     &--activity-feed {
         padding: 0 20px;
-        margin-top: 50px;
+        margin-block-start: 50px;
 
         @include media-query(tablet-landscape) {
-            margin-top: 70px;
+            margin-block-start: 70px;
         }
     }
 
     &--comments {
-        padding-bottom: 15px;
-        margin-bottom: 15px;
-        border-bottom: 1px solid $color--mid-grey;
+        padding-block-end: 15px;
+        margin-block-end: 15px;
+        border-block-end: 1px solid $color--mid-grey;
 
         @include media-query(tablet-portrait) {
-            padding-bottom: 35px;
-            margin-bottom: 35px;
+            padding-block-end: 35px;
+            margin-block-end: 35px;
         }
 
         .helptext {
@@ -299,13 +299,13 @@
     }
 
     &--submission-actions {
-        margin-left: auto;
+        margin-inline-start: auto;
         display: flex;
-        margin-top: 1rem;
+        margin-block-start: 1rem;
         align-items: flex-start;
 
         @include media-query(tablet-landscape) {
-            margin-top: 0;
+            margin-block-start: 0;
             justify-content: flex-end;
             flex: 1;
         }

--- a/hypha/static_src/src/sass/apply/fancybox.scss
+++ b/hypha/static_src/src/sass/apply/fancybox.scss
@@ -5,21 +5,21 @@ body.fancybox-active {
 
 body.fancybox-iosfix {
     position: fixed;
-    left: 0;
-    right: 0;
+    inset-inline-start: 0;
+    inset-inline-end: 0;
 }
 
 .fancybox-is-hidden {
     position: absolute;
-    top: -9999px;
-    left: -9999px;
+    inset-block-start: -9999px;
+    inset-inline-start: -9999px;
     visibility: hidden;
 }
 
 .fancybox-container {
     position: fixed;
-    top: 0;
-    left: 0;
+    inset-block-start: 0;
+    inset-inline-start: 0;
     width: 100%;
     height: 100%;
     z-index: 99992;
@@ -36,10 +36,10 @@ body.fancybox-iosfix {
 .fancybox-bg,
 .fancybox-stage {
     position: absolute;
-    top: 0;
-    right: 0;
-    bottom: 0;
-    left: 0;
+    inset-block-start: 0;
+    inset-inline-end: 0;
+    inset-block-end: 0;
+    inset-inline-start: 0;
 }
 
 .fancybox-outer {
@@ -85,8 +85,8 @@ body.fancybox-iosfix {
 }
 
 .fancybox-infobar {
-    top: 0;
-    left: 0;
+    inset-block-start: 0;
+    inset-inline-start: 0;
     font-size: 13px;
     padding: 0 10px;
     height: 44px;
@@ -103,8 +103,8 @@ body.fancybox-iosfix {
 }
 
 .fancybox-toolbar {
-    top: 0;
-    right: 0;
+    inset-block-start: 0;
+    inset-inline-end: 0;
     margin: 0;
     padding: 0;
 }
@@ -122,8 +122,8 @@ body.fancybox-iosfix {
 
 .fancybox-slide {
     position: absolute;
-    top: 0;
-    left: 0;
+    inset-block-start: 0;
+    inset-inline-start: 0;
     width: 100%;
     height: 100%;
     margin: 0;
@@ -201,8 +201,8 @@ body.fancybox-iosfix {
 
 .fancybox-slide .fancybox-image-wrap {
     position: absolute;
-    top: 0;
-    left: 0;
+    inset-block-start: 0;
+    inset-inline-start: 0;
     margin: 0;
     padding: 0;
     border: 0;
@@ -237,8 +237,8 @@ body.fancybox-iosfix {
 .fancybox-image,
 .fancybox-spaceball {
     position: absolute;
-    top: 0;
-    left: 0;
+    inset-block-start: 0;
+    inset-inline-start: 0;
     width: 100%;
     height: 100%;
     margin: 0;
@@ -367,7 +367,7 @@ body.fancybox-iosfix {
 
 .fancybox-navigation button {
     position: absolute;
-    top: 50%;
+    inset-block-start: 50%;
     margin: -50px 0 0 0;
     z-index: 99997;
     background: transparent;
@@ -379,27 +379,27 @@ body.fancybox-iosfix {
 .fancybox-navigation button:before {
     content: "";
     position: absolute;
-    top: 30px;
-    right: 10px;
+    inset-block-start: 30px;
+    inset-inline-end: 10px;
     width: 40px;
     height: 40px;
     background: rgba(30, 30, 30, 0.6);
 }
 
 .fancybox-navigation .fancybox-button--arrow_left {
-    left: 0;
+    inset-inline-start: 0;
 }
 
 .fancybox-navigation .fancybox-button--arrow_right {
-    right: 0;
+    inset-inline-end: 0;
 }
 
 /* Close button on the top right corner of html content */
 
 .fancybox-close-small {
     position: absolute;
-    top: 5px;
-    right: 5px;
+    inset-block-start: 5px;
+    inset-inline-end: 5px;
     width: 40px;
     height: 40px;
     padding: 0;
@@ -426,8 +426,8 @@ body.fancybox-iosfix {
 
 .fancybox-slide--image .fancybox-close-small,
 .fancybox-slide--iframe .fancybox-close-small {
-    top: 0;
-    right: -40px;
+    inset-block-start: 0;
+    inset-inline-end: -40px;
 }
 
 .fancybox-slide--image .fancybox-close-small:after,
@@ -450,9 +450,9 @@ body.fancybox-iosfix {
 /* Caption */
 
 .fancybox-caption-wrap {
-    bottom: 0;
-    left: 0;
-    right: 0;
+    inset-block-end: 0;
+    inset-inline-start: 0;
+    inset-inline-end: 0;
     padding: 60px 2vw 0 2vw;
     background: linear-gradient(
         to bottom,
@@ -467,7 +467,7 @@ body.fancybox-iosfix {
 
 .fancybox-caption {
     padding: 30px 0;
-    border-top: 1px solid rgba(255, 255, 255, 0.4);
+    border-block-start: 1px solid rgba(255, 255, 255, 0.4);
     font-size: 14px;
     color: #fff;
     line-height: 20px;
@@ -490,17 +490,17 @@ body.fancybox-iosfix {
 
 .fancybox-slide > .fancybox-loading {
     border: 6px solid rgba(100, 100, 100, 0.4);
-    border-top: 6px solid rgba(255, 255, 255, 0.6);
+    border-block-start: 6px solid rgba(255, 255, 255, 0.6);
     border-radius: 100%;
     height: 50px;
     width: 50px;
     animation: fancybox-rotate 0.8s infinite linear;
     background: transparent;
     position: absolute;
-    top: 50%;
-    left: 50%;
-    margin-top: -30px;
-    margin-left: -30px;
+    inset-block-start: 50%;
+    inset-inline-start: 50%;
+    margin-block-start: -30px;
+    margin-inline-start: -30px;
     z-index: 99999;
 }
 

--- a/hypha/static_src/src/sass/apply/layout/_header.scss
+++ b/hypha/static_src/src/sass/apply/layout/_header.scss
@@ -2,7 +2,7 @@
     position: relative;
     padding: 20px;
     background-color: var(--color-header-bg);
-    border-bottom: 1px solid rgb(136 146 171 / 10%);
+    border-block-end: 1px solid rgb(136 146 171 / 10%);
 
     &__inner {
         position: relative;
@@ -81,8 +81,8 @@
 
         &--mobile {
             position: fixed;
-            top: 0;
-            left: 0;
+            inset-block-start: 0;
+            inset-inline-start: 0;
             z-index: 10;
             width: 100%;
             height: 100%;

--- a/hypha/static_src/src/sass/apply/wagtail_groups_list.scss
+++ b/hypha/static_src/src/sass/apply/wagtail_groups_list.scss
@@ -1,6 +1,6 @@
 .group-help-text {
     font-size: smaller;
-    padding-left: 10px;
+    padding-inline-start: 10px;
 }
 
 // Stylings used for the Wagtail admin "roles" tab when creating/editing a user

--- a/hypha/static_src/src/sass/apply/wagtail_users_list.scss
+++ b/hypha/static_src/src/sass/apply/wagtail_users_list.scss
@@ -21,14 +21,14 @@
 
         button[type="submit"] {
             display: block;
-            margin-top: 20px;
+            margin-block-start: 20px;
         }
     }
 
     &__export {
         button {
             display: block;
-            margin-top: 20px;
+            margin-block-start: 20px;
         }
 
         a {

--- a/hypha/static_src/src/sass/normalize.scss
+++ b/hypha/static_src/src/sass/normalize.scss
@@ -86,7 +86,7 @@ a {
  */
 
 abbr[title] {
-    border-bottom: none; /* 1 */
+    border-block-end: none; /* 1 */
     text-decoration: underline; /* 2 */
     text-decoration: underline dotted; /* 2 */
 }
@@ -134,11 +134,11 @@ sup {
 }
 
 sub {
-    bottom: -0.25em;
+    inset-block-end: -0.25em;
 }
 
 sup {
-    top: -0.5em;
+    inset-block-start: -0.5em;
 }
 
 /* Embedded content

--- a/hypha/static_src/src/sass/print.scss
+++ b/hypha/static_src/src/sass/print.scss
@@ -76,12 +76,12 @@ h3 {
 
 .admin-bar {
     position: static;
-    right: auto;
-    left: auto;
+    inset-inline-end: auto;
+    inset-inline-start: auto;
     width: auto;
     padding: 0;
-    margin-right: 0;
-    margin-left: 0;
+    margin-inline-end: 0;
+    margin-inline-start: 0;
 }
 
 nav,


### PR DESCRIPTION
Fixes #3731

Improves rtl support among other things. Replaces attributes like top/left/margin-right/padding-left as well as tailwind classes with `*-inline*` and `*-block*` version.

`padding-inline-start` is for ltr the same as `padding-left` but for rtl it is the same as `padding-right`. The browser just does the right thing.

For tailwind we should always use `ms-1` instead of `ml-1` and `me-1` instead of `mr-1` etc. The s/e stands for start/end.

## Test Steps
 - [ ] Look at multiple pages and confirm that the styling is not off/look weird anywhere.
