### PR TITLE
Add `APPLICANT_PARTNER` visibility to staff comment visibility

### DIFF
--- a/hypha/apply/activity/models.py
+++ b/hypha/apply/activity/models.py
@@ -224,7 +224,7 @@ class Activity(models.Model):
             A list of visibility strings
         """
         if user.is_apply_staff:
-            return [TEAM, APPLICANT, REVIEWER, PARTNER, ALL]
+            return [TEAM, APPLICANT, REVIEWER, APPLICANT_PARTNERS, PARTNER, ALL]
         if user.is_reviewer:
             return [REVIEWER, ALL]
         if user.is_finance or user.is_contracting:
@@ -259,6 +259,25 @@ class Activity(models.Model):
         """
         has_partner = submission_partner_list and len(submission_partner_list) > 0
 
+        if user.is_apply_staff:
+            if not has_partner:
+                choices = [
+                    (TEAM, VISIBILITY[TEAM]),
+                    (APPLICANT, VISIBILITY[APPLICANT]),
+                    (REVIEWER, VISIBILITY[REVIEWER]),
+                    (ALL, VISIBILITY[ALL]),
+                ]
+            else:
+                choices = [
+                    (TEAM, VISIBILITY[TEAM]),
+                    (APPLICANT, VISIBILITY[APPLICANT]),
+                    (PARTNER, VISIBILITY[PARTNER]),
+                    (APPLICANT_PARTNERS, VISIBILITY[APPLICANT_PARTNERS]),
+                    (REVIEWER, VISIBILITY[REVIEWER]),
+                    (ALL, VISIBILITY[ALL]),
+                ]
+            return choices
+
         if user.is_partner and has_partner and submission_partner_list.contains(user):
             return [
                 (APPLICANT_PARTNERS, VISIBILITY[APPLICANT_PARTNERS]),
@@ -277,26 +296,6 @@ class Activity(models.Model):
 
         if user.is_reviewer:
             return [(REVIEWER, VISIBILITY[REVIEWER])]
-
-        if user.is_apply_staff:
-            if not has_partner:
-                choices = [
-                    (TEAM, VISIBILITY[TEAM]),
-                    (APPLICANT, VISIBILITY[APPLICANT]),
-                    (REVIEWER, VISIBILITY[REVIEWER]),
-                    (ALL, VISIBILITY[ALL]),
-                ]
-            else:
-                choices = [
-                    (TEAM, VISIBILITY[TEAM]),
-                    (APPLICANT, VISIBILITY[APPLICANT]),
-                    (PARTNER, VISIBILITY[PARTNER]),
-                    (APPLICANT_PARTNERS, VISIBILITY[APPLICANT_PARTNERS]),
-                    (REVIEWER, VISIBILITY[REVIEWER]),
-                    (ALL, VISIBILITY[ALL]),
-                ]
-
-            return choices
 
         if user.is_finance or user.is_contracting:
             return [(TEAM, VISIBILITY[TEAM]), (APPLICANT, VISIBILITY[APPLICANT])]


### PR DESCRIPTION
<!--
Thanks for contributing to Hypha!

Please ensure your contributions pass all necessary linting/testing and that the appropriate documentation has been updated.
-->

<!--
Describe briefly what your pull request changes. If this is resoving an issue, please specify below via "Fixes #<Github Issue ID>"
-->
Fixes #3831. Somehow this slipped through both me & user testing but all works well now. Also swapped so staff comment logic gets evaluated first, thus if staff submits an application (usually for testing) then goes to make a comment to another application they won't be stuck with applicant options for visibility.


## Test Steps
<!-- 
If step does not require manual testing, skip/remove this section.

Give a brief overview of the steps required for a user/dev to test this contribution. Important things to include:
 - Required user roles for where neccesary (ie. "As a Staff Admin...")
 - Clear & validatable expected results (ie. "Confirm the submit button is now not clickable")
 - Langauge that can be understood by non-technical testers if being tested by users
-->

 - [ ] As `User Testing Applicant` create a new application and submit it.
 - [ ] As staff, add `User Testing Partner` as a partner on the created application.
 - [ ] As `User Testing Applicant` leave a comment on the application with `Partner` visibility
 - [ ] As staff, ensure the comment that was left is visible.