### PR TITLE
Reduce the lazy load time for applicant submission on dashboard

### DIFF
--- a/hypha/apply/dashboard/templates/dashboard/applicant_dashboard.html
+++ b/hypha/apply/dashboard/templates/dashboard/applicant_dashboard.html
@@ -44,7 +44,7 @@
                     <h2 class="font-light flex-1">{% trans "My submissions" %}</h2>
                 </div>
 
-                <div hx-get="{% url 'dashboard:applicant_submissions' %}" hx-trigger="load delay:1000" id="submissions_list">
+                <div hx-get="{% url 'dashboard:applicant_submissions' %}" hx-trigger="load" id="submissions_list">
                     {% for dummy_item in per_section_items %}
                         <div class="wrapper wrapper--status-bar-outer animate-pulse min-h-40">
                             <div class="mt-5 ms-4 lg:max-w-[30%] h-9 bg-gray-200 "></div>

--- a/hypha/apply/dashboard/views.py
+++ b/hypha/apply/dashboard/views.py
@@ -521,9 +521,10 @@ class ApplicantDashboardView(TemplateView):
         context["my_submissions_exists"] = ApplicationSubmission.objects.filter(
             user=self.request.user
         ).exists()
-        context["per_section_items"] = range(
-            5
-        )  # it is just for animation, nothing to do with no of items there.
+
+        # Number of items to show in skeleton in each section of lazy loading
+        context["per_section_items"] = range(3)
+
         context["my_projects_exists"] = Project.objects.filter(
             user=self.request.user
         ).exists()


### PR DESCRIPTION
## Description

Right now, the my submission for the applicants on their dashboard is
loaded after 1s of page load which is too much delay.

This PR reduces the delay so it's the loading via htmx is triggered as
soon as the page is finished loading. Also, the PR reduces the loading
preview/skeleton to 3 so there is must of jumpiness before/after the
submissions are loading, this is based on the fact that on an average
there we only few submission by a single applicant.

<!--
Thanks for contributing to Hypha!

Please ensure your contributions pass all necessary linting/testing and that the appropriate documentation has been updated.
-->

<!--
Describe briefly what your pull request changes. If this is resoving an issue, please specify below via "Fixes #<Github Issue ID>"
-->

## Test Steps
<!-- 
If step does not require manual testing, skip/remove this section.

Give a brief overview of the steps required for a user/dev to test this contribution. Important things to include:
 - Required user roles for where neccesary (ie. "As a Staff Admin...")
 - Clear & validatable expected results (ie. "Confirm the submit button is now not clickable")
 - Langauge that can be understood by non-technical testers if being tested by users
-->

 - [ ] Login as applicant
 - [ ] Notice the difference in the loading of "My submission" section, it should be much after now
