### PR TITLE
Add * to file field label instead of Upload button

### DIFF
--- a/hypha/apply/templates/forms/includes/field.html
+++ b/hypha/apply/templates/forms/includes/field.html
@@ -4,15 +4,17 @@
 
     <div class="form__group {{ field.id_for_label }} form__group--{{ widget_type }} {% if widget_type == 'checkbox_input' %} form__group--checkbox{% endif %}{% if widget_type == 'clearable_file_input' or widget_type == 'multi_file_input' or widget_type == 'single_file_field_widget' or widget_type == 'multi_file_field_widget' %} form__group--file{% endif %}{% if field.help_text %} form__group--wrap{% endif %}{% if field.errors %} form__error{% endif %}{% if is_application and field.field.group_number > 1 %} field-group field-group-{{ field.field.group_number }}{% endif %}{% if is_application and field.field.grouper_for %} form-fields-grouper{% endif %}"{% if is_application and field.field.grouper_for %}data-grouper-for="{{ field.field.grouper_for }}" data-toggle-on="{{ field.field.choices.0.0 }}" data-toggle-off="{{ field.field.choices.1.0 }}"{% endif %}{% if is_application and field.field.group_number > 1 %} data-hidden="{% if not show_all_group_fields and not field.field.visible %}true{% else %}false{% endif %}" data-required="{{ field.field.required_when_visible }}"{% endif %}{% if field.field.word_limit %} data-word-limit="{{ field.field.word_limit }}"{% endif %}>
         {% if widget_type == 'clearable_file_input' or widget_type == 'multi_file_input' or widget_type == 'single_file_field_widget' or widget_type == 'multi_file_field_widget'%}
-            <span class="form__question form__file-label">{{ field.label }}</span>
+            <span class="form__question form__file-label">
+                {{ field.label }}
+                {% if field.field.required %}
+                    <span class="form__required">*</span>
+                {% endif %}
+            </span>
             <label for="{{ field.id_for_label }}" class="mb-2 form__question form__question--{{ field_type }} {{ widget_type }}" {% if field.field.required %}required{% endif %}>
                 <span class="whitespace-nowrap">
                     {% heroicon_mini "arrow-up-tray" size=18 class="inline me-1" aria_hidden="true" %}
                     {% trans "Upload" %}
                 </span>
-                {% if field.field.required %}
-                    <span class="form__required">*</span>
-                {% endif %}
             </label>
         {% elif widget_type == 'checkbox_select_multiple' or widget_type == 'radio_select' %}
             <fieldset>


### PR DESCRIPTION
<!--
Thanks for contributing to Hypha!

Please ensure your contributions pass all necessary linting/testing and that the appropriate documentation has been updated.
-->

<!--
Describe briefly what your pull request changes. If this is resoving an issue, please specify below via "Fixes #<Github Issue ID>"
-->
Fixes #3640 

![image](https://github.com/HyphaApp/hypha/assets/23638629/0362f6d7-9f04-4f77-b3e4-6fc45db96f14)



## Test Steps
<!-- 
If step does not require manual testing, skip/remove this section.

Give a brief overview of the steps required for a user/dev to test this contribution. Important things to include:
 - Required user roles for where neccesary (ie. "As a Staff Admin...")
 - Clear & validatable expected results (ie. "Confirm the submit button is now not clickable")
 - Langauge that can be understood by non-technical testers if being tested by users
-->

 - [ ] Open any form that has a required file field
 - [ ] Check for the '*' on the label of the required file field.
