### PR TITLE
Fix url namespace warnings.

### DIFF
--- a/hypha/apply/projects/urls.py
+++ b/hypha/apply/projects/urls.py
@@ -146,30 +146,4 @@ urlpatterns = [
             )
         ),
     ),
-    path(
-        "vendor/",
-        include(
-            (
-                [
-                    path("", ReportListView.as_view(), name="all"),
-                    path(
-                        "<int:pk>/",
-                        include(
-                            [
-                                path("", ReportDetailView.as_view(), name="detail"),
-                                path("skip/", ReportSkipView.as_view(), name="skip"),
-                                path("edit/", ReportUpdateView.as_view(), name="edit"),
-                                path(
-                                    "documents/<int:file_pk>/",
-                                    ReportPrivateMedia.as_view(),
-                                    name="document",
-                                ),
-                            ]
-                        ),
-                    ),
-                ],
-                "reports",
-            )
-        ),
-    ),
 ]


### PR DESCRIPTION
Fixes #3748.

To silence the remaning Django check warning one can add this to `local.py`:

`SILENCED_SYSTEM_CHECKS = ["urls.W003"]` 