### PR TITLE
Display "View Live" button only if round is live in admin

### DIFF
--- a/hypha/apply/funds/models/applications.py
+++ b/hypha/apply/funds/models/applications.py
@@ -5,6 +5,7 @@ from django import forms
 from django.conf import settings
 from django.contrib.postgres.fields import ArrayField
 from django.core.exceptions import ValidationError
+from django.core.handlers.wsgi import WSGIRequest
 from django.core.validators import MaxValueValidator, MinValueValidator
 from django.db import models
 from django.db.models import (
@@ -233,7 +234,7 @@ class RoundBase(WorkflowStreamForm, SubmittableStreamForm):  # type: ignore
     )
     sealed = models.BooleanField(default=False)
 
-    def get_url(self) -> Optional[str]:
+    def get_url(self, request: Optional[WSGIRequest] = None) -> Optional[str]:
         """Generates the live url, primarily used in the wagtail admin for the "view live" button.
 
         Returns:

--- a/hypha/apply/funds/models/applications.py
+++ b/hypha/apply/funds/models/applications.py
@@ -1,4 +1,5 @@
 from datetime import date
+from typing import Optional
 
 from django import forms
 from django.conf import settings
@@ -232,6 +233,18 @@ class RoundBase(WorkflowStreamForm, SubmittableStreamForm):  # type: ignore
     )
     sealed = models.BooleanField(default=False)
 
+    def get_url(self) -> Optional[str]:
+        """Generates the live url, primarily used in the wagtail admin for the "view live" button.
+
+        Returns:
+            str: The live url of the page, or None if the page is not live.
+        """
+        if self.is_open:
+            return self.fund.url
+        return None
+
+    url = property(get_url)
+
     content_panels = SubmittableStreamForm.content_panels + [
         FieldPanel("lead"),
         MultiFieldPanel(
@@ -302,8 +315,19 @@ class RoundBase(WorkflowStreamForm, SubmittableStreamForm):  # type: ignore
         return self.sealed and self.is_open
 
     @property
-    def is_open(self):
-        return self.start_date <= date.today() <= self.end_date
+    def is_open(self) -> bool:
+        """
+        Checks if the application is open based on the current date.
+
+        The application is considered open if the current date is between the start and end dates (inclusive).
+        If the end date is not set, the application is considered open if the current date is on or after the start date.
+
+        Returns:
+            bool: True if the application is open, False otherwise.
+        """
+        if self.start_date and self.end_date:
+            return self.start_date <= date.today() <= self.end_date
+        return self.start_date <= date.today()
 
     def save(self, *args, **kwargs):
         is_new = not self.id


### PR DESCRIPTION
## Description

Currently the "view live" button on the round detail admin page, links
to the round pages with the url containing fund slug followed by slug of
the round page.

The round can be accessed only via the fund url and the fund url serves
the active round, so the current link leads to 404.

This fixes the admin "view live" button so that it's displayed only if
the round is live and also links it correctly to the fund slug

Fixes #3794

## Test Steps
<!-- 
If step does not require manual testing, skip/remove this section.

Give a brief overview of the steps required for a user/dev to test this contribution. Important things to include:
 - Required user roles for where neccesary (ie. "As a Staff Admin...")
 - Clear & validatable expected results (ie. "Confirm the submit button is now not clickable")
 - Langauge that can be understood by non-technical testers if being tested by users
-->

 - [ ] Goto Admin > apply > rounds
 - [ ] Open one of the active rounds, based on start and end date
 - [ ] Ensure it displayed "Live" button on the top right corner.
 - [ ] If the page is not live, the button should be hidden
