### PR TITLE
Fix applicant dashboard invoices table Ui for smaller screens

### DIFF
--- a/hypha/apply/dashboard/templates/dashboard/applicant_dashboard.html
+++ b/hypha/apply/dashboard/templates/dashboard/applicant_dashboard.html
@@ -78,17 +78,17 @@
                 </div>
                 {% for invoice in active_invoices.data %}
                     <div class="wrapper wrapper--status-bar-outer">
-                        <div class="wrapper wrapper--status-bar-inner ps-4 pe-4">
-                            <div class="max-w-[33%] w-full text-start my-auto">
+                        <div class="wrapper flex flex-wrap justify-between ps-4 pe-4">
+                            <div class="md:w-1/3 flex flex-col item-start my-auto">
                                 <h4 class="heading heading--no-margin font-bold"><a class="link" href="{{ invoice.get_absolute_url }}">
                                     {% if invoice.invoice_number %}{{ invoice.invoice_number }}{% else %}{{ invoice.vendor_document_number }}{% endif %}
                                 </a></h4>
                                 <p class="m-0 text-fg-muted text-sm">{% trans "Date added: " %} {{ invoice.requested_at }}</p>
                             </div>
-                            <div class="max-w-[33%] w-full text-center my-auto">
+                            <div class="md:w-1/3 flex flex-col items-center text-center my-auto">
                                 <p class="text-2xl">{% if invoice.invoice_amount %}{{ invoice.invoice_amount | format_number_as_currency }}{% else %}-{% endif %}</p>
                             </div>
-                            <div class="max-w-[33%] w-full flex my-auto">
+                            <div class="md:w-1/3 flex flex-col items-end my-auto">
                                 {% display_invoice_table_status_for_user invoice.status request.user as invoice_status %}
                                 <div class="w-full flex-1"></div>
                                 <div class="max-w-fit w-full text-end">


### PR DESCRIPTION
<!--
Thanks for contributing to Hypha!

Please ensure your contributions pass all necessary linting/testing and that the appropriate documentation has been updated.
-->

<!--
Describe briefly what your pull request changes. If this is resoving an issue, please specify below via "Fixes #<Github Issue ID>"
-->
Fixes #3827 

Mobile UI:
<img width="392" alt="image" src="https://github.com/HyphaApp/hypha/assets/23638629/c2a57217-a393-446b-91c4-f6af70553487">


Desktop/Ipad:
<img width="755" alt="image" src="https://github.com/HyphaApp/hypha/assets/23638629/3ff96f4a-0924-4d72-8dae-539e8b70f465">



## Test Steps
<!-- 
If step does not require manual testing, skip/remove this section.

Give a brief overview of the steps required for a user/dev to test this contribution. Important things to include:
 - Required user roles for where neccesary (ie. "As a Staff Admin...")
 - Clear & validatable expected results (ie. "Confirm the submit button is now not clickable")
 - Langauge that can be understood by non-technical testers if being tested by users
-->

 - [ ] Just check the applicant dashboard invoices table.
