### PR TITLE
Fix alignment of expand icon + make it accessible

### DIFF
--- a/hypha/static_src/javascript/all-submissions-table.js
+++ b/hypha/static_src/javascript/all-submissions-table.js
@@ -4,11 +4,12 @@
     let submission_arrow = document.createElement("span");
     submission_arrow.classList.add("arrow");
 
-    let submission_toggle = document.createElement("span");
+    let submission_toggle = document.createElement("button");
     submission_toggle.classList.add(
         "all-submissions-table__toggle",
         "js-toggle-submission"
     );
+    submission_toggle.setAttribute("title", "Show submission details");
     submission_toggle.appendChild(submission_arrow);
 
     // Add the toggle arrow before the submission titles.

--- a/hypha/static_src/sass/components/_all-submissions-table.scss
+++ b/hypha/static_src/sass/components/_all-submissions-table.scss
@@ -161,7 +161,6 @@
                     @include triangle(right, $color--primary, 6px);
                     position: relative;
                     display: inline-block;
-                    margin-inline-end: 10px;
                     transform: rotate(0);
                     transition: transform $transition;
 
@@ -245,7 +244,14 @@
     }
 
     &__toggle {
-        padding: 5px 0 5px 5px;
+        padding: 0.5em;
+        margin-top: -0.5em;
+        cursor: pointer;
+        vertical-align: top;
+
+        &:hover {
+            opacity: 0.7;
+        }
     }
 
     &__more {

--- a/hypha/static_src/sass/components/_table.scss
+++ b/hypha/static_src/sass/components/_table.scss
@@ -116,7 +116,7 @@
             }
 
             &.title {
-                padding-inline-start: 20px;
+                padding-inline-start: 0.5em;
             }
         }
     }


### PR DESCRIPTION
<!--
Thanks for contributing to Hypha!

Please ensure your contributions pass all necessary linting/testing and that the appropriate documentation has been updated.
-->

<!--
Describe briefly what your pull request changes. If this is resolving an issue, please specify below via "Fixes #<Github Issue ID>"
-->
Fixes #3889

![Screenshot 2024-05-06 at 6  42 58@2x](https://github.com/HyphaApp/hypha/assets/236356/7daeb715-76e9-48e0-b695-d4588bd60903)


## Test Steps
<!-- 
If step does not require manual testing, skip/remove this section.

Give a brief overview of the steps required for a user/dev to test this contribution. Important things to include:
 - Required user roles for where necessary (ie. "As a Staff Admin...")
 - Clear & validatable expected results (ie. "Confirm the submit button is now not clickable")
 - Language that can be understood by non-technical testers if being tested by users
-->

 - [ ] Goto submission list views
 - [ ] Check the arrow icon in each row is aligned with the title