### PR TITLE
Utilize emails as display name on comments when no name is set

### DIFF
--- a/hypha/apply/activity/templatetags/activity_tags.py
+++ b/hypha/apply/activity/templatetags/activity_tags.py
@@ -35,7 +35,7 @@ def display_author(activity, user) -> str:
         return settings.ORG_LONG_NAME
     if isinstance(activity.related_object, Review) and activity.source.user == user:
         return "Reviewer"
-    return activity.user.get_full_name_with_group()
+    return activity.user.get_display_name_with_group()
 
 
 @register.filter

--- a/hypha/apply/users/models.py
+++ b/hypha/apply/users/models.py
@@ -226,21 +226,26 @@ class User(AbstractUser):
     def get_full_name(self):
         return self.full_name.strip()
 
-    def get_short_name(self):
-        return self.email
+    def get_short_name(self) -> str:
+        """Gets the local-part (username) of the user's email
+
+        ie. hyphaiscool@hypha.app returns "hyphaiscool"
+        """
+        return self.email.split("@")[0]
 
     def get_display_name_with_group(self) -> str:
         """Gets the user's display name, along with their role in parenthesis
 
         If the user has a full name set that will be used, otherwise pulls the email.
         """
-        display_name = self.full_name if self.full_name else self.email
+        display_name = str(self)
         is_apply_staff = f" ({STAFF_GROUP_NAME})" if self.is_apply_staff else ""
         is_reviewer = f" ({REVIEWER_GROUP_NAME})" if self.is_reviewer else ""
+        is_partner = f" ({PARTNER_GROUP_NAME})" if self.is_applicant else ""
         is_applicant = f" ({APPLICANT_GROUP_NAME})" if self.is_applicant else ""
         is_finance = f" ({FINANCE_GROUP_NAME})" if self.is_finance else ""
         is_contracting = f" ({CONTRACTING_GROUP_NAME})" if self.is_contracting else ""
-        return f"{display_name.strip()}{is_apply_staff}{is_reviewer}{is_applicant}{is_finance}{is_contracting}"
+        return f"{display_name}{is_apply_staff}{is_reviewer}{is_applicant}{is_partner}{is_finance}{is_contracting}"
 
     @cached_property
     def roles(self):

--- a/hypha/apply/users/models.py
+++ b/hypha/apply/users/models.py
@@ -229,13 +229,18 @@ class User(AbstractUser):
     def get_short_name(self):
         return self.email
 
-    def get_full_name_with_group(self):
+    def get_display_name_with_group(self) -> str:
+        """Gets the user's display name, along with their role in parenthesis
+
+        If the user has a full name set that will be used, otherwise pulls the email.
+        """
+        display_name = self.full_name if self.full_name else self.email
         is_apply_staff = f" ({STAFF_GROUP_NAME})" if self.is_apply_staff else ""
         is_reviewer = f" ({REVIEWER_GROUP_NAME})" if self.is_reviewer else ""
         is_applicant = f" ({APPLICANT_GROUP_NAME})" if self.is_applicant else ""
         is_finance = f" ({FINANCE_GROUP_NAME})" if self.is_finance else ""
         is_contracting = f" ({CONTRACTING_GROUP_NAME})" if self.is_contracting else ""
-        return f"{self.full_name.strip()}{is_apply_staff}{is_reviewer}{is_applicant}{is_finance}{is_contracting}"
+        return f"{display_name.strip()}{is_apply_staff}{is_reviewer}{is_applicant}{is_finance}{is_contracting}"
 
     @cached_property
     def roles(self):

--- a/hypha/apply/users/models.py
+++ b/hypha/apply/users/models.py
@@ -241,7 +241,7 @@ class User(AbstractUser):
         display_name = str(self)
         is_apply_staff = f" ({STAFF_GROUP_NAME})" if self.is_apply_staff else ""
         is_reviewer = f" ({REVIEWER_GROUP_NAME})" if self.is_reviewer else ""
-        is_partner = f" ({PARTNER_GROUP_NAME})" if self.is_applicant else ""
+        is_partner = f" ({PARTNER_GROUP_NAME})" if self.is_partner else ""
         is_applicant = f" ({APPLICANT_GROUP_NAME})" if self.is_applicant else ""
         is_finance = f" ({FINANCE_GROUP_NAME})" if self.is_finance else ""
         is_contracting = f" ({CONTRACTING_GROUP_NAME})" if self.is_contracting else ""


### PR DESCRIPTION
<!--
Thanks for contributing to Hypha!

Please ensure your contributions pass all necessary linting/testing and that the appropriate documentation has been updated.
-->

<!--
Describe briefly what your pull request changes. If this is resoving an issue, please specify below via "Fixes #<Github Issue ID>"
-->
Fixes #3895. Quick one I noticed while working on the partner comment stuff. Comments will now display with the user email where no full name is set.

## Screenshots
<img width="1303" alt="Screenshot 2024-04-22 at 05 20 24" src="https://github.com/HyphaApp/hypha/assets/145372368/e9bc89c0-b27a-44bb-98ca-28401875dd49">


## Test Steps
<!-- 
If step does not require manual testing, skip/remove this section.

Give a brief overview of the steps required for a user/dev to test this contribution. Important things to include:
 - Required user roles for where neccesary (ie. "As a Staff Admin...")
 - Clear & validatable expected results (ie. "Confirm the submit button is now not clickable")
 - Langauge that can be understood by non-technical testers if being tested by users
-->

 - [ ] Clear the `Full Name` field on https://test-apply.hypha.app/account/ and select `Update Profile`
 - [ ] Navigate to a submission that has comments from the current user account
 - [ ] Ensure that the current email appears on the comments instead of an empty name
