### PR TITLE
Fix footer display on the htmx rendered pages

### DIFF
--- a/hypha/templates/includes/_partial-main.html
+++ b/hypha/templates/includes/_partial-main.html
@@ -1,4 +1,4 @@
-<main class="wrapper wrapper--large wrapper--main" id="main">
+<main class="wrapper wrapper--large wrapper--main grow" id="main">
     {% block content_wrapper %}
         {% block content %}{% endblock %}
     {% endblock %}


### PR DESCRIPTION
<!--
Thanks for contributing to Hypha!

Please ensure your contributions pass all necessary linting/testing and that the appropriate documentation has been updated.
-->

## Description
<!--
Describe briefly what your pull request changes. If this is resoving an issue, please specify below via "Fixes #<Github Issue ID>"
-->

This fixes the partial html returned to replace the <main> section, adds flex `grow` so that the footer div sticks to the bottom on the pages with less content.

![Screenshot 2024-02-09 at 3  21 01@2x](https://github.com/HyphaApp/hypha/assets/236356/8701a6a2-323f-49ab-9e35-171a11dc66a2)


## Test Steps
<!-- 
If step does not require manual testing, skip/remove this section.

Give a brief overview of the steps required for a user/dev to test this contribution. Important things to include:
 - Required user roles for where neccesary (ie. "As a Staff Admin...")
 - Clear & validatable expected results (ie. "Confirm the submit button is now not clickable")
 - Langauge that can be understood by non-technical testers if being tested by users
-->

 - [ ] on a relatively big screen, use passwordless login
 - [ ] After email is submitted, the server returns just the <main> content, ensure the footer sticks to the bottom and not mid-way of the page
