### PR TITLE
Make PAF form required for fund creation on Project settings enabled

### DIFF
--- a/hypha/apply/funds/admin_forms.py
+++ b/hypha/apply/funds/admin_forms.py
@@ -2,6 +2,7 @@ from collections import Counter
 
 from django.apps import apps
 from django.conf import settings
+from django.utils.translation import gettext as _
 from wagtail.admin.forms import WagtailAdminModelForm, WagtailAdminPageForm
 
 from .models.submissions import ApplicationSubmission
@@ -102,7 +103,7 @@ class WorkflowFormAdminForm(WagtailAdminPageForm):
         if forms.is_valid():
             valid_forms = [form for form in forms if not form.cleaned_data["DELETE"]]
             if settings.PROJECTS_ENABLED and not valid_forms:
-                self.add_error(None, "Please provide Project Approval Form.")
+                self.add_error(None, _("Please provide Project Approval Form."))
 
 
 class RoundBasePageAdminForm(WagtailAdminPageForm):

--- a/hypha/apply/funds/admin_forms.py
+++ b/hypha/apply/funds/admin_forms.py
@@ -1,6 +1,7 @@
 from collections import Counter
 
 from django.apps import apps
+from django.conf import settings
 from wagtail.admin.forms import WagtailAdminModelForm, WagtailAdminPageForm
 
 from .models.submissions import ApplicationSubmission
@@ -16,6 +17,7 @@ class WorkflowFormAdminForm(WagtailAdminPageForm):
         review_forms = self.formsets["review_forms"]
         external_review_forms = self.formsets["external_review_forms"]
         determination_forms = self.formsets["determination_forms"]
+        paf_forms = self.formsets["approval_forms"]
         number_of_stages = len(workflow.stages)
 
         self.validate_application_forms(workflow, application_forms)
@@ -30,6 +32,7 @@ class WorkflowFormAdminForm(WagtailAdminPageForm):
         self.validate_stages_equal_forms(
             workflow, determination_forms, form_type="Determination form"
         )
+        self.validate_paf_form(paf_forms)
 
         return cleaned_data
 
@@ -94,6 +97,12 @@ class WorkflowFormAdminForm(WagtailAdminPageForm):
                         "form",
                         "Exceeds required number of forms for stage, please remove.",
                     )
+
+    def validate_paf_form(self, forms):
+        if forms.is_valid():
+            valid_forms = [form for form in forms if not form.cleaned_data["DELETE"]]
+            if settings.PROJECTS_ENABLED and not valid_forms:
+                self.add_error(None, "Please provide Project Approval Form.")
 
 
 class RoundBasePageAdminForm(WagtailAdminPageForm):

--- a/hypha/apply/funds/tests/test_admin_form.py
+++ b/hypha/apply/funds/tests/test_admin_form.py
@@ -1,5 +1,5 @@
 import factory
-from django.test import TestCase
+from django.test import TestCase, override_settings
 
 from hypha.apply.determinations.tests.factories import DeterminationFormFactory
 from hypha.apply.funds.models import FundType
@@ -209,11 +209,19 @@ class TestWorkflowFormAdminForm(TestCase):
         )
         self.assertTrue(form.is_valid(), form.errors.as_text())
 
+    @override_settings(PROJECTS_ENABLED=False)
     def test_does_validates_without_project_approval_form(self):
         form = self.submit_data(
             form_data(1, 1, 1, 0, num_project_approval_form=0, stages=1)
         )
         self.assertTrue(form.is_valid(), form.errors.as_text())
+
+    @override_settings(PROJECTS_ENABLED=True)
+    def test_dosnt_validates_without_project_approval_form_for_projects_enabled(self):
+        form = self.submit_data(
+            form_data(1, 1, 1, 0, num_project_approval_form=0, stages=1)
+        )
+        self.assertFalse(form.is_valid(), form.errors.as_text())
 
     def test_doesnt_validates_with_multiple_project_approval_form(self):
         form = self.submit_data(


### PR DESCRIPTION
<!--
Thanks for contributing to Hypha!

Please ensure your contributions pass all necessary linting/testing and that the appropriate documentation has been updated.
-->

## Description
<!--
Describe briefly what your pull request changes. If this is resoving an issue, please specify below via "Fixes #<Github Issue ID>"
-->
Fixes #3192 


## Test Steps
<!-- 
If step does not require manual testing, skip/remove this section.

Give a brief overview of the steps required for a user/dev to test this contribution. Important things to include:
 - Required user roles for where neccesary (ie. "As a Staff Admin...")
 - Clear & validatable expected results (ie. "Confirm the submit button is now not clickable")
 - Langauge that can be understood by non-technical testers if being tested by users
-->

 - [ ] Set PROJECTS_ENABLED = True (it is already true for test site)
 - [ ] Create/Edit a fund and leave Approval form empty. It should show the error that "Please provide Approval form"
