### PR TITLE
Skip PAF Approval process if no PAFReviewerRole assigned

### DIFF
--- a/hypha/apply/projects/forms/__init__.py
+++ b/hypha/apply/projects/forms/__init__.py
@@ -17,6 +17,7 @@ from .project import (
     RemoveContractDocumentForm,
     RemoveDocumentForm,
     SetPendingForm,
+    SkipPAFApprovalProcessForm,
     StaffUploadContractForm,
     SubmitContractDocumentsForm,
     UpdateProjectLeadForm,
@@ -37,6 +38,7 @@ from .vendor import (
 __all__ = [
     "SelectDocumentForm",
     "SubmitContractDocumentsForm",
+    "SkipPAFApprovalProcessForm",
     "ApproveContractForm",
     "ApproversForm",
     "AssignApproversForm",

--- a/hypha/apply/projects/forms/project.py
+++ b/hypha/apply/projects/forms/project.py
@@ -359,6 +359,16 @@ class SubmitContractDocumentsForm(forms.ModelForm):
         super().__init__(*args, **kwargs)
 
 
+class SkipPAFApprovalProcessForm(forms.ModelForm):
+    class Meta:
+        fields = ["id"]
+        model = Project
+        widgets = {"id": forms.HiddenInput()}
+
+    def __init__(self, user=None, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+
+
 class UploadContractForm(FileFormMixin, forms.ModelForm):
     file = SingleFileField(label=_("Contract"), required=True)
 

--- a/hypha/apply/projects/permissions.py
+++ b/hypha/apply/projects/permissions.py
@@ -12,6 +12,7 @@ from .models.project import (
     INVOICING_AND_REPORTING,
     ProjectSettings,
 )
+from .utils import no_pafreviewer_role
 
 
 def has_permission(action, user, object=None, raise_exception=True, **kwargs):
@@ -249,14 +250,18 @@ def can_update_paf_status(user, project, **kwargs):
 
 
 def can_update_project_status(user, project, **kwargs):
-    if project.status not in [COMPLETE, CLOSING, INVOICING_AND_REPORTING]:
+    if project.status not in [DRAFT, COMPLETE, CLOSING, INVOICING_AND_REPORTING]:
         return False, "Forbidden Error"
 
     if not user.is_authenticated:
         return False, "Login Required"
 
     if user.is_apply_staff or user.is_apply_staff_admin:
-        return True, "Staff and Staff Admin can update status"
+        if project.status == DRAFT:
+            if no_pafreviewer_role():
+                return True, "Staff and Staff Admin can skip the PAF approval process"
+        else:
+            return True, "Staff and Staff Admin can update status"
 
     return False, "Forbidden Error"
 

--- a/hypha/apply/projects/templates/application_projects/includes/supporting_documents.html
+++ b/hypha/apply/projects/templates/application_projects/includes/supporting_documents.html
@@ -30,21 +30,6 @@
                     {% endif %}
                 </a>
             {% endif %}
-            {% user_can_skip_pafapproval_process project user as can_skip_paf_process %}
-            {% if can_skip_paf_process %}
-                <a data-fancybox
-                   data-src="#continue-to-next-phase"
-                   class="button button--project-action"
-                   href="#">
-                    {% trans "Continue to next phase" %}
-                </a>
-                <div class="modal" id="continue-to-next-phase">
-                    <h4 class="modal__project-header-bar">{% trans "Continue to next phase" %}</h4>
-                    <p>{% trans "Are you done with PAF and sure to move to the next phase, this action can not be reverted" %}</p>
-                    {% trans "Continue" as submit %}
-                    {% include 'funds/includes/delegated_form_base.html' with form=skip_paf_approval_form value=submit %}
-                </div>
-            {% endif %}
             {% user_can_update_paf_approvers object user request as can_update_paf_approvers %}
             {% user_can_assign_approvers_to_project object user request as can_assign_paf_approvers %}
             {% if can_update_paf_approvers %}

--- a/hypha/apply/projects/templates/application_projects/includes/supporting_documents.html
+++ b/hypha/apply/projects/templates/application_projects/includes/supporting_documents.html
@@ -30,6 +30,21 @@
                     {% endif %}
                 </a>
             {% endif %}
+            {% user_can_skip_pafapproval_process project user as can_skip_paf_process %}
+            {% if can_skip_paf_process %}
+                <a data-fancybox
+                   data-src="#continue-to-next-phase"
+                   class="button button--project-action"
+                   href="#">
+                    {% trans "Continue to next phase" %}
+                </a>
+                <div class="modal" id="continue-to-next-phase">
+                    <h4 class="modal__project-header-bar">{% trans "Continue to next phase" %}</h4>
+                    <p>{% trans "Are you done with PAF and sure to move to the next phase, this action can not be reverted" %}</p>
+                    {% trans "Continue" as submit %}
+                    {% include 'funds/includes/delegated_form_base.html' with form=skip_paf_approval_form value=submit %}
+                </div>
+            {% endif %}
             {% user_can_update_paf_approvers object user request as can_update_paf_approvers %}
             {% user_can_assign_approvers_to_project object user request as can_assign_paf_approvers %}
             {% if can_update_paf_approvers %}

--- a/hypha/apply/projects/templates/application_projects/project_admin_detail.html
+++ b/hypha/apply/projects/templates/application_projects/project_admin_detail.html
@@ -4,14 +4,24 @@
 
 
 {% block admin_assignments %}
-    {% if object.is_in_progress %}
+    {% user_can_update_project_status object user as can_update_status %}
+    {% if can_update_status %}
         <div class="js-actions-sidebar sidebar__inner sidebar__inner--light-blue sidebar__inner--actions {% if mobile %}sidebar__inner--mobile{% endif %}">
 
             <h5>{% trans "Actions to take" %}</h5>
 
-            {% user_can_update_project_status project user as can_update_status %}
+            {% user_can_skip_pafapproval_process project user as can_skip_paf %}
+            {% if can_skip_paf %}
+                <a data-fancybox data-src="#continue-to-next-phase" class="button button--white button--full-width button--bottom-space" href="#">{% trans "Continue to next status" %}</a>
+
+                <div class="modal" id="continue-to-next-phase">
+                    <h4 class="modal__project-header-bar">{% trans "Continue to next stage" %}</h4>
+                    <p>{% trans "Have you filled the PAF and sure to move to the next stage, this action can not be reverted" %}</p>
+                    {% trans "Continue" as submit %}
+                    {% include 'funds/includes/delegated_form_base.html' with form=skip_paf_approval_form value=submit %}
+                </div>
+            {% else %}
     <!-- Move the condition below to link if add more than one link to 'More Actions'-->
-            {% if can_update_status %}
                 <details>
                     <summary class="sidebar__separator sidebar__separator--medium">{% trans "More actions" %}</summary>
 

--- a/hypha/apply/projects/templates/application_projects/project_admin_detail.html
+++ b/hypha/apply/projects/templates/application_projects/project_admin_detail.html
@@ -16,7 +16,7 @@
 
                 <div class="modal" id="continue-to-next-phase">
                     <h4 class="modal__project-header-bar">{% trans "Continue to next stage" %}</h4>
-                    <p>{% trans "Have you filled the PAF and sure to move to the next stage, this action can not be reverted" %}</p>
+                    <p>{% trans "Please ensure the Project Form is completed and you are ready to proceed to the next stage. This action cannot be reverted." %}</p>
                     {% trans "Continue" as submit %}
                     {% include 'funds/includes/delegated_form_base.html' with form=skip_paf_approval_form value=submit %}
                 </div>

--- a/hypha/apply/projects/templatetags/approval_tools.py
+++ b/hypha/apply/projects/templatetags/approval_tools.py
@@ -3,6 +3,7 @@ from datetime import timedelta
 from django import template
 
 from ..permissions import has_permission
+from ..utils import no_pafreviewer_role
 
 register = template.Library()
 
@@ -19,7 +20,11 @@ def user_has_approved(project, user):
 
 @register.simple_tag
 def user_can_send_for_approval(project, user):
-    return user.is_apply_staff and project.can_send_for_approval
+    return (
+        user.is_apply_staff
+        and project.can_send_for_approval
+        and not (no_pafreviewer_role())
+    )
 
 
 @register.simple_tag

--- a/hypha/apply/projects/templatetags/project_tags.py
+++ b/hypha/apply/projects/templatetags/project_tags.py
@@ -43,7 +43,7 @@ def user_next_step_on_project(project, user, request=None):
                     "heading": _("To do"),
                     "text": _("Fill in the Approval Form(PAF)"),
                 }
-            if no_pafreviewer_role:
+            if no_pafreviewer_role():
                 return {
                     "heading": _("To do"),
                     "text": _("Move project to next stage"),

--- a/hypha/apply/projects/templatetags/project_tags.py
+++ b/hypha/apply/projects/templatetags/project_tags.py
@@ -27,7 +27,7 @@ def project_can_have_report(project):
 
 @register.simple_tag
 def user_can_skip_pafapproval_process(project, user):
-    if project.status == DRAFT and user.is_apply_staff:
+    if project.status == DRAFT and (user.is_apply_staff or user.is_apply_staff_admin):
         return no_pafreviewer_role()
     return False
 
@@ -46,7 +46,7 @@ def user_next_step_on_project(project, user, request=None):
             if no_pafreviewer_role:
                 return {
                     "heading": _("To do"),
-                    "text": _("Move project to next phase"),
+                    "text": _("Move project to next stage"),
                 }
             else:
                 if project.paf_approvals.exists():

--- a/hypha/apply/projects/templatetags/project_tags.py
+++ b/hypha/apply/projects/templatetags/project_tags.py
@@ -13,7 +13,7 @@ from hypha.apply.projects.models.project import (
     INVOICING_AND_REPORTING,
 )
 from hypha.apply.projects.permissions import has_permission
-from hypha.apply.projects.utils import get_project_public_status
+from hypha.apply.projects.utils import get_project_public_status, no_pafreviewer_role
 
 register = template.Library()
 
@@ -22,6 +22,13 @@ register = template.Library()
 def project_can_have_report(project):
     if project.status in [COMPLETE, CLOSING, INVOICING_AND_REPORTING]:
         return True
+    return False
+
+
+@register.simple_tag
+def user_can_skip_pafapproval_process(project, user):
+    if project.status == DRAFT and user.is_apply_staff:
+        return no_pafreviewer_role()
     return False
 
 
@@ -36,15 +43,21 @@ def user_next_step_on_project(project, user, request=None):
                     "heading": _("To do"),
                     "text": _("Fill in the Approval Form(PAF)"),
                 }
-            if project.paf_approvals.exists():
+            if no_pafreviewer_role:
                 return {
                     "heading": _("To do"),
-                    "text": _("Resubmit project documents for approval"),
+                    "text": _("Move project to next phase"),
                 }
-            return {
-                "heading": _("To do"),
-                "text": _("Submit project documents for approval"),
-            }
+            else:
+                if project.paf_approvals.exists():
+                    return {
+                        "heading": _("To do"),
+                        "text": _("Resubmit project documents for approval"),
+                    }
+                return {
+                    "heading": _("To do"),
+                    "text": _("Submit project documents for approval"),
+                }
         elif user.is_applicant:
             return {
                 "heading": _("Waiting for"),

--- a/hypha/apply/projects/tests/test_views.py
+++ b/hypha/apply/projects/tests/test_views.py
@@ -289,6 +289,16 @@ class TestStaffProjectDetailView(BaseProjectDetailTestCase):
 class TestFinanceProjectDetailView(BaseProjectDetailTestCase):
     user_factory = FinanceFactory
 
+    def setUp(self):
+        super().setUp()
+        apply_site = ApplySiteFactory()
+        self.project_setting, _ = ProjectSettings.objects.get_or_create(
+            site_id=apply_site.id
+        )
+        self.project_setting.use_settings = True
+        self.project_setting.save()
+        self.role = PAFReviewerRoleFactory(page=self.project_setting)
+
     def test_has_access(self):
         project = ProjectFactory(status=INTERNAL_APPROVAL)
         response = self.get_page(project)

--- a/hypha/apply/projects/utils.py
+++ b/hypha/apply/projects/utils.py
@@ -28,9 +28,11 @@ from .models.payment import (
     SUBMITTED,
 )
 from .models.project import (
+    INTERNAL_APPROVAL,
     PAF_STATUS_CHOICES,
     PROJECT_PUBLIC_STATUSES,
     PROJECT_STATUS_CHOICES,
+    PAFReviewersRole,
 )
 
 
@@ -105,6 +107,26 @@ def fetch_and_save_project_details(project_id, external_projectid):
 
         data = fetch_project_details(external_projectid)
         save_project_details(project_id, data)
+
+
+def no_pafreviewer_role():
+    """
+    Return True if no PAFReviewerRoles exists
+    """
+    return not (PAFReviewersRole.objects.exists())
+
+
+def get_project_status_choices():
+    """
+    Return available Project status choices by removing the disabled ones
+    """
+    if no_pafreviewer_role():
+        return [
+            (status, label)
+            for status, label in PROJECT_STATUS_CHOICES
+            if status != INTERNAL_APPROVAL
+        ]
+    return PROJECT_STATUS_CHOICES
 
 
 def save_project_details(project_id, data):

--- a/hypha/apply/projects/views/project.py
+++ b/hypha/apply/projects/views/project.py
@@ -81,6 +81,7 @@ from ..forms import (
     RemoveDocumentForm,
     SelectDocumentForm,
     SetPendingForm,
+    SkipPAFApprovalProcessForm,
     SubmitContractDocumentsForm,
     UpdateProjectLeadForm,
     UploadContractDocumentForm,
@@ -110,7 +111,7 @@ from ..models.project import (
 from ..models.report import Report
 from ..permissions import has_permission
 from ..tables import InvoiceListTable, ProjectsListTable, ReportListTable
-from ..utils import get_paf_status_display, get_placeholder_file
+from ..utils import get_paf_status_display, get_placeholder_file, get_project_status_choices
 from ..views.payment import ChangeInvoiceStatusView
 from .report import ReportFrequencyUpdate, ReportingMixin
 
@@ -575,6 +576,41 @@ class UploadContractView(DelegatedViewMixin, CreateView):
                 related_obj=project,
             )
 
+        return response
+
+
+class SkipPAFApprovalProcessView(DelegatedViewMixin, UpdateView):
+    context_name = "skip_paf_approval_form"
+    model = Project
+    form_class = SkipPAFApprovalProcessForm
+
+    def form_valid(self, form):
+        project = self.kwargs["object"]
+        old_stage = project.status
+        project.is_locked = True
+        project.status = CONTRACTING
+        response = super().form_valid(form)
+
+        messenger(
+            MESSAGES.PROJECT_TRANSITION,
+            request=self.request,
+            user=self.request.user,
+            source=self.object,
+            related=old_stage,
+        )
+        # add project waiting contract task to staff/contracting groups
+        if settings.STAFF_UPLOAD_CONTRACT:
+            add_task_to_user_group(
+                code=PROJECT_WAITING_CONTRACT,
+                user_group=Group.objects.filter(name=STAFF_GROUP_NAME),
+                related_obj=self.object,
+            )
+        else:
+            add_task_to_user_group(
+                code=PROJECT_WAITING_CONTRACT,
+                user_group=Group.objects.filter(name=CONTRACTING_GROUP_NAME),
+                related_obj=self.object,
+            )
         return response
 
 
@@ -1176,9 +1212,9 @@ class UpdatePAFApproversView(DelegatedViewMixin, UpdateView):
 class BaseProjectDetailView(ReportingMixin, DetailView):
     def get_context_data(self, **kwargs):
         context = super().get_context_data(**kwargs)
-        context["statuses"] = PROJECT_STATUS_CHOICES
+        context["statuses"] = get_project_status_choices()
         context["current_status_index"] = [
-            status for status, _ in PROJECT_STATUS_CHOICES
+            status for status, _ in get_project_status_choices()
         ].index(self.object.status)
         context["supporting_documents_configured"] = (
             True if DocumentCategory.objects.count() else False
@@ -1210,6 +1246,7 @@ class AdminProjectDetailView(
         ChangePAFStatusView,
         ChangeProjectstatusView,
         ChangeInvoiceStatusView,
+        SkipPAFApprovalProcessView,
     ]
     model = Project
     template_name_suffix = "_admin_detail"
@@ -1223,9 +1260,9 @@ class AdminProjectDetailView(
 
     def get_context_data(self, **kwargs):
         context = super().get_context_data(**kwargs)
-        context["statuses"] = PROJECT_STATUS_CHOICES
+        context["statuses"] = get_project_status_choices()
         context["current_status_index"] = [
-            status for status, _ in PROJECT_STATUS_CHOICES
+            status for status, _ in get_project_status_choices()
         ].index(self.object.status)
         project_settings = ProjectSettings.for_request(self.request)
         context["project_settings"] = project_settings

--- a/hypha/apply/projects/views/project.py
+++ b/hypha/apply/projects/views/project.py
@@ -111,7 +111,11 @@ from ..models.project import (
 from ..models.report import Report
 from ..permissions import has_permission
 from ..tables import InvoiceListTable, ProjectsListTable, ReportListTable
-from ..utils import get_paf_status_display, get_placeholder_file, get_project_status_choices
+from ..utils import (
+    get_paf_status_display,
+    get_placeholder_file,
+    get_project_status_choices,
+)
 from ..views.payment import ChangeInvoiceStatusView
 from .report import ReportFrequencyUpdate, ReportingMixin
 

--- a/hypha/apply/projects/views/project_partials.py
+++ b/hypha/apply/projects/views/project_partials.py
@@ -14,8 +14,9 @@ from hypha.apply.funds.utils import get_statuses_as_params
 
 from ..constants import statuses_and_table_statuses_mapping
 from ..models.payment import Invoice
-from ..models.project import PROJECT_STATUS_CHOICES, Project
+from ..models.project import Project
 from ..permissions import has_permission
+from ..utils import get_project_status_choices
 
 
 @login_required
@@ -53,7 +54,7 @@ def get_project_status_counts(request):
             if project_status_url_query and key in project_status_url_query
             else False,
         }
-        for key, display in PROJECT_STATUS_CHOICES
+        for key, display in get_project_status_choices()
     }
 
     return render(


### PR DESCRIPTION
<!--
Thanks for contributing to Hypha!

Please ensure your contributions pass all necessary linting/testing and that the appropriate documentation has been updated.
-->

<!--
Describe briefly what your pull request changes. If this is resoving an issue, please specify below via "Fixes #<Github Issue ID>"
-->
Fixes #3839 

##  Assumptions

An organization only chooses one option either go with PAFReviewerRoles or without that. Changing in between might cause the issue with `Internal Approval` status projects. We will fix this in another issue if needed.

## Test Steps
<!-- 
If step does not require manual testing, skip/remove this section.

Give a brief overview of the steps required for a user/dev to test this contribution. Important things to include:
 - Required user roles for where neccesary (ie. "As a Staff Admin...")
 - Clear & validatable expected results (ie. "Confirm the submit button is now not clickable")
 - Langauge that can be understood by non-technical testers if being tested by users
-->

 - [ ] Remove all PAFReviewerRoles from wagtail admin
 - [ ] Select a project in draft state, and fill paf
 - [ ] There should be a `Continue to next status` button in Actions to take. Also check `To do` message in the sidebar.
 - [ ] After confirmation, the project should move to the contracting stage.
 - [ ] There shouldn't be any `Internal Approval` stage.

Don't forget to add those PAFReviewerRoles back because we have already chosen that option and to avoid the issue explained in assumption above.

