### PR TITLE
Fix templates to show base header on determination forms

### DIFF
--- a/hypha/apply/determinations/templates/determinations/base_determination_form.html
+++ b/hypha/apply/determinations/templates/determinations/base_determination_form.html
@@ -3,12 +3,10 @@
 {% block title %}{% if object %}{% trans "Edit a Determination" %} {% if object.is_draft %}{% trans "draft" %}{% endif %}{% else %}{% trans "Create a Determination" %}{% endif %}{% endblock %}
 {% block content %}
 
-    {% block header %}
-        {% adminbar %}
-            {% slot header %}{% if object %}{% trans "Update Determination draft" %}{% else %}{% trans "Create Determination" %}{% endif %}{% endslot %}
-            {% slot sub_heading %}{% trans "For" %} <a href="{% url "funds:submissions:detail" submission.id %}">{{ submission.title }}</a>{% endslot %}
-        {% endadminbar %}
-    {% endblock %}
+    {% adminbar %}
+        {% slot header %}{% if object %}{% trans "Update Determination draft" %}{% else %}{% trans "Create Determination" %}{% endif %}{% endslot %}
+        {% slot sub_heading %}{% if submission %}{% trans "For" %} <a href="{% url "funds:submissions:detail" submission.id %}">{{ submission.title }}</a>{% endif %}{% endslot %}
+    {% endadminbar %}
 
     {% block form %}
         <section class="my-8">

--- a/hypha/apply/determinations/templates/determinations/batch_determination_form.html
+++ b/hypha/apply/determinations/templates/determinations/batch_determination_form.html
@@ -6,11 +6,9 @@
     <link rel="stylesheet" href="{% static 'css/fancybox.css' %}">
 {% endblock %}
 
-{% block header %}
-    {% adminbar %}
-        {% slot header %}{% trans "Add Batch Determination" %} - {{ action_name }}{% endslot %}
-    {% endadminbar %}
-{% endblock %}
+{% adminbar %}
+    {% slot header %}{% trans "Add Batch Determination" %} - {{ action_name }}{% endslot %}
+{% endadminbar %}
 
 {% block determination_information %}
     <div class="list-reveal list-reveal--determination">

--- a/hypha/apply/determinations/templates/determinations/determination_form.html
+++ b/hypha/apply/determinations/templates/determinations/determination_form.html
@@ -1,11 +1,9 @@
 {% extends "determinations/base_determination_form.html" %}
 {% load i18n %}
 
-{% block header %}
-    {% adminbar %}
-        {% slot header %}
-            {% if object %}{% trans "Edit determination" %} {% if object.is_draft %}{% trans "draft" %}{% endif %}{% else %}{% trans "Create Determination" %}{% endif %}
-        {% endslot %}
-        {% slot sub_heading %}{% trans "For" %} <a class="text-blue-300 hover:underline" href="{% url "funds:submissions:detail" submission.id %}">{{ submission.title }}</a>{% endslot %}
-    {% endadminbar %}
-{% endblock %}
+{% adminbar %}
+    {% slot header %}
+        {% if object %}{% trans "Edit determination" %} {% if object.is_draft %}{% trans "draft" %}{% endif %}{% else %}{% trans "Create Determination" %}{% endif %}
+    {% endslot %}
+    {% slot sub_heading %}{% trans "For" %} <a class="text-blue-300 hover:underline" href="{% url "funds:submissions:detail" submission.id %}">{{ submission.title }}</a>{% endslot %}
+{% endadminbar %}


### PR DESCRIPTION
Fixes #3797

Before:
<img width="777" alt="Skärmavbild 2024-03-02 kl  11 11 42" src="https://github.com/HyphaApp/hypha/assets/191392/9cc95c7d-14b4-492f-b756-90ec041bb695">

After:
<img width="855" alt="Skärmavbild 2024-03-02 kl  11 11 07" src="https://github.com/HyphaApp/hypha/assets/191392/8e0e0f34-3f03-4f97-810c-f624bdbd69fe">

## Test Steps

 - [ ] Headers are shown on determination forms.
 - [ ] Determinations works as they should still.
