### PR TITLE
Email notifications on new comments for partners

### DIFF
--- a/hypha/apply/activity/adapters/base.py
+++ b/hypha/apply/activity/adapters/base.py
@@ -172,11 +172,13 @@ class AdapterBase:
         kwargs.update(self.get_neat_related(message_type, related))
         kwargs.update(self.extra_kwargs(message_type, **kwargs))
 
-        message = self.message(message_type, **kwargs)
-        if not message:
-            return
-
         for recipient in recipients:
+            # Allow for customization of message based on recipient string (will vary based on adapter)
+            message_kwargs = {**kwargs, "recipient": recipient}
+            message = self.message(message_type, **message_kwargs)
+            if not message:
+                continue
+
             message_logs = self.create_logs(message, recipient, *events)
 
             if settings.SEND_MESSAGES or self.always_send:

--- a/hypha/apply/activity/adapters/emails.py
+++ b/hypha/apply/activity/adapters/emails.py
@@ -424,8 +424,7 @@ class EmailAdapter(AdapterBase):
             recipients: List[str] = []
 
             comment = kwargs["related"]
-            partners = self.partners(source)
-            if partners:
+            if partners := [*source.partners.values_list("email", flat=True)]:
                 if comment.visibility == PARTNER:
                     recipients = partners
                 elif comment.visibility in [APPLICANT_PARTNERS, ALL]:
@@ -470,14 +469,6 @@ class EmailAdapter(AdapterBase):
             if source.phase.permissions.can_review(reviewer)
             and not reviewer.is_apply_staff
         ]
-
-    def partners(self, source) -> List[str]:
-        """Get all partner emails from the source (if any)
-
-        Returns:
-            list: emails of all partners on the source
-        """
-        return [partner.email for partner in source.partners.all()]
 
     def partners_updated_applicant(self, added, removed, **kwargs):
         if added:

--- a/hypha/apply/activity/adapters/emails.py
+++ b/hypha/apply/activity/adapters/emails.py
@@ -418,26 +418,31 @@ class EmailAdapter(AdapterBase):
             return user.email
 
         ApplicationSubmission = apps.get_model("funds", "ApplicationSubmission")
-        if message_type == MESSAGES.COMMENT and isinstance(
-            source, ApplicationSubmission
-        ):
-            recipients: List[str] = []
+        Project = apps.get_model("application_projects", "Project")
+        if message_type == MESSAGES.COMMENT:
+            # Comment handling for Submissions
+            if isinstance(source, ApplicationSubmission):
+                recipients: List[str] = []
 
-            comment = kwargs["related"]
-            if partners := [*source.partners.values_list("email", flat=True)]:
-                if comment.visibility == PARTNER:
-                    recipients = partners
-                elif comment.visibility in [APPLICANT_PARTNERS, ALL]:
-                    recipients = partners + [source.user.email]
-                else:
-                    recipients = [source.user.email]
+                comment = kwargs["related"]
+                if partners := [*source.partners.values_list("email", flat=True)]:
+                    if comment.visibility == PARTNER:
+                        recipients = partners
+                    elif comment.visibility in [APPLICANT_PARTNERS, ALL]:
+                        recipients = partners + [source.user.email]
+                    else:
+                        recipients = [source.user.email]
 
-            try:
-                recipients.remove(comment.user.email)
-            except ValueError:
-                pass
+                try:
+                    recipients.remove(comment.user.email)
+                except ValueError:
+                    pass
 
-            return recipients
+                return recipients
+
+            # Comment handling for Projects
+            if isinstance(source, Project) and user == source.user:
+                return []
 
         return [source.user.email]
 

--- a/hypha/apply/activity/adapters/emails.py
+++ b/hypha/apply/activity/adapters/emails.py
@@ -425,7 +425,7 @@ class EmailAdapter(AdapterBase):
                 recipients: List[str] = [source.user.email]
 
                 comment = kwargs["related"]
-                if partners := [*source.partners.values_list("email", flat=True)]:
+                if partners := list(source.partners.values_list("email", flat=True)):
                     if comment.visibility == PARTNER:
                         recipients = partners
                     elif comment.visibility in [APPLICANT_PARTNERS, ALL]:

--- a/hypha/apply/activity/adapters/emails.py
+++ b/hypha/apply/activity/adapters/emails.py
@@ -422,16 +422,14 @@ class EmailAdapter(AdapterBase):
         if message_type == MESSAGES.COMMENT:
             # Comment handling for Submissions
             if isinstance(source, ApplicationSubmission):
