### PR TITLE
Hide wagtail admin > sidebar > search

### DIFF
--- a/hypha/core/wagtail_hooks.py
+++ b/hypha/core/wagtail_hooks.py
@@ -1,0 +1,10 @@
+from django.templatetags.static import static
+from django.utils.html import format_html
+from wagtail import hooks
+
+
+@hooks.register("insert_global_admin_css")
+def global_admin_css():
+    return format_html(
+        '<link rel="stylesheet" href="{}">', static("css/wagtail_global_admin.css")
+    )

--- a/hypha/static_src/sass/wagtail_global_admin.css
+++ b/hypha/static_src/sass/wagtail_global_admin.css
@@ -1,0 +1,3 @@
+.sidebar form[role="search"] {
+    display: none;
+}


### PR DESCRIPTION
## Description

Since the sidebar is generated via javascript / react, the best way I
could find to remove it is to use css and then hide it.

Fixes #3808

## Test Steps
<!-- 
If step does not require manual testing, skip/remove this section.

Give a brief overview of the steps required for a user/dev to test this contribution. Important things to include:
 - Required user roles for where neccesary (ie. "As a Staff Admin...")
 - Clear & validatable expected results (ie. "Confirm the submit button is now not clickable")
 - Langauge that can be understood by non-technical testers if being tested by users
-->

 - [ ] Goto admin, and check the sidebar
