### PR TITLE
Fix results page when all submissions lack "Requested amount" field

### DIFF
--- a/hypha/apply/funds/views.py
+++ b/hypha/apply/funds/views.py
@@ -1795,7 +1795,10 @@ class SubmissionResultView(SubmissionStatsMixin, FilterView):
             submission_values = self.object_list.value()
             count_values = submission_values.get("value__count")
             total_value = intcomma(submission_values.get("value__sum"))
-            average_value = intcomma(round(submission_values.get("value__avg")))
+            if value := submission_values.get("value__avg"):
+                average_value = intcomma(round(value))
+            else:
+                average_value = 0
         else:
             count_values = 0
             total_value = 0


### PR DESCRIPTION
Fixes https://github.com/HyphaApp/hypha/issues/3902

<!--
Thanks for contributing to Hypha!

Please ensure your contributions pass all necessary linting/testing and that the appropriate documentation has been updated.
-->

<!--
Describe briefly what your pull request changes. If this is resoving an issue, please specify below via "Fixes #<Github Issue ID>"
-->

## Test Steps
<!-- 
If step does not require manual testing, skip/remove this section.

Give a brief overview of the steps required for a user/dev to test this contribution. Important things to include:
 - Required user roles for where neccesary (ie. "As a Staff Admin...")
 - Clear & validatable expected results (ie. "Confirm the submit button is now not clickable")
 - Langauge that can be understood by non-technical testers if being tested by users
-->

 - [ ] Check the results page when a fund/lab doesn't have a requested amount in it.