-                recipients: List[str] = []
+                recipients: List[str] = [source.user.email]
 
                 comment = kwargs["related"]
                 if partners := [*source.partners.values_list("email", flat=True)]:
                     if comment.visibility == PARTNER:
                         recipients = partners
                     elif comment.visibility in [APPLICANT_PARTNERS, ALL]:
-                        recipients = partners + [source.user.email]
-                    else:
-                        recipients = [source.user.email]
+                        recipients += partners
 
                 try:
                     recipients.remove(comment.user.email)

--- a/hypha/apply/activity/adapters/emails.py
+++ b/hypha/apply/activity/adapters/emails.py
@@ -1,11 +1,14 @@
 import logging
 from collections import defaultdict
+from typing import List
 
+from django.apps import apps
 from django.conf import settings
 from django.contrib.auth import get_user_model
 from django.template.loader import render_to_string
 from django.utils.translation import gettext as _
 
+from hypha.apply.activity.models import ALL, APPLICANT_PARTNERS, PARTNER
 from hypha.apply.projects.models.payment import CHANGES_REQUESTED_BY_STAFF, DECLINED
 from hypha.apply.projects.templatetags.project_tags import display_project_status
 from hypha.apply.users.groups import (
@@ -264,8 +267,11 @@ class EmailAdapter(AdapterBase):
 
     def notify_comment(self, **kwargs):
         comment = kwargs["comment"]
-        source = kwargs["source"]
-        if not comment.priviledged and not comment.user == source.user:
+        recipient = kwargs["recipient"]
+        # Pass the user object to render_message rather than the email string
+        recipient_obj = User.objects.get(email__exact=recipient)
+        kwargs["recipient"] = recipient_obj
+        if not comment.priviledged:
             return self.render_message("messages/email/comment.html", **kwargs)
 
     def recipients(self, message_type, source, user, **kwargs):
@@ -410,6 +416,30 @@ class EmailAdapter(AdapterBase):
 
         if isinstance(source, get_user_model()):
             return user.email
+
+        ApplicationSubmission = apps.get_model("funds", "ApplicationSubmission")
+        if message_type == MESSAGES.COMMENT and isinstance(
+            source, ApplicationSubmission
+        ):
+            recipients: List[str] = []
+
+            comment = kwargs["related"]
+            partners = self.partners(source)
+            if partners:
+                if comment.visibility == PARTNER:
+                    recipients = partners
+                elif comment.visibility in [APPLICANT_PARTNERS, ALL]:
+                    recipients = partners + [source.user.email]
+                else:
+                    recipients = [source.user.email]
+
+            try:
+                recipients.remove(comment.user.email)
+            except ValueError:
+                pass
+
+            return recipients
+
         return [source.user.email]
 
     def batch_recipients(self, message_type, sources, **kwargs):
@@ -441,6 +471,14 @@ class EmailAdapter(AdapterBase):
             and not reviewer.is_apply_staff
         ]
 
+    def partners(self, source) -> List[str]:
+        """Get all partner emails from the source (if any)
+
+        Returns:
+            list: emails of all partners on the source
+        """
+        return [partner.email for partner in source.partners.all()]
+
     def partners_updated_applicant(self, added, removed, **kwargs):
         if added:
             return self.render_message(
@@ -448,7 +486,12 @@ class EmailAdapter(AdapterBase):
             )
 
     def partners_updated_partner(self, added, removed, **kwargs):
-        for _partner in added:
+        if added:
+            recipient = kwargs["recipient"]
+            # Pass the user object to render_message rather than the email string
+            recipient_obj = User.objects.get(email__exact=recipient)
+            kwargs["recipient"] = recipient_obj
+
             return self.render_message(
                 "messages/email/partners_update_partner.html", **kwargs
             )

--- a/hypha/apply/activity/messaging.py
+++ b/hypha/apply/activity/messaging.py
@@ -22,6 +22,21 @@ class MessengerBackend:
     ):
         from .models import Event
 
+        print("SEND CALL")
+        print("MESSAGE TYPE:")
+        print(message_type)
+        print("REQUEST:")
+        print(request)
+        print("USER:")
+        print(user)
+        print("RELATED:")
+        print(related)
+        print("SOURCE:")
+        print(source)
+        print("SOURCES:")
+        print(sources)
+        print()
+
         if sources is None:
             sources = []
 

