### PR TITLE
Make the open rounds beta filter the default

### DIFF
--- a/hypha/apply/funds/templates/funds/includes/round-block.html
+++ b/hypha/apply/funds/templates/funds/includes/round-block.html
@@ -1,7 +1,7 @@
 {% load i18n %}
 <div class="wrapper wrapper--bottom-space"
-     x-data="{ activeTab: 'closed-rounds' }"
-     x-init="activeTab = window.location.hash && ['#open-rounds', '#closed-rounds'].includes(window.location.hash) ? window.location.hash.substring(1) : 'closed-rounds'"
+     x-data="{ activeTab: 'open-rounds' }"
+     x-init="activeTab = window.location.hash && ['#open-rounds', '#closed-rounds'].includes(window.location.hash) ? window.location.hash.substring(1) : activeTab"
 >
     <section class="section section--with-options">
         <h4 class="heading heading--normal heading--no-margin">{{ title }}</a></h4>

--- a/hypha/apply/funds/templates/submissions/submenu/rounds.html
+++ b/hypha/apply/funds/templates/submissions/submenu/rounds.html
@@ -17,22 +17,26 @@
 
         <div
             role="tablist"
-            x-data="{tab: 'closed_rounds'}"
+            {% if open_rounds %}
+                x-data="{tab: 'open_rounds'}"
+            {% else %}
+                x-data="{tab: 'closed_rounds'}"
+            {% endif %}
         >
             <nav class="flex px-3 pt-2" style="box-shadow: inset 0 -1px 0 #e5e7eb">
-
-                {% if closed_rounds %}
-                    <span @click="tab = 'closed_rounds'"
-                          role="tab"
-                          :class="{ 'border-x border-t border-b-transparent': tab === 'closed_rounds' }"
-                          class="text-center bg-white inline-block px-4 py-2 border-b rounded-t-lg cursor-pointer hover:text-gray-900">{% trans "Closed" %}</span>
-                {% endif %}
 
                 {% if open_rounds %}
                     <span @click="tab = 'open_rounds'"
                           role="tab"
                           :class="{ 'border-x border-t border-b-transparent': tab === 'open_rounds' }"
                           class="text-center bg-white inline-block px-4 py-2 border-b rounded-t-lg round cursor-pointer hover:text-gray-900">{% trans "Open" %}</span>
+                {% endif %}
+
+                {% if closed_rounds %}
+                    <span @click="tab = 'closed_rounds'"
+                          role="tab"
+                          :class="{ 'border-x border-t border-b-transparent': tab === 'closed_rounds' }"
+                          class="text-center bg-white inline-block px-4 py-2 border-b rounded-t-lg cursor-pointer hover:text-gray-900">{% trans "Closed" %}</span>
                 {% endif %}
             </nav>
 


### PR DESCRIPTION
<!--
Thanks for contributing to Hypha!

Please ensure your contributions pass all necessary linting/testing and that the appropriate documentation has been updated.
-->

<!--
Describe briefly what your pull request changes. If this is resoving an issue, please specify below via "Fixes #<Github Issue ID>"
-->
Fixes #3857. Swaps the `Open` & `Closed` tabs in the beta round filter. This also ensures that the closed tab will be selected if there are no open rounds.


## Test Steps
<!-- 
If step does not require manual testing, skip/remove this section.

Give a brief overview of the steps required for a user/dev to test this contribution. Important things to include:
 - Required user roles for where neccesary (ie. "As a Staff Admin...")
 - Clear & validatable expected results (ie. "Confirm the submit button is now not clickable")
 - Langauge that can be understood by non-technical testers if being tested by users
-->

 - [ ] Navigate to the all submissions beta view as Staff
 - [ ] Ensure `Open` rounds is the default tab in the filter prompt
