### PR TITLE
Fix table layout of Submissions Results page

### DIFF
--- a/hypha/apply/funds/templates/funds/includes/submission_stats.html
+++ b/hypha/apply/funds/templates/funds/includes/submission_stats.html
@@ -1,22 +1,22 @@
 {% load i18n apply_tags %}
-<div class="stat-block">
-    <div class="stat-block__item">
-        <h5>{% trans "Amounts" %}</h5>
-        <table>
+<div class="flex flex-wrap gap-4">
+    <div class="border p-4">
+        <strong>{% trans "Amounts" %}</strong>
+        <table class="mb-0">
             <tr><th>{% trans "Applied" %} ({{ ""|format_number_as_currency }})</th><th>{% trans "Accepted" %}  ({{ ""|format_number_as_currency }})</th></tr>
             <tr><td>{{ submission_sum|default:"0" }}</td><td>{{ submission_accepted_sum|default:"0" }}</td></tr>
         </table>
     </div>
-    <div class="stat-block__item">
+    <div class="border p-4">
         <h5>{% trans "Submissions" %}</h5>
-        <table>
-            <tr><th>{% trans "Applied" %}</th><th>{% trans "Accepted" %}</th><th>{% trans "Pending" %}</th></tr>
+        <table class="mb-0">
+            <tr><th class="px-4">{% trans "Applied" %}</th><th>{% trans "Accepted" %}</th><th>{% trans "Pending" %}</th></tr>
             <tr><td>{{ object_list.count }}</td><td>{{ submission_accepted_count|default:"0" }}</td><td>{{ submission_undetermined_count|default:"0" }}</td></tr>
         </table>
     </div>
-    <div class="stat-block__item">
+    <div class="border p-4">
         <h5>{% trans "Reviews" %}</h5>
-        <table>
+        <table class="mb-0">
             <tr><th>{% trans "All" %}</th><th>{% trans "You" %}</th><th>{% trans "Your avg. score" %}</th></tr>
             <tr><td>{{ review_count|default:"0" }}</td><td>{{ review_my_count|default:"0" }}</td><td>{{ review_my_score|floatformat:"0"|default:"0" }}</td></tr>
         </table>

--- a/hypha/apply/funds/templates/funds/submissions_result.html
+++ b/hypha/apply/funds/templates/funds/submissions_result.html
@@ -12,11 +12,46 @@
 
     <div class="wrapper wrapper--large wrapper--inner-space-medium">
         <div class="wrapper wrapper--bottom-space">
-            <h4 class="heading heading--normal">{% trans "Summary" %}</h4>
-            {% include "funds/includes/submission_stats.html" %}
+            <h3>{% trans "Summary" %}</h3>
+            <div class="prose max-w-none"><div class="flex flex-wrap gap-4">
+                <div class="border p-4 shadow">
+                    <h5>{% trans "Amounts" %}</h5>
+                    <table class="mb-0 mt-2">
+                        <tr><th class="pe-4">{% trans "Applied" %} ({{ ""|format_number_as_currency }})</th><th>{% trans "Accepted" %}  ({{ ""|format_number_as_currency }})</th></tr>
+                        <tr><td>{{ submission_sum|default:"0" }}</td><td>{{ submission_accepted_sum|default:"0" }}</td></tr>
+                    </table>
+                </div>
+                <div class="border p-4 shadow">
+                    <h5>{% trans "Submissions" %}</h5>
+                    <table class="mb-0 mt-2">
+                        <tr>
+                            <th class="pe-4">{% trans "Applied" %}</th>
+                            <th class="pe-4">{% trans "Accepted" %}</th>
+                            <th>{% trans "Pending" %}</th>
+                        </tr>
+                        <tr>
+                            <td>{{ object_list.count }}</td>
+                            <td>{{ submission_accepted_count|default:"0" }}</td>
+                            <td>{{ submission_undetermined_count|default:"0" }}</td>
+                        </tr>
+                    </table>
+                </div>
+                <div class="border p-4 shadow">
+                    <h5>{% trans "Reviews" %}</h5>
+                    <table class="mb-0 mt-2">
+                        <tr>
+                            <th class="pe-4">{% trans "All" %}</th>
+                            <th class="pe-4">{% trans "You" %}</th>
+                            <th>{% trans "Your avg. score" %}</th></tr>
+                        <tr><td>{{ review_count|default:"0" }}</td><td>{{ review_my_count|default:"0" }}</td><td>{{ review_my_score|floatformat:"0"|default:"0" }}</td></tr>
+                    </table>
+                </div>
+            </div>
+
+            </div>
         </div>
 
-        <h4 class="heading heading--normal">{% trans "Filter submissions to calculate values" %}</h4>
+        <h3>{% trans "Filter submissions to calculate values" %}</h3>
         {% include "funds/includes/table_filter_and_search.html" with filter_form=filter_form search_term=search_term use_search=True filter_action=filter_action use_batch_actions=False filter_classes="filters-open" %}
         <div class="grid">
             <div><strong>{% trans "Number of submission" %}:</strong> {{ count_values }}{% if not count_values == object_list.count %} ({{ object_list.count }}){% endif %}</div>


### PR DESCRIPTION
<!--
Thanks for contributing to Hypha!

Please ensure your contributions pass all necessary linting/testing and that the appropriate documentation has been updated.
-->

<!--
Describe briefly what your pull request changes. If this is resoving an issue, please specify below via "Fixes #<Github Issue ID>"
-->

The summary section table is unformatted, making it hard to read the stats.  This PR fixes it.

![Screenshot 2024-03-28 at 2  25 02@2x](https://github.com/HyphaApp/hypha/assets/236356/278375d4-cf30-45ac-865b-91668a0ea354)


## Test Steps
<!-- 
If step does not require manual testing, skip/remove this section.

Give a brief overview of the steps required for a user/dev to test this contribution. Important things to include:
 - Required user roles for where neccesary (ie. "As a Staff Admin...")
 - Clear & validatable expected results (ie. "Confirm the submit button is now not clickable")
 - Langauge that can be understood by non-technical testers if being tested by users
-->

 - [ ] Goto Header > Submissions Dropdown > Submissions Results
 - [ ] check the layout of the "Summary" section

![Screenshot 2024-03-28 at 2  19 13@2x](https://github.com/HyphaApp/hypha/assets/236356/1281ca93-9802-4910-adfe-1a1ea66590f4)
