### PR TITLE
Add head end and body end include files. Empty by default to make it easy to insert custom content

### DIFF
--- a/hypha/templates/base.html
+++ b/hypha/templates/base.html
@@ -73,6 +73,7 @@
         <!-- modules -->
         <script type="module" src="{% static 'js/esm/github-relative-time-element-4-3-0.js' %}"></script>
         <script type="module" src="{% static 'js/esm/github-filter-input-element-0-1-1.js' %}"></script>
+        {% include "includes/head_end.html" %}
     </head>
 
     <body
@@ -139,5 +140,6 @@
                 </script>
             {% endif %}
         {% endblock sentry_sdk %}
+        {% include "includes/body_end.html" %}
     </body>
 </html>

--- a/hypha/templates/includes/body_end.html
+++ b/hypha/templates/includes/body_end.html
@@ -1,0 +1,1 @@
+{% comment %} Override in templates_custom to add custom content here. {% endcomment %}

--- a/hypha/templates/includes/head_end.html
+++ b/hypha/templates/includes/head_end.html
@@ -1,0 +1,1 @@
+{% comment %} Override in templates_custom to add custom content here. {% endcomment %}


### PR DESCRIPTION
Allow implementors to add `templates_custom/includes/head_end.html` and/or `templates_custom/includes/body_end.html` to easily insert things like tracking code etc. in to `base.html`.