### PR TITLE
Swapped out hamburger menu for a `Login` button in mobile view

### DIFF
--- a/hypha/templates/base-apply.html
+++ b/hypha/templates/base-apply.html
@@ -42,10 +42,19 @@
             </a>
 
             <div class="header__inner header__inner--mobile-buttons">
-                <button class="button button--left-space js-mobile-menu-toggle" aria-haspopup="true">
-                    <span class="sr-only">{% trans "Open Menu" %}</span>
-                    {% heroicon_outline "bars-3" size=32 stroke_width=2 class="inline" aria_hidden="true" %}
-                </button>
+                {% if request.user.is_authenticated %}
+                    <button class="button button--left-space js-mobile-menu-toggle" aria-haspopup="true">
+                        <span class="sr-only">{% trans "Open Menu" %}</span>
+                        {% heroicon_outline "bars-3" size=32 stroke_width=2 class="inline" aria_hidden="true" %}
+                    </button>
+                {% else %}
+                    {% if request.path != '/auth/' %}
+                        {% include "includes/login_button.html" %}
+                    {% endif %}
+                    {% if ENABLE_PUBLIC_SIGNUP and request.path == '/auth/' %}
+                        {% include "includes/register_button.html" %}
+                    {% endif %}
+                {% endif %}
             </div>
 
             {% block header_menu %}


### PR DESCRIPTION
<!--
Thanks for contributing to Hypha!

Please ensure your contributions pass all necessary linting/testing and that the appropriate documentation has been updated.
-->

## Description
<!--
Describe briefly what your pull request changes. If this is resoving an issue, please specify below via "Fixes #<Github Issue ID>"
-->
Fixes #3811. This removes the hamburger menu for unauthenticated users in favor of a simple `Login` button. If a signup is intended and `ENABLE_PUBLIC_SIGNUP` is enabled on the instance, the signup button can be found on the `/auth/` view. I didn't want to overload the mobile view by putting login & signup next to eachother.


## Test Steps
<!-- 
If step does not require manual testing, skip/remove this section.

Give a brief overview of the steps required for a user/dev to test this contribution. Important things to include:
 - Required user roles for where neccesary (ie. "As a Staff Admin...")
 - Clear & validatable expected results (ie. "Confirm the submit button is now not clickable")
 - Langauge that can be understood by non-technical testers if being tested by users
-->

**Testing no burger menu when not logged in**
 - [ ] Ensure you're logged out
 - [ ] Set screen width to <= 600px
 - [ ] Ensure only a `Login` button appears in the top right

**Testing burger menu for logged in users**
 - [ ] Ensure you're logged in
 - [ ] Set screen width to <= 600px
 - [ ] Ensure only [hamburger menu](https://github.com/tailwindlabs/heroicons/blob/master/src/24/outline/bars-3.svg) appears in the top right that shows dashboard options when selected.