### PR TITLE
Fix error message alignment for change password form

### DIFF
--- a/hypha/apply/templates/forms/includes/field.html
+++ b/hypha/apply/templates/forms/includes/field.html
@@ -56,7 +56,11 @@
 
                 {{ field }}
 
-                {% if field.errors %}<h6 class="form__error-text">{{ field.errors.as_text|linebreaksbr }}</h6>{% endif %}
+                {% if field.errors %}
+                    <h6 class="form__error-text">
+                        {{ field.errors.as_text|linebreaksbr }}
+                    </h6>
+                {% endif %}
                 {% if widget_type == 'clearable_file_input' or widget_type == 'multi_file_input' %}
                     <output class="form__file-list"></output>
                 {% endif %}

--- a/hypha/apply/templates/forms/includes/field.html
+++ b/hypha/apply/templates/forms/includes/field.html
@@ -57,9 +57,9 @@
                 {{ field }}
 
                 {% if field.errors %}
-                    <h6 class="form__error-text">
+                    <p class="form__error-text">
                         {{ field.errors.as_text|linebreaksbr }}
-                    </h6>
+                    </p>
                 {% endif %}
                 {% if widget_type == 'clearable_file_input' or widget_type == 'multi_file_input' %}
                     <output class="form__file-list"></output>

--- a/hypha/apply/users/templates/users/change_password.html
+++ b/hypha/apply/users/templates/users/change_password.html
@@ -14,7 +14,7 @@
     {% endadminbar %}
 
     <div class="wrapper mt-6 max-w-2xl">
-        <form class="form" action="" method="POST" novalidate>
+        <form class="form form--error-inline" action="" method="POST" novalidate>
             {% if redirect_url %}
                 <input type="hidden" value="{{ redirect_url }}" name="next">
             {% endif %}

--- a/hypha/static_src/sass/components/_form.scss
+++ b/hypha/static_src/sass/components/_form.scss
@@ -35,6 +35,7 @@
     &--error-inline {
         // stylelint-disable-next-line selector-class-pattern
         .form__error-text {
+            padding-left: 0.5rem;
             position: relative;
             max-width: 100%;
 


### PR DESCRIPTION
Inline error messages

![Screenshot 2024-04-10 at 5  58 42@2x](https://github.com/HyphaApp/hypha/assets/236356/44710100-99f6-419e-b8a0-2c438f06f301)


<!--
Thanks for contributing to Hypha!

Please ensure your contributions pass all necessary linting/testing and that the appropriate documentation has been updated.
-->

<!--
Describe briefly what your pull request changes. If this is resoving an issue, please specify below via "Fixes #<Github Issue ID>"
-->
Fixes https://github.com/HyphaApp/hypha/issues/3842


## Test Steps
<!-- 
If step does not require manual testing, skip/remove this section.

Give a brief overview of the steps required for a user/dev to test this contribution. Important things to include:
 - Required user roles for where neccesary (ie. "As a Staff Admin...")
 - Clear & validatable expected results (ie. "Confirm the submit button is now not clickable")
 - Langauge that can be understood by non-technical testers if being tested by users
-->

 - [ ] Try changing the password and use different password while retyping
