### PR TITLE
Fix homepage title and upgrade tailwind to 3.4.x

### DIFF
--- a/hypha/apply/home/templates/apply_home/apply_home_page.html
+++ b/hypha/apply/home/templates/apply_home/apply_home_page.html
@@ -14,8 +14,10 @@
 
 {% block content %}
     <div class="py-8 lg:py-16  max-w-3xl mx-auto">
+        <h1 class="font-bold text-5xl text-balance">{{ page.title }}</h1>
+
         {% if page.strapline %}
-            <h1 class="font-bold mb-8">{{ page.strapline }}</h1>
+            <p class="mb-8 text-fg-muted text-pretty">{{ page.strapline }}</p>
         {% endif %}
 
         <div class="divide-y">

--- a/hypha/apply/home/templates/apply_home/includes/apply_listing.html
+++ b/hypha/apply/home/templates/apply_home/includes/apply_listing.html
@@ -1,7 +1,7 @@
 {% load i18n bleach_tags wagtailcore_tags markdown_tags heroicons %}
 
 {% if page.open_round %}
-  <div class="flex justify-between items-center py-8 gap-4">
+  <div class="flex justify-between items-center px-4 py-8 gap-4 hover:bg-slate-50 transition-colors">
 
     <div>
       <h2>{{ page.title }}</h2>

--- a/package-lock.json
+++ b/package-lock.json
@@ -29,10 +29,10 @@
         "stylelint": "^15.10.2",
         "stylelint-config-standard": "^34.0.0",
         "stylelint-config-standard-scss": "^10.0.0",
-        "tailwindcss": "^3.3.6"
+        "tailwindcss": "^3.4.1"
       },
       "engines": {
-        "node": "18.x"
+        "node": "20.10.x"
       }
     },
     "node_modules/@aashutoshrathi/word-wrap": {
@@ -5849,9 +5849,9 @@
       "dev": true
     },
     "node_modules/tailwindcss": {
-      "version": "3.3.6",
-      "resolved": "https://registry.npmjs.org/tailwindcss/-/tailwindcss-3.3.6.tgz",
-      "integrity": "sha512-AKjF7qbbLvLaPieoKeTjG1+FyNZT6KaJMJPFeQyLfIp7l82ggH1fbHJSsYIvnbTFQOlkh+gBYpyby5GT1LIdLw==",
+      "version": "3.4.1",
+      "resolved": "https://registry.npmjs.org/tailwindcss/-/tailwindcss-3.4.1.tgz",
+      "integrity": "sha512-qAYmXRfk3ENzuPBakNK0SRrUDipP8NQnEY6772uDhflcQz5EhRdD7JNZxyrFHVQNCwULPBn6FNPp9brpO7ctcA==",
       "dev": true,
       "dependencies": {
         "@alloc/quick-lru": "^5.2.0",

--- a/package.json
+++ b/package.json
@@ -49,7 +49,7 @@
     "stylelint": "^15.10.2",
     "stylelint-config-standard": "^34.0.0",
     "stylelint-config-standard-scss": "^10.0.0",
-    "tailwindcss": "^3.3.6"
+    "tailwindcss": "^3.4.1"
   },
   "scripts": {
     "heroku-postbuild": "npm run build",


### PR DESCRIPTION

<!--
Thanks for contributing to Hypha!

Please ensure your contributions pass all necessary linting/testing and that the appropriate documentation has been updated.
-->

## Description
<!--
Describe briefly what your pull request changes. If this is resoving an issue, please specify below via "Fixes #<Github Issue ID>"
-->
After removal of the public site, the apply homepage no longer displayed the page title. 
This PR fix the homepage to include page title.

Also, adds a subtle hover state to each of the fund list to improve it UX. 

Updgraes tailwindcss to 3.4 to make use of `text-balance` and `text-pretty` classes

## Test Steps
<!-- 
If step does not require manual testing, skip/remove this section.

Give a brief overview of the steps required for a user/dev to test this contribution. Important things to include:
 - Required user roles for where neccesary (ie. "As a Staff Admin...")
 - Clear & validatable expected results (ie. "Confirm the submit button is now not clickable")
 - Langauge that can be understood by non-technical testers if being tested by users
-->

 - [ ] goto homepage, it should include the page title and strapline
 - [ ] fund/lab listing has a hover state
