### PR TITLE
Fix alignment of text in the plain-text emails

### DIFF
--- a/hypha/apply/activity/templates/messages/email/applicant_base.html
+++ b/hypha/apply/activity/templates/messages/email/applicant_base.html
@@ -3,9 +3,12 @@
 {% load i18n %}
 {% block salutation %}{% blocktrans with name=source.user.get_full_name|default:"applicant" %}Dear {{ name }},{% endblocktrans %}{% endblock %}
 
+{# fmt:off #}
 {% block more_info %}{% trans "Link to your application" %}: {{ request.scheme }}://{{ request.get_host }}{{ source.get_absolute_url }}
-    {% trans "If you have any questions, please submit them here" %}: {{ request.scheme }}://{{ request.get_host }}{{ source.get_absolute_url }}#communications
 
-    {% trans "See our guide for more information" %}: {{ ORG_GUIDE_URL }}
+{% trans "If you have any questions, please submit them here" %}: {{ request.scheme }}://{{ request.get_host }}{{ source.get_absolute_url }}#communications
 
-    {% blocktrans %}If you have any issues accessing the submission system or other general inquiries, please email us at {{ ORG_EMAIL }}{% endblocktrans %}{% endblock %}
+{% trans "See our guide for more information" %}: {{ ORG_GUIDE_URL }}
+
+{% blocktrans %}If you have any issues accessing the submission system or other general inquiries, please email us at {{ ORG_EMAIL }}{% endblocktrans %}{% endblock %}
+{# fmt:on #}

--- a/hypha/apply/activity/templates/messages/email/assign_paf_approvers.html
+++ b/hypha/apply/activity/templates/messages/email/assign_paf_approvers.html
@@ -3,12 +3,12 @@
 {% load i18n %}
 {% block salutation %}{% endblock %}
 
-{% block content %}
-    {% trans "Project documents are ready to be assigned for approval." %}
+{% block content %}{# fmt:off #}
+{% trans "Project documents are ready to be assigned for approval." %}
 
-    {% trans "Title" %}: {{ source.title }}
-    {% trans "Link" %}: {{ request.scheme }}://{{ request.get_host }}{% url 'apply:projects:approval' pk=source.pk %}
-    {% trans "Original Submission" %}: {{ request.scheme }}://{{ request.get_host }}{% url 'apply:submissions:simplified' pk=source.submission.pk %}
+{% trans "Title" %}: {{ source.title }}
+{% trans "Link" %}: {{ request.scheme }}://{{ request.get_host }}{% url 'apply:projects:approval' pk=source.pk %}
+{% trans "Original Submission" %}: {{ request.scheme }}://{{ request.get_host }}{% url 'apply:submissions:simplified' pk=source.submission.pk %}
 
-    {% blocktrans with lead=source.lead email=source.lead.email %}Please contact {{ lead }} - {{ email }} if you have any questions.{% endblocktrans %}
-{% endblock %}
+{% blocktrans with lead=source.lead email=source.lead.email %}Please contact {{ lead }} - {{ email }} if you have any questions.{% endblocktrans %}
+{% endblock %}{# fmt:on #}

--- a/hypha/apply/activity/templates/messages/email/batch_ready_to_review.html
+++ b/hypha/apply/activity/templates/messages/email/batch_ready_to_review.html
@@ -3,12 +3,11 @@
 {% load i18n %}
 {% block salutation %}{% trans "Dear Reviewer," %}{% endblock %}
 
-{% block content %}
-    {% trans "New applications have been added to your review list." %}
-    {% for submission in sources %}
+{% block content %}{# fmt:off #}
+{% trans "New applications have been added to your review list." %}
+{% for submission in sources %}
+{% trans "Title" %}: {{ submission.title }}
+{% trans "Link" %}: {{ request.scheme }}://{{ request.get_host }}{{ submission.get_absolute_url }}
+{% endfor %}
 
-        {% trans "Title" %}: {{ submission.title }}
-        {% trans "Link" %}: {{ request.scheme }}://{{ request.get_host }}{{ submission.get_absolute_url }}
-    {% endfor %}
-
-{% endblock %}
+{% endblock %}{# fmt:on #}

--- a/hypha/apply/activity/templates/messages/email/comment.html
+++ b/hypha/apply/activity/templates/messages/email/comment.html
@@ -1,10 +1,12 @@
 {% extends "messages/email/applicant_base.html" %}
-
 {% load i18n %}
-{% block content %}{% blocktrans with title=source.title user=comment.user %}There has been a new comment on "{{ title }}" by {{ user }}.{% endblocktrans %}
 
-    {% trans "Read the full comment here" %}: {{ request.scheme }}://{{ request.get_host }}{{ source.get_absolute_url }}#communications{% endblock %}
+{% block content %}{# fmt:off #}
+{% blocktrans with title=source.title user=comment.user %}There has been a new comment on "{{ title }}" by {{ user }}.{% endblocktrans %}
+
+{% trans "Read the full comment here" %}: {{ request.scheme }}://{{ request.get_host }}{{ source.get_absolute_url }}#communications
+{% endblock %}
 
 {% block more_info %}
-    {% blocktrans %}If you have any issues accessing the submission system or other general inquiries, please email us at {{ ORG_EMAIL }}{% endblocktrans %}
-{% endblock %}
+{% blocktrans %}If you have any issues accessing the submission system or other general inquiries, please email us at {{ ORG_EMAIL }}{% endblocktrans %}
+{% endblock %}{# fmt:on #}

--- a/hypha/apply/activity/templates/messages/email/contract_uploaded.html
+++ b/hypha/apply/activity/templates/messages/email/contract_uploaded.html
@@ -8,28 +8,28 @@
     {% endif %}
 {% endblock %}
 
-{% block content %}
+{% block content %}{# fmt:off #}
 
-    {% trans "A new contract has been added to your Project" %}:
+{% trans "A new contract has been added to your Project" %}:
 
-    {% trans "Title" %}: {{ source.title }}
-    {% trans "Link" %}: {{ request.scheme }}://{{ request.get_host }}{{ source.get_absolute_url }}
+{% trans "Title" %}: {{ source.title }}
+{% trans "Link" %}: {{ request.scheme }}://{{ request.get_host }}{{ source.get_absolute_url }}
 
-    {% if contract.is_signed %}
-        {% trans "This contract has already been signed and there is no action for you to take." %}
-    {% else %}
-        {% blocktrans %}Please review the contract and sign it before reuploading it to your Project page for the {{ ORG_SHORT_NAME }} Team to approve.{% endblocktrans %}
-    {% endif %}
+{% if contract.is_signed %}
+{% trans "This contract has already been signed and there is no action for you to take." %}
+{% else %}
+{% blocktrans %}Please review the contract and sign it before reuploading it to your Project page for the {{ ORG_SHORT_NAME }} Team to approve.{% endblocktrans %}
+{% endif %}
 {% endblock %}
 
 
 {% block more_info %}
-    {% if request.user != source.user %}
-        {% trans "Link to your application" %}: {{ request.scheme }}://{{ request.get_host }}{{ source.get_absolute_url }}
-        {% trans "If you have any questions, please submit them here" %}: {{ request.scheme }}://{{ request.get_host }}{{ source.get_absolute_url }}#communications
+{% if request.user != source.user %}
+{% trans "Link to your application" %}: {{ request.scheme }}://{{ request.get_host }}{{ source.get_absolute_url }}
+{% trans "If you have any questions, please submit them here" %}: {{ request.scheme }}://{{ request.get_host }}{{ source.get_absolute_url }}#communications
 
-        {% trans "See our guide for more information" %}: {{ ORG_GUIDE_URL }}
+{% trans "See our guide for more information" %}: {{ ORG_GUIDE_URL }}
 
-        {% blocktrans %}If you have any issues accessing the submission system or other general inquiries, please email us at {{ ORG_EMAIL }}{% endblocktrans %}
-    {% endif %}
-{% endblock %}
+{% blocktrans %}If you have any issues accessing the submission system or other general inquiries, please email us at {{ ORG_EMAIL }}{% endblocktrans %}
+{% endif %}
+{% endblock %}{# fmt:on #}

--- a/hypha/apply/activity/templates/messages/email/determination.html
+++ b/hypha/apply/activity/templates/messages/email/determination.html
@@ -1,8 +1,10 @@
 {% extends "messages/email/applicant_base.html" %}
 {% load nh3_tags i18n %}
 
-{% block content %}{% trans "Your application has been reviewed and the outcome is" %}: {{ determination.clean_outcome }}
+{% block content %}{# fmt:off #}
+{% trans "Your application has been reviewed and the outcome is" %}: {{ determination.clean_outcome }}
 
-    {{ determination.message|nh3|striptags }}
+{{ determination.message|nh3|striptags }}
 
-    {% trans "Read the full determination here" %}: {{ request.scheme }}://{{ request.get_host }}{{ determination.get_absolute_url }}{% endblock %}
+{% trans "Read the full determination here" %}: {{ request.scheme }}://{{ request.get_host }}{{ determination.get_absolute_url }}
+{% endblock %}{# fmt:on #}

--- a/hypha/apply/activity/templates/messages/email/invited_to_proposal.html
+++ b/hypha/apply/activity/templates/messages/email/invited_to_proposal.html
@@ -1,13 +1,16 @@
 {% extends "messages/email/applicant_base.html" %}
 
 {% load i18n %}
-{% block content %}{% blocktrans %}We’ve reviewed your Concept note and think it could be a good fit for {{ ORG_SHORT_NAME }} funding. We would like to invite you to submit a Proposal with more details about your project. You will receive a second email linking to a determination message with detailed feedback.{% endblocktrans %}
+{% block content %}{# fmt:off #}
+{% blocktrans %}We’ve reviewed your Concept note and think it could be a good fit for {{ ORG_SHORT_NAME }} funding. We would like to invite you to submit a Proposal with more details about your project. You will receive a second email linking to a determination message with detailed feedback.{% endblocktrans %}
 
-    {% blocktrans %}Please review our Proposal Guide at {{ ORG_GUIDE_URL }} to learn more about the information we’d like to see. In the proposal please also address the feedback we provided in the concept note determination.{% endblocktrans %}{% endblock %}
+{% blocktrans %}Please review our Proposal Guide at {{ ORG_GUIDE_URL }} to learn more about the information we’d like to see. In the proposal please also address the feedback we provided in the concept note determination.{% endblocktrans %}{% endblock %}
 
-{% block more_info %}{% trans "Here is the link to start creating your proposal" %}: {{ request.scheme }}://{{ request.get_host }}{{ source.get_absolute_url }}
-    {% trans "If you have any questions, please submit them here" %}: {{ request.scheme }}://{{ request.get_host }}{{ source.get_absolute_url }}#communications
+{% block more_info %}
+{% trans "Here is the link to start creating your proposal" %}: {{ request.scheme }}://{{ request.get_host }}{{ source.get_absolute_url }}
+{% trans "If you have any questions, please submit them here" %}: {{ request.scheme }}://{{ request.get_host }}{{ source.get_absolute_url }}#communications
 
-    {% blocktrans %}The system will allow you to save a draft of your proposal as you work on it. When you feel it is ready for our review, please click the “Submit” button and we’ll know to take a look at it. We’ll reply to you with feedback on your Proposal as quickly as possible.{% endblocktrans %}
+{% blocktrans %}The system will allow you to save a draft of your proposal as you work on it. When you feel it is ready for our review, please click the “Submit” button and we’ll know to take a look at it. We’ll reply to you with feedback on your Proposal as quickly as possible.{% endblocktrans %}
 
-    {% blocktrans %}If you have any issues accessing the submission system or other general inquiries, please email us at {{ ORG_EMAIL }}{% endblocktrans %}{% endblock %}
+{% blocktrans %}If you have any issues accessing the submission system or other general inquiries, please email us at {{ ORG_EMAIL }}{% endblocktrans %}
+{% endblock %}{# fmt:on #}

--- a/hypha/apply/activity/templates/messages/email/invoice_approved.html
+++ b/hypha/apply/activity/templates/messages/email/invoice_approved.html
@@ -3,12 +3,12 @@
 {% load i18n %}
 {% block salutation %}{% endblock %}
 
-{% block content %}
-    {% trans "An Invoice is waiting for your approval." %}
+{% block content %}{# fmt:off #}
+{% trans "An Invoice is waiting for your approval." %}
 
-    {% trans "Title" %}: {{ source.title }}
-    {% trans "Link" %}: {{ request.scheme }}://{{ request.get_host }}{{ invoice.get_absolute_url }}
-    {% trans "Project" %}: {{ request.scheme }}://{{ request.get_host }}{{ source.get_absolute_url }}
+{% trans "Title" %}: {{ source.title }}
+{% trans "Link" %}: {{ request.scheme }}://{{ request.get_host }}{{ invoice.get_absolute_url }}
+{% trans "Project" %}: {{ request.scheme }}://{{ request.get_host }}{{ source.get_absolute_url }}
 
-    {% blocktrans with lead=source.lead email=source.lead.email %}Please contact {{ lead }} - {{ email }} if you have any questions.{% endblocktrans %}
-{% endblock %}
+{% blocktrans with lead=source.lead email=source.lead.email %}Please contact {{ lead }} - {{ email }} if you have any questions.{% endblocktrans %}
+{% endblock %}{# fmt:on #}

--- a/hypha/apply/activity/templates/messages/email/invoice_status_updated.html
+++ b/hypha/apply/activity/templates/messages/email/invoice_status_updated.html
@@ -1,19 +1,20 @@
 {% extends "messages/email/applicant_base.html" %}
 
 {% load i18n invoice_tools %}
-{% block content %}
-    {% display_invoice_status_for_user source.user invoice as invoice_status %}
-    {% blocktrans with title=source.title date_from=invoice.date_from date_to=invoice.date_to %}An {{ ORG_SHORT_NAME }} staff member has updated your invoice for {{ title }} for period {{ date_from }} to {{ date_to }}.{% endblocktrans %}
 
-    {% blocktrans %}It is now {{ invoice_status }}.{% endblocktrans %}
+{% block content %}{# fmt:off #}
+{% display_invoice_status_for_user source.user invoice as invoice_status %}
+{% blocktrans with title=source.title date_from=invoice.date_from date_to=invoice.date_to %}An {{ ORG_SHORT_NAME }} staff member has updated your invoice for {{ title }} for period {{ date_from }} to {{ date_to }}.{% endblocktrans %}
 
-    {% if has_changes_requested and invoice.comment %}
-        {% trans "The staff member left this comment" %}:
+{% blocktrans %}It is now {{ invoice_status }}.{% endblocktrans %}
 
-        {{ invoice.comment }}
-    {% endif %}
+{% if has_changes_requested and invoice.comment %}
+{% trans "The staff member left this comment" %}:
 
-    {% trans "Invoice Link" %}: {{ request.scheme }}://{{ request.get_host }}{{ invoice.get_absolute_url }}
-    {% trans "Title" %}: {{ source.title }}
-    {% trans "Project Link" %}: {{ request.scheme }}://{{ request.get_host }}{{ source.get_absolute_url }}
-{% endblock %}
+>  {{ invoice.comment }}
+{% endif %}
+
+{% trans "Invoice Link" %}: {{ request.scheme }}://{{ request.get_host }}{{ invoice.get_absolute_url }}
+{% trans "Title" %}: {{ source.title }}
+{% trans "Project Link" %}: {{ request.scheme }}://{{ request.get_host }}{{ source.get_absolute_url }}
+{% endblock %}{# fmt:on #}

--- a/hypha/apply/activity/templates/messages/email/invoice_updated.html
+++ b/hypha/apply/activity/templates/messages/email/invoice_updated.html
@@ -1,12 +1,12 @@
 {% extends "messages/email/applicant_base.html" %}
 
 {% load i18n invoice_tools %}
-{% block content %}
-    {% display_invoice_status_for_user source.user invoice as invoice_status %}
+{% block content %}{# fmt:off #}
+{% display_invoice_status_for_user source.user invoice as invoice_status %}
 
-    {% blocktrans with title=source.title date_from=invoice.date_from date_to=invoice.date_to %}An {{ ORG_SHORT_NAME }} staff member has updated your invoice for {{ title }} for period {{ date_from }} to {{ date_to }}.{% endblocktrans %}
-    {% blocktrans %}It is now {{ invoice_status }}.{% endblocktrans %}
+{% blocktrans with title=source.title date_from=invoice.date_from date_to=invoice.date_to %}An {{ ORG_SHORT_NAME }} staff member has updated your invoice for {{ title }} for period {{ date_from }} to {{ date_to }}.{% endblocktrans %}
+{% blocktrans %}It is now {{ invoice_status }}.{% endblocktrans %}
 
-    {% trans "Title" %}: {{ source.title }}
-    {% trans "Link" %}: {{ request.scheme }}://{{ request.get_host }}{{ source.get_absolute_url }}
-{% endblock %}
+{% trans "Title" %}: {{ source.title }}
+{% trans "Link" %}: {{ request.scheme }}://{{ request.get_host }}{{ source.get_absolute_url }}
+{% endblock %}{# fmt:on #}

--- a/hypha/apply/activity/templates/messages/email/paf_for_approval.html
+++ b/hypha/apply/activity/templates/messages/email/paf_for_approval.html
@@ -3,12 +3,12 @@
 {% load i18n %}
 {% block salutation %}{% endblock %}
 
-{% block content %}
-    {% trans "A Project is awaiting your review." %}
+{% block content %}{# fmt:off #}
+{% trans "A Project is awaiting your review." %}
 
-    {% trans "Title" %}: {{ source.title }}
-    {% trans "Link" %}: {{ request.scheme }}://{{ request.get_host }}{% url 'apply:projects:approval' pk=source.pk %}
-    {% trans "Original Submission" %}: {{ request.scheme }}://{{ request.get_host }}{% url 'apply:submissions:simplified' pk=source.submission.pk %}
+{% trans "Title" %}: {{ source.title }}
+{% trans "Link" %}: {{ request.scheme }}://{{ request.get_host }}{% url 'apply:projects:approval' pk=source.pk %}
+{% trans "Original Submission" %}: {{ request.scheme }}://{{ request.get_host }}{% url 'apply:submissions:simplified' pk=source.submission.pk %}
 
-    {% blocktrans with lead=source.lead email=source.lead.email %}Please contact {{ lead }} - {{ email }} if you have any questions.{% endblocktrans %}
-{% endblock %}
+{% blocktrans with lead=source.lead email=source.lead.email %}Please contact {{ lead }} - {{ email }} if you have any questions.{% endblocktrans %}
+{% endblock %}{# fmt:on #}

--- a/hypha/apply/activity/templates/messages/email/partners_update_applicant.html
+++ b/hypha/apply/activity/templates/messages/email/partners_update_applicant.html
@@ -1,11 +1,11 @@
 {% extends "messages/email/applicant_base.html" %}
 
 {% load i18n %}
-{% block content %}
-    {% trans "New partner(s) has been added to your submission." %}
-    {% for partner in added %}
-        * {{ partner }}
-    {% endfor %}
-    {% trans "Title" %}: {{ submission.title }}
-    {% trans "Link" %}: {{ request.scheme }}://{{ request.get_host }}{{ submission.get_absolute_url }}
-{% endblock %}
+{% block content %}{# fmt:off #}
+{% trans "New partner(s) has been added to your submission." %}
+{% for partner in added %}
+    * {{ partner }}
+{% endfor %}
+{% trans "Title" %}: {{ submission.title }}
+{% trans "Link" %}: {{ request.scheme }}://{{ request.get_host }}{{ submission.get_absolute_url }}
+{% endblock %}{# fmt:on #}

--- a/hypha/apply/activity/templates/messages/email/partners_update_partner.html
+++ b/hypha/apply/activity/templates/messages/email/partners_update_partner.html
@@ -3,9 +3,9 @@
 {% load i18n %}
 {% block salutation %}{% trans "Dear Partner," %}{% endblock %}
 
-{% block content %}
-    {% trans "You have been added as a partner the following submission." %}
+{% block content %}{# fmt:off #}
+{% trans "You have been added as a partner the following submission." %}
 
-    {% trans "Title" %}: {{ submission.title }}
-    {% trans "Link" %}: {{ request.scheme }}://{{ request.get_host }}{{ submission.get_absolute_url }}
-{% endblock %}
+{% trans "Title" %}: {{ submission.title }}
+{% trans "Link" %}: {{ request.scheme }}://{{ request.get_host }}{{ submission.get_absolute_url }}
+{% endblock %}{# fmt:on #}

--- a/hypha/apply/activity/templates/messages/email/project_final_approval.html
+++ b/hypha/apply/activity/templates/messages/email/project_final_approval.html
@@ -3,12 +3,12 @@
 {% load i18n %}
 {% block salutation %}{% endblock %}
 
-{% block content %}
-    {% trans "A Project is awaiting final approval." %}
+{% block content %}{# fmt:off #}
+{% trans "A Project is awaiting final approval." %}
 
-    {% trans "Title" %}: {{ source.title }}
-    {% trans "Link" %}: {{ request.scheme }}://{{ request.get_host }}{% url 'apply:projects:approval' pk=source.pk %}
-    {% trans "Original Submission" %}: {{ request.scheme }}://{{ request.get_host }}{% url 'apply:submissions:simplified' pk=source.submission.pk %}
+{% trans "Title" %}: {{ source.title }}
+{% trans "Link" %}: {{ request.scheme }}://{{ request.get_host }}{% url 'apply:projects:approval' pk=source.pk %}
+{% trans "Original Submission" %}: {{ request.scheme }}://{{ request.get_host }}{% url 'apply:submissions:simplified' pk=source.submission.pk %}
 
-    {% blocktrans with lead=source.lead email=source.lead.email %}Please contact {{ lead }} - {{ email }} if you have any questions.{% endblocktrans %}
-{% endblock %}
+{% blocktrans with lead=source.lead email=source.lead.email %}Please contact {{ lead }} - {{ email }} if you have any questions.{% endblocktrans %}
+{% endblock %}{# fmt:on #}

--- a/hypha/apply/activity/templates/messages/email/project_request_change.html
+++ b/hypha/apply/activity/templates/messages/email/project_request_change.html
@@ -3,10 +3,9 @@
 {% load i18n %}
 {% block salutation %}{% endblock %}
 
-{% block content %}
-    {% trans "A Project has been rejected by PAF reviewers, please update it accordingly and resubmit it to the reviewers." %}
+{% block content %}{# fmt:off #}
+{% trans "A Project has been rejected by PAF reviewers, please update it accordingly and resubmit it to the reviewers." %}
 
-    {% trans "Title" %}: {{ source.title }}
-    {% trans "Link" %}: {{ request.scheme }}://{{ request.get_host }}{% url 'apply:projects:detail' pk=source.pk %}
-
-{% endblock %}
+{% trans "Title" %}: {{ source.title }}
+{% trans "Link" %}: {{ request.scheme }}://{{ request.get_host }}{% url 'apply:projects:detail' pk=source.pk %}
+{% endblock %}{# fmt:on #}

--- a/hypha/apply/activity/templates/messages/email/ready_for_contracting.html
+++ b/hypha/apply/activity/templates/messages/email/ready_for_contracting.html
@@ -3,13 +3,13 @@
 {% load i18n %}
 {% block salutation %}{% endblock %}
 
-{% block content %}
-    {% trans "A Project is waiting for contract" %}
+{% block content %}{# fmt:off #}
+{% trans "A Project is waiting for contract" %}
 
-    {% trans "Title" %}: {{ source.title }}
-    {% trans "Link" %}: {{ request.scheme }}://{{ request.get_host }}{% url 'apply:projects:detail' pk=source.pk %}
-    {% trans "Project Approval Form" %}: {{ request.scheme }}://{{ request.get_host }}{% url 'apply:projects:approval' pk=source.pk %}
-    {% trans "Original Submission" %}: {{ request.scheme }}://{{ request.get_host }}{% url 'apply:submissions:simplified' pk=source.submission.pk %}
+{% trans "Title" %}: {{ source.title }}
+{% trans "Link" %}: {{ request.scheme }}://{{ request.get_host }}{% url 'apply:projects:detail' pk=source.pk %}
+{% trans "Project Approval Form" %}: {{ request.scheme }}://{{ request.get_host }}{% url 'apply:projects:approval' pk=source.pk %}
+{% trans "Original Submission" %}: {{ request.scheme }}://{{ request.get_host }}{% url 'apply:submissions:simplified' pk=source.submission.pk %}
 
-    {% blocktrans with lead=source.lead email=source.lead.email %}Please contact {{ lead }} - {{ email }} if you have any questions.{% endblocktrans %}
-{% endblock %}
+{% blocktrans with lead=source.lead email=source.lead.email %}Please contact {{ lead }} - {{ email }} if you have any questions.{% endblocktrans %}
+{% endblock %}{# fmt:on #}

--- a/hypha/apply/activity/templates/messages/email/ready_for_invoicing.html
+++ b/hypha/apply/activity/templates/messages/email/ready_for_invoicing.html
@@ -1,11 +1,16 @@
 {% extends "messages/email/applicant_base.html" %}
 
 {% load i18n %}
-{% block content %}{% blocktrans with title=source.title %}The contract for your project "{{ title }}" has approved. Now, your project is ready for invoicing.{% endblocktrans %}{% endblock %}
 
-{% block more_info %}{% trans "Link to your project" %}: {{ request.scheme }}://{{ request.get_host }}{{ source.get_absolute_url }}
-    {% trans "If you have any questions, please submit them here" %}: {{ request.scheme }}://{{ request.get_host }}{{ source.get_absolute_url }}#communications
+{% block content %}{# fmt:off #}
+{% blocktrans with title=source.title %}The contract for your project "{{ title }}" has approved. Now, your project is ready for invoicing.{% endblocktrans %}
+{% endblock %}
 
-    {% trans "See our guide for more information" %}: {{ ORG_GUIDE_URL }}
+{% block more_info %}
+{% trans "Link to your project" %}: {{ request.scheme }}://{{ request.get_host }}{{ source.get_absolute_url }}
+{% trans "If you have any questions, please submit them here" %}: {{ request.scheme }}://{{ request.get_host }}{{ source.get_absolute_url }}#communications
 
-    {% blocktrans %}If you have any issues accessing the project or other general inquiries, please email us at {{ ORG_EMAIL }}{% endblocktrans %}{% endblock %}
+{% trans "See our guide for more information" %}: {{ ORG_GUIDE_URL }}
+
+{% blocktrans %}If you have any issues accessing the project or other general inquiries, please email us at {{ ORG_EMAIL }}{% endblocktrans %}
+{% endblock %}{# fmt:on #}

--- a/hypha/apply/activity/templates/messages/email/ready_to_review.html
+++ b/hypha/apply/activity/templates/messages/email/ready_to_review.html
@@ -2,15 +2,11 @@
 
 {% load i18n %}
 {% block salutation %}{% trans "Dear Reviewer," %}{% endblock %}
-{% block content %}
-    {% trans "This application is awaiting your review." %}
+{% block content %}{# fmt:off #}
+{% trans "This application is awaiting your review." %}
 
-    {% trans "Title" %}: {{ source.title }}
-    {% if related.title %}
-        {% trans "Reminder Title" %}: {{ related.title }}
-    {% endif %}
-    {% if related.description %}
-        {% trans "Reminder Description" %}: {{ related.description }}
-    {% endif %}
-    {% trans "Link" %}: {{ request.scheme }}://{{ request.get_host }}{{ source.get_absolute_url }}
-{% endblock %}
+{% trans "Title" %}: {{ source.title }}
+{% if related.title %}{% trans "Reminder Title" %}: {{ related.title }}{% endif %}
+{% if related.description %}{% trans "Reminder Description" %}: {{ related.description }}{% endif %}
+{% trans "Link" %}: {{ request.scheme }}://{{ request.get_host }}{{ source.get_absolute_url }}
+{% endblock %}{# fmt:on #}

--- a/hypha/apply/activity/templates/messages/email/report_frequency.html
+++ b/hypha/apply/activity/templates/messages/email/report_frequency.html
@@ -1,14 +1,14 @@
 {% extends "messages/email/applicant_base.html" %}
 
 {% load i18n %}
-{% block content %}
 
-    {% blocktrans with title=source.title %}An {{ ORG_SHORT_NAME }} staff member has changed the reporting frequency of {{ title }}.{% endblocktrans %}
+{% block content %}{# fmt:off #}
+{% blocktrans with title=source.title %}An {{ ORG_SHORT_NAME }} staff member has changed the reporting frequency of {{ title }}.{% endblocktrans %}
 
-    {% trans "The new schedule is" %}: {{ config.get_frequency_display }}
+{% trans "The new schedule is" %}: {{ config.get_frequency_display }}
 
-    {% trans "The next report is due" %}: {{ config.current_due_report.end_date }}
+{% trans "The next report is due" %}: {{ config.current_due_report.end_date }}
 
-    {% trans "Title" %}: {{ source.title }}
-    {% trans "Link" %}: {{ request.scheme }}://{{ request.get_host }}{{ source.get_absolute_url }}
-{% endblock %}
+{% trans "Title" %}: {{ source.title }}
+{% trans "Link" %}: {{ request.scheme }}://{{ request.get_host }}{{ source.get_absolute_url }}
+{% endblock %}{# fmt:on #}

--- a/hypha/apply/activity/templates/messages/email/report_notify.html
+++ b/hypha/apply/activity/templates/messages/email/report_notify.html
@@ -1,11 +1,10 @@
 {% extends "messages/email/applicant_base.html" %}
 
 {% load i18n %}
-{% block content %}
 
-    {% blocktrans with title=source.title end_date=report.end_date %}A report is due for {{ title }} on {{ end_date }}.{% endblocktrans %}
+{% block content %}{# fmt:off #}
+{% blocktrans with title=source.title end_date=report.end_date %}A report is due for {{ title }} on {{ end_date }}.{% endblocktrans %}
 
-    {% blocktrans %}More information can be found on the project page:{% endblocktrans %}
-    {{ request.scheme }}://{{ request.get_host }}{{ source.get_absolute_url }}
-
-{% endblock %}
+{% blocktrans %}More information can be found on the project page:{% endblocktrans %}
+{{ request.scheme }}://{{ request.get_host }}{{ source.get_absolute_url }}
+{% endblock %}{# fmt:on #}

--- a/hypha/apply/activity/templates/messages/email/report_skipped.html
+++ b/hypha/apply/activity/templates/messages/email/report_skipped.html
@@ -1,14 +1,14 @@
 {% extends "messages/email/applicant_base.html" %}
 
 {% load i18n %}
-{% block content %}
 
-    {% blocktrans %}An {{ ORG_SHORT_NAME }} staff member has marked a report as {% endblocktrans %}{% if report.skipped %}{% trans "no longer required" %}{% else %}{% trans "required" %}{% endif %}{% blocktrans with title=source.title start_date=report.start_date end_date=report.end_date %} for {{ title }} for period {{ start_date }} to {{ end_date }}.{% endblocktrans %}
+{% block content %}{# fmt:off #}
+{% blocktrans %}An {{ ORG_SHORT_NAME }} staff member has marked a report as {% endblocktrans %}{% if report.skipped %}{% trans "no longer required" %}{% else %}{% trans "required" %}{% endif %}{% blocktrans with title=source.title start_date=report.start_date end_date=report.end_date %} for {{ title }} for period {{ start_date }} to {{ end_date }}.{% endblocktrans %}
 
-    {% if not report.skipped %}
-        {% trans "This report was previously not required. Please ensure you now complete the report." %}
-    {% endif %}
+{% if not report.skipped %}
+    {% trans "This report was previously not required. Please ensure you now complete the report." %}
+{% endif %}
 
-    {% trans "Title" %}: {{ source.title }}
-    {% trans "Link" %}: {{ request.scheme }}://{{ request.get_host }}{{ source.get_absolute_url }}
-{% endblock %}
+{% trans "Title" %}: {{ source.title }}
+{% trans "Link" %}: {{ request.scheme }}://{{ request.get_host }}{{ source.get_absolute_url }}
+{% endblock %}{# fmt:on #}

--- a/hypha/apply/activity/templates/messages/email/report_submitted.html
+++ b/hypha/apply/activity/templates/messages/email/report_submitted.html
@@ -1,11 +1,12 @@
 {% extends "messages/email/applicant_base.html" %}
 
 {% load i18n %}
-{% block content %}
-    {% blocktrans with title=source.title start_date=report.start_date end_date=report.end_date %}An {{ ORG_SHORT_NAME }} staff member has submitted a report for {{ title }} for period {{ start_date }} to {{ end_date }}.{% endblocktrans %}
 
-    {% trans "You can review the report here" %}: {{ request.scheme }}://{{ request.get_host }}{{ report.get_absolute_url }}
+{% block content %}{# fmt:off #}
+{% blocktrans with title=source.title start_date=report.start_date end_date=report.end_date %}An {{ ORG_SHORT_NAME }} staff member has submitted a report for {{ title }} for period {{ start_date }} to {{ end_date }}.{% endblocktrans %}
 
-    {% trans "Project" %}: {{ source.title }}
-    {% trans "Link" %}: {{ request.scheme }}://{{ request.get_host }}{{ source.get_absolute_url }}
-{% endblock %}
+{% trans "You can review the report here" %}: {{ request.scheme }}://{{ request.get_host }}{{ report.get_absolute_url }}
+
+{% trans "Project" %}: {{ source.title }}
+{% trans "Link" %}: {{ request.scheme }}://{{ request.get_host }}{{ source.get_absolute_url }}
+{% endblock %}{# fmt:on #}

--- a/hypha/apply/activity/templates/messages/email/sent_to_compliance.html
+++ b/hypha/apply/activity/templates/messages/email/sent_to_compliance.html
@@ -3,12 +3,12 @@
 {% load i18n %}
 {% block salutation %}{% endblock %}
 
-{% block content %}
-    {% trans "A Project is awaiting your review." %}
+{% block content %}{# fmt:off #}
+{% trans "A Project is awaiting your review." %}
 
-    {% trans "Title" %}: {{ source.title }}
-    {% trans "Link" %}: {{ request.scheme }}://{{ request.get_host }}{% url 'apply:projects:approval' pk=source.pk %}
-    {% trans "Original Submission" %}: {{ request.scheme }}://{{ request.get_host }}{% url 'apply:submissions:simplified' pk=source.submission.pk %}
+{% trans "Title" %}: {{ source.title }}
+{% trans "Link" %}: {{ request.scheme }}://{{ request.get_host }}{% url 'apply:projects:approval' pk=source.pk %}
+{% trans "Original Submission" %}: {{ request.scheme }}://{{ request.get_host }}{% url 'apply:submissions:simplified' pk=source.submission.pk %}
 
-    {% blocktrans with lead=source.lead email=source.lead.email %}Please contact {{ lead }} - {{ email }} if you have any questions.{% endblocktrans %}
-{% endblock %}
+{% blocktrans with lead=source.lead email=source.lead.email %}Please contact {{ lead }} - {{ email }} if you have any questions.{% endblocktrans %}
+{% endblock %}{# fmt:on #}

--- a/hypha/apply/activity/templates/messages/email/submission_confirmation.html
+++ b/hypha/apply/activity/templates/messages/email/submission_confirmation.html
@@ -1,18 +1,21 @@
 {% extends "messages/email/base.html" %}
 
 {% load i18n %}
-{% block content %}{% blocktrans with title=source.title %}We appreciate your {{ title }} application submission to the {{ ORG_LONG_NAME }}.{% endblocktrans %}
 
-    {% if source.is_draft %}{% trans "Please note that it is not submitted for review because it's still in draft." %} {% trans "You can access the draft at" %}: {{ request.scheme }}://{{ request.get_host }}{{ source.get_absolute_url }}{% else %}{% trans "We will review and reply to your submission as quickly as possible." %}{% endif %}
+{% block content %}{# fmt:off #}
+{% blocktrans with title=source.title %}We appreciate your {{ title }} application submission to the {{ ORG_LONG_NAME }}.{% endblocktrans %}
 
-    {% trans "If you have any questions, please submit them here" %}: {{ request.scheme }}://{{ request.get_host }}{{ source.get_absolute_url }}#communications
+{% if source.is_draft %}{% trans "Please note that it is not submitted for review because it's still in draft." %} {% trans "You can access the draft at" %}: {{ request.scheme }}://{{ request.get_host }}{{ source.get_absolute_url }}{% else %}{% trans "We will review and reply to your submission as quickly as possible." %}{% endif %}
 
-    {% blocktrans %}If you have issues accessing the submission system or general inquiries, please email us at {{ ORG_EMAIL }}.{% endblocktrans %}
+{% trans "If you have any questions, please submit them here" %}: {{ request.scheme }}://{{ request.get_host }}{{ source.get_absolute_url }}#communications
 
-    {% blocktrans %}For more information about our support options, review process, and selection criteria, please visit our website at {{ ORG_URL }}.{% endblocktrans %}
+{% blocktrans %}If you have issues accessing the submission system or general inquiries, please email us at {{ ORG_EMAIL }}.{% endblocktrans %}
 
-    {% with email_context=source.page.specific %}{{ email_context.confirmation_text_extra }}{% endwith %}
+{% blocktrans %}For more information about our support options, review process, and selection criteria, please visit our website at {{ ORG_URL }}.{% endblocktrans %}
 
-    {% trans "Project name" %}: {{ source.title }}
-    {% trans "Contact name" %}: {{ source.user.get_full_name }}
-    {% trans "Contact email" %}: {{ source.user.email }}{% endblock %}
+{% with email_context=source.page.specific %}{{ email_context.confirmation_text_extra }}{% endwith %}
+
+{% trans "Project name" %}: {{ source.title }}
+{% trans "Contact name" %}: {{ source.user.get_full_name }}
+{% trans "Contact email" %}: {{ source.user.email }}
+{% endblock %}{# fmt:on #}

--- a/hypha/apply/activity/templates/messages/email/submission_edit.html
+++ b/hypha/apply/activity/templates/messages/email/submission_edit.html
@@ -1,6 +1,7 @@
 {% extends "messages/email/applicant_base.html" %}
 
 {% load i18n %}
-{% block content %}
-    {% trans "Your submission has been edited by a member of staff." %}
-{% endblock %}
+
+{% block content %}{# fmt:off #}
+{% trans "Your submission has been edited by a member of staff." %}
+{% endblock %}{# fmt:on #}

--- a/hypha/apply/activity/templates/messages/email/submit_contract_documents.html
+++ b/hypha/apply/activity/templates/messages/email/submit_contract_documents.html
@@ -5,11 +5,11 @@
 {% block salutation %}
 {% endblock %}
 
-{% block content %}
-    {% trans "A Project's contract is awaiting your review." %}
+{% block content %}{# fmt:off #}
+{% trans "A Project's contract is awaiting your review." %}
 
-    {% trans "Title" %}: {{ source.title }}
-    {% trans "Link" %}: {{ request.scheme }}://{{ request.get_host }}{{ source.get_absolute_url }}
+{% trans "Title" %}: {{ source.title }}
+{% trans "Link" %}: {{ request.scheme }}://{{ request.get_host }}{{ source.get_absolute_url }}
 
-    {% blocktrans with lead=source.lead email=source.lead.email %}Please contact {{ lead }} - {{ email }} if you have any questions.{% endblocktrans %}
-{% endblock %}
+{% blocktrans with lead=source.lead email=source.lead.email %}Please contact {{ lead }} - {{ email }} if you have any questions.{% endblocktrans %}
+{% endblock %}{# fmt:on #}

--- a/hypha/apply/activity/templates/messages/email/transition.html
+++ b/hypha/apply/activity/templates/messages/email/transition.html
@@ -1,6 +1,9 @@
 {% extends "messages/email/applicant_base.html" %}
 
 {% load i18n %}
-{% block content %}{% blocktrans with old_status=old_phase.public_name new_status=source.phase.public_name %}Your application is now in "{{ new_status }}" status (progressed from "{{ old_status }}").{% endblocktrans %}
 
-    {% trans "Please submit any questions related to your application here" %}: {{ request.scheme }}://{{ request.get_host }}{{ source.get_absolute_url }}#communications{% endblock %}
+{% block content %}{# fmt:off #}
+{% blocktrans with old_status=old_phase.public_name new_status=source.phase.public_name %}Your application is now in "{{ new_status }}" status (progressed from "{{ old_status }}").{% endblocktrans %}
+
+{% trans "Please submit any questions related to your application here" %}: {{ request.scheme }}://{{ request.get_host }}{{ source.get_absolute_url }}#communications
+{% endblock %}{# fmt:on #}

--- a/hypha/apply/activity/templates/messages/email/vendor_setup_needed.html
+++ b/hypha/apply/activity/templates/messages/email/vendor_setup_needed.html
@@ -1,12 +1,13 @@
 {% extends "messages/email/applicant_base.html" %}
 
 {% load i18n %}
-{% block content %}
-    {% blocktrans %}A Project has been created for your submission on {{ ORG_SHORT_NAME }}.{% endblocktrans %}
 
-    {% trans "Next step is to complete Contracting Information by visiting project detail page." %}
+{% block content %}{# fmt:off #}
+{% blocktrans %}A Project has been created for your submission on {{ ORG_SHORT_NAME }}.{% endblocktrans %}
 
-    {% trans "Project" %}: {{ source.title }}
-    {% trans "Link" %}: {{ request.scheme }}://{{ request.get_host }}{{ source.get_absolute_url }}
-    {% trans "Submission" %}: {{ request.scheme }}://{{ request.get_host }}{{ source.submission.get_absolute_url }}
-{% endblock %}
+{% trans "Next step is to complete Contracting Information by visiting project detail page." %}
+
+{% trans "Project" %}: {{ source.title }}
+{% trans "Link" %}: {{ request.scheme }}://{{ request.get_host }}{{ source.get_absolute_url }}
+{% trans "Submission" %}: {{ request.scheme }}://{{ request.get_host }}{{ source.submission.get_absolute_url }}
+{% endblock %}{# fmt:on #}

--- a/hypha/apply/activity/templates/messages/email/vendor_updated.html
+++ b/hypha/apply/activity/templates/messages/email/vendor_updated.html
@@ -1,9 +1,10 @@
 {% extends "messages/email/base.html" %}
 
 {% load i18n %}
-{% block content %}
-    {% blocktrans with title=source.title %}Contracting Information has been updated on {{ title }}.{% endblocktrans %}
 
-    {% trans "Project" %}: {{ source.title }}
-    {% trans "Link" %}: {{ request.scheme }}://{{ request.get_host }}{{ source.get_absolute_url }}
-{% endblock %}
+{% block content %}{# fmt:off #}
+{% blocktrans with title=source.title %}Contracting Information has been updated on {{ title }}.{% endblocktrans %}
+
+{% trans "Project" %}: {{ source.title }}
+{% trans "Link" %}: {{ request.scheme }}://{{ request.get_host }}{{ source.get_absolute_url }}
+{% endblock %}{# fmt:on #}


### PR DESCRIPTION
Due to djhtml the emails templates where formatted with indendation.
That lead to alignment also being present in the plain-text emails.

This was an unintentional behaviour that this PR fixes by adding {# fmt:off #} markers in the email templates so djhtml won't format them

<!--
Thanks for contributing to Hypha!

Please ensure your contributions pass all necessary linting/testing and that the appropriate documentation has been updated.
-->

<!--
Describe briefly what your pull request changes. If this is resoving an issue, please specify below via "Fixes #<Github Issue ID>"
-->

## Test Steps
<!-- 
If step does not require manual testing, skip/remove this section.

Give a brief overview of the steps required for a user/dev to test this contribution. Important things to include:
 - Required user roles for where neccesary (ie. "As a Staff Admin...")
 - Clear & validatable expected results (ie. "Confirm the submit button is now not clickable")
 - Langauge that can be understood by non-technical testers if being tested by users
-->

 - [ ] check the alignemnts of the paragraphs of different emails sent.
