### PR TITLE
Hide "Forms" menu in wagtail admin

### DIFF
--- a/hypha/apply/funds/wagtail_hooks.py
+++ b/hypha/apply/funds/wagtail_hooks.py
@@ -37,3 +37,13 @@ def register_permissions():
             "delete_applicationsubmission",
         ],
     )
+
+
+@hooks.register("construct_main_menu")
+def hide_forms_menu_item(request, menu_items):
+    """Hides the "Forms" menu item from the main menu.
+
+    The "Forms" menu item is added by wagtail.contrib.forms.
+    """
+    menu_items[:] = [item for item in menu_items if item.name != "forms"]
+    return menu_items


### PR DESCRIPTION

<!--
Thanks for contributing to Hypha!

Please ensure your contributions pass all necessary linting/testing and that the appropriate documentation has been updated.
-->

## Description
<!--
Describe briefly what your pull request changes. If this is resoving an issue, please specify below via "Fixes #<Github Issue ID>"
-->
The "Forms" menu is added by the wagtail.contrib.forms, hypha doesn't
use it, so this PR simply hidee/removes the main menu

Fixes: https://github.com/HyphaApp/hypha/issues/3745


## Test Steps
<!-- 
If step does not require manual testing, skip/remove this section.

Give a brief overview of the steps required for a user/dev to test this contribution. Important things to include:
 - Required user roles for where neccesary (ie. "As a Staff Admin...")
 - Clear & validatable expected results (ie. "Confirm the submit button is now not clickable")
 - Langauge that can be understood by non-technical testers if being tested by users
-->

 - [ ] Goto wagatail admin and on the left sidebar you shouldn't see the "Forms" menu
