### PR TITLE
Add goto apply listing for user with no dashboard

### DIFF
--- a/hypha/apply/users/templates/users/account.html
+++ b/hypha/apply/users/templates/users/account.html
@@ -1,5 +1,5 @@
 {% extends 'base-apply.html' %}
-{% load i18n users_tags %}
+{% load i18n users_tags wagtailcore_tags %}
 
 {% block title %}{% trans "Account" %}{% endblock %}
 
@@ -13,6 +13,17 @@
                 {% trans "Go to my dashboard" %}
                 <svg><use xlink:href="#arrow-head-pixels--solid"></use></svg>
             </a>
+        {% else %}
+            <div class="wrapper wrapper--cta-box flex items-center">
+                <div class="flex-1">
+                    <h3 class="heading heading--no-margin font-bold">{% trans "Submit a new application" %}</h3>
+                    <p class="text-base m-0">{% trans "Apply now for our open rounds" %}</p>
+                </div>
+                <div>
+                    <a class="button button--blue-white" href="{% pageurl APPLY_SITE.root_page %}" class="button">{% trans "Apply" %}</a>
+                </div>
+            </div>
+
         {% endif %}
     {% endadminbar %}
 


### PR DESCRIPTION
<!--
Thanks for contributing to Hypha!

Please ensure your contributions pass all necessary linting/testing and that the appropriate documentation has been updated.
-->

## Description
<!--
Describe briefly what your pull request changes. If this is resoving an issue, please specify below via "Fixes #<Github Issue ID>"
-->
For users, who just just logged and doesn't have any role yet, they can
only visit their profile page.

This adds link to the "apply" fund listing page. Clicking on the logo to
go their is not super obvious. This PR fixes it.

![Screenshot 2024-02-09 at 11  33 59@2x](https://github.com/HyphaApp/hypha/assets/236356/e82c4947-790c-4027-ac02-64c581ac03a6)


## Test Steps
<!-- 
If step does not require manual testing, skip/remove this section.

Give a brief overview of the steps required for a user/dev to test this contribution. Important things to include:
 - Required user roles for where neccesary (ie. "As a Staff Admin...")
 - Clear & validatable expected results (ie. "Confirm the submit button is now not clickable")
 - Langauge that can be understood by non-technical testers if being tested by users
-->

 - [ ] signup to a new account, do not apply to any fund
 - [ ] goto to your profile by click on the top nav, top right
 - [ ] See "submit an application" call to action, instead "goto your dashboard"

