### PR TITLE
Update styling of the opinion info message

### DIFF
--- a/hypha/apply/review/templates/review/review_detail.html
+++ b/hypha/apply/review/templates/review/review_detail.html
@@ -81,7 +81,10 @@
             {{ form }}
         </form>
 
-        <P>{% trans "An opinion is a replacement for a review. You will no longer be able to submit a review for this application." %}</P>
+        <em class='text-fg-muted flex items-center mb-8'>
+            {% heroicon_micro "information-circle" class="mr-1 w-4 h-4 fill-fg-muted" aria_hidden=true %}
+            <span>{% trans "An opinion is a replacement for a review. You will no longer be able to submit a review for this application." %}</span>
+        </em>
     {% endif %}
 
 {% endblock %}


### PR DESCRIPTION
<!--
Thanks for contributing to Hypha!

Please ensure your contributions pass all necessary linting/testing and that the appropriate documentation has been updated.
-->

<!--
Describe briefly what your pull request changes. If this is resoving an issue, please specify below via "Fixes #<Github Issue ID>"
-->
The messages display below the opinion buttons looks like part of the rest of the form display

This PR add styling so the info displayed is little different

## Test Steps
<!-- 
If step does not require manual testing, skip/remove this section.

Give a brief overview of the steps required for a user/dev to test this contribution. Important things to include:
 - Required user roles for where neccesary (ie. "As a Staff Admin...")
 - Clear & validatable expected results (ie. "Confirm the submit button is now not clickable")
 - Langauge that can be understood by non-technical testers if being tested by users
-->

 - [ ] for a submission, try adding an opinion to an existing review


![Screenshot 2024-04-17 at 6  10 27@2x](https://github.com/HyphaApp/hypha/assets/236356/f1674891-1fb4-46f9-8bf2-7d01a6d7d33e)

### After
![Screenshot 2024-04-17 at 6  19 46@2x](https://github.com/HyphaApp/hypha/assets/236356/474d812d-2964-49c4-96f2-43d2da2e9f7b)