--- a/hypha/apply/activity/messaging.py
+++ b/hypha/apply/activity/messaging.py
@@ -22,21 +22,6 @@ class MessengerBackend:
     ):
         from .models import Event
 
-        print("SEND CALL")
-        print("MESSAGE TYPE:")
-        print(message_type)
-        print("REQUEST:")
-        print(request)
-        print("USER:")
-        print(user)
-        print("RELATED:")
-        print(related)
-        print("SOURCE:")
-        print(source)
-        print("SOURCES:")
-        print(sources)
-        print()
-
         if sources is None:
             sources = []
 

--- a/hypha/apply/activity/models.py
+++ b/hypha/apply/activity/models.py
@@ -243,7 +243,7 @@ class Activity(models.Model):
     @property
     def priviledged(self):
         # Not visible to applicant
-        return self.visibility not in [APPLICANT, ALL]
+        return self.visibility not in [APPLICANT, PARTNER, APPLICANT_PARTNERS, ALL]
 
     @property
     def private(self):

--- a/hypha/apply/activity/templates/messages/email/comment.html
+++ b/hypha/apply/activity/templates/messages/email/comment.html
@@ -1,9 +1,7 @@
 {% extends "messages/email/applicant_base.html" %}
 
-{% load i18n activity_tags %}
-{% block salutation %}{% trans "Dear" %} {% comment_saluatation_name %},{% endblock %}
-
-{% block content %}{% blocktrans with title=source.title user=comment.user %}There has been a new comment on "{{ title }}" by {{ user }}.{% endblocktrans %}
+{% load i18n %}
+{% block salutation %}{% trans "Dear" %} {{ recipient }},{% endblock %}
 
 {% block content %}{# fmt:off #}
 {% blocktrans with title=source.title user=comment.user %}There has been a new comment on "{{ title }}" by {{ user }}.{% endblocktrans %}

--- a/hypha/apply/activity/templates/messages/email/comment.html
+++ b/hypha/apply/activity/templates/messages/email/comment.html
@@ -1,5 +1,9 @@
 {% extends "messages/email/applicant_base.html" %}
-{% load i18n %}
+
+{% load i18n activity_tags %}
+{% block salutation %}{% trans "Dear" %} {% comment_saluatation_name %},{% endblock %}
+
+{% block content %}{% blocktrans with title=source.title user=comment.user %}There has been a new comment on "{{ title }}" by {{ user }}.{% endblocktrans %}
 
 {% block content %}{# fmt:off #}
 {% blocktrans with title=source.title user=comment.user %}There has been a new comment on "{{ title }}" by {{ user }}.{% endblocktrans %}

--- a/hypha/apply/activity/templates/messages/email/partners_update_partner.html
+++ b/hypha/apply/activity/templates/messages/email/partners_update_partner.html
@@ -1,7 +1,7 @@
 {% extends "messages/email/base.html" %}
 
-{% load i18n %}
-{% block salutation %}{% trans "Dear Partner," %}{% endblock %}
+{% load i18n activity_tags %}
+{% block salutation %}{% trans "Dear" %} {% comment_saluatation_name %},{% endblock %}
 
 {% block content %}{# fmt:off #}
 {% trans "You have been added as a partner the following submission." %}

--- a/hypha/apply/activity/templates/messages/email/partners_update_partner.html
+++ b/hypha/apply/activity/templates/messages/email/partners_update_partner.html
@@ -1,7 +1,7 @@
 {% extends "messages/email/base.html" %}
 
-{% load i18n activity_tags %}
-{% block salutation %}{% trans "Dear" %} {% comment_saluatation_name %},{% endblock %}
+{% load i18n %}
+{% block salutation %}{% trans "Dear" %} {{ recipient }},{% endblock %}
 
 {% block content %}{# fmt:off #}
 {% trans "You have been added as a partner the following submission." %}

--- a/hypha/apply/activity/templatetags/activity_tags.py
+++ b/hypha/apply/activity/templatetags/activity_tags.py
@@ -2,7 +2,6 @@ import json
 
 from django import template
 from django.conf import settings
-from django.utils.translation import gettext as _
 
 from hypha.apply.determinations.models import Determination
 from hypha.apply.projects.models import Contract
@@ -119,42 +118,3 @@ def visibility_display(visibility: str, user) -> str:
         return f"{visibility} + {team_string}"
 
     return visibility
-
-
-@register.filter
-def source_type(value) -> str:
-    """Formats source type
-
-    For a given source type containing "submission", this will be converted
-    to "Submission" (ie. "application submission" -> "Submission").
-
-    Args:
-        value: the source type to be formatted
-
-    Returns:
-        A source type string with a capitalized first letter
-    """
-    if value and "submission" in value:
-        return "Submission"
-    return str(value).capitalize()
-
-
-@register.simple_tag(takes_context=True)
-def comment_saluatation_name(context: dict) -> str:
-    """Get the salutation name for comment notification emails
-
-    Args:
-        context: the context dict containing the activity source and recipient [`User`][hypha.apply.users.models.User] object.
-
-    Returns:
-        A salutation display name, defaults to user's full name if set otherwise uses role.
-    """
-    source = context["source"]
-    recipient = context["recipient"]
-    full_name = recipient.get_full_name()
-    if full_name:
-        return full_name
-    if recipient == source.user:
-        return _("applicant")
-    elif recipient in source.partners.all():
-        return _("partner")

--- a/hypha/apply/activity/templatetags/activity_tags.py
+++ b/hypha/apply/activity/templatetags/activity_tags.py
@@ -2,6 +2,7 @@ import json
 
 from django import template
 from django.conf import settings
+from django.utils.translation import gettext as _
 
 from hypha.apply.determinations.models import Determination
 from hypha.apply.projects.models import Contract
@@ -136,3 +137,24 @@ def source_type(value) -> str:
     if value and "submission" in value:
         return "Submission"
     return str(value).capitalize()
+
+
+@register.simple_tag(takes_context=True)
+def comment_saluatation_name(context: dict) -> str:
+    """Get the salutation name for comment notification emails
+
+    Args:
+        context: the context dict containing the activity source and recipient [`User`][hypha.apply.users.models.User] object.
+
+    Returns:
+        A salutation display name, defaults to user's full name if set otherwise uses role.
+    """
+    source = context["source"]
+    recipient = context["recipient"]
+    full_name = recipient.get_full_name()
+    if full_name:
+        return full_name
+    if recipient == source.user:
+        return _("applicant")
+    elif recipient in source.partners.all():
+        return _("partner")

--- a/hypha/apply/activity/tests/test_messaging.py
+++ b/hypha/apply/activity/tests/test_messaging.py
@@ -524,6 +524,19 @@ class TestEmailAdapter(AdapterMixin, TestCase):
         )
         self.assertEqual(len(mail.outbox), 0)
 
+    def test_email_staff_submission_comments(self):
+        staff_commenter = StaffFactory()
+        submission = ApplicationSubmissionFactory()
+        comment = CommentFactory(
+            user=staff_commenter, source=submission, visibility=APPLICANT
+        )
+
+        self.adapter_process(
+            MESSAGES.COMMENT, related=comment, user=comment.user, source=comment.source
+        )
+        self.assertEqual(len(mail.outbox), 1)
+        self.assertCountEqual(mail.outbox[0].to, [submission.user.email])
+
     def test_email_staff_project_comments(self):
         staff_commenter = StaffFactory()
         project = ProjectFactory()


### PR DESCRIPTION
<!--
Thanks for contributing to Hypha!

Please ensure your contributions pass all necessary linting/testing and that the appropriate documentation has been updated.
-->

<!--
Describe briefly what your pull request changes. If this is resoving an issue, please specify below via "Fixes #<Github Issue ID>"
-->
Fixes #3871. Allows partners that are assigned to an application to also get email notifications when a new comment is made that has applicable visibility. There was some refactoring that took place to allow for email messages to be customized on a per-recipient basis rather than having one be generated for all recipients.

## Test Steps
<!-- 
If step does not require manual testing, skip/remove this section.

Give a brief overview of the steps required for a user/dev to test this contribution. Important things to include:
 - Required user roles for where neccesary (ie. "As a Staff Admin...")
 - Clear & validatable expected results (ie. "Confirm the submit button is now not clickable")
 - Langauge that can be understood by non-technical testers if being tested by users
-->

 - [ ] Assign one or more partners to an application
 - [ ] As staff, comment on the application with the visibility of `Partners`
 - [ ] Ensure only partners receive the notification email
 - [ ] As staff, comment on the application with the visibility of `Applicants`
 - [ ] Ensure only the applicant receives the notification email
 - [ ] As staff, comment on the application with the visibility of `Applicants & Partners`
 - [ ] Ensure both the applicant & partners receive the notification email
 - [ ] Try some of the same logic but become partner and/or applicant and ensure email notifications have a similar result as the previous steps
