### PR TITLE
Allow unassign staff reviewers only for inactive reviewers

### DIFF
--- a/hypha/apply/funds/forms.py
+++ b/hypha/apply/funds/forms.py
@@ -310,7 +310,7 @@ class UpdateReviewersForm(ApplicationSubmissionModelForm):
             ).last()
             if (
                 assigned_reviewer
-                and not cleaned_data[field]
+                and (not cleaned_data[field] and assigned_reviewer.reviewer.is_active)
                 and assigned_reviewer.reviewer in self.submitted_reviewers
             ):
                 self.add_error(


### PR DESCRIPTION
<!--
Thanks for contributing to Hypha!

Please ensure your contributions pass all necessary linting/testing and that the appropriate documentation has been updated.
-->

## Description
<!--
Describe briefly what your pull request changes. If this is resoving an issue, please specify below via "Fixes #<Github Issue ID>"
-->
Fixes #3553 


## Test Steps
<!-- 
If step does not require manual testing, skip/remove this section.

Give a brief overview of the steps required for a user/dev to test this contribution. Important things to include:
 - Required user roles for where neccesary (ie. "As a Staff Admin...")
 - Clear & validatable expected results (ie. "Confirm the submit button is now not clickable")
 - Langauge that can be understood by non-technical testers if being tested by users
-->

 - [ ] Assign a staff reviewer to a submission.
 - [ ] Submit the review
 - [ ] Set assigned reviewer as inactive via admin.
 - [ ] Try to update reviewers or unset that inactive reviewer.
