### PR TITLE
Disable project related functionality if PROJECTS_ENABLED=False

### DIFF
--- a/hypha/apply/dashboard/templates/dashboard/dashboard.html
+++ b/hypha/apply/dashboard/templates/dashboard/dashboard.html
@@ -113,7 +113,7 @@
         {% if my_reviewed.table.data %}
             <div class="wrapper wrapper--bottom-space">
                 {% trans "Your previous reviews" as review_heading %}
-                {% include "funds/includes/table_filter_and_search.html" with filter=my_reviewed.filterset filter_action=my_reviewed.url search_term=search_term search_action=my_reviewed.url use_search=True use_batch_actions=False heading=review_heading %}
+                <h2 class="heading heading--normal">{{ review_heading }}</h2>
                 {% render_table my_reviewed.table %}
 
                 {% if my_reviewed.display_more %}

--- a/hypha/apply/dashboard/views.py
+++ b/hypha/apply/dashboard/views.py
@@ -82,17 +82,18 @@ class AdminDashboardView(MyFlaggedMixin, TemplateView):
 
         context.update(
             {
-                "active_invoices": self.active_invoices(),
                 "awaiting_reviews": self.awaiting_reviews(submissions),
                 "can_export": can_export_submissions(self.request.user),
                 "my_reviewed": self.my_reviewed(submissions),
-                "projects": self.projects(),
                 "rounds": self.rounds(),
                 "my_flagged": self.my_flagged(submissions),
-                "paf_for_review": self.paf_for_review(),
                 "my_tasks": self.my_tasks(),
             }
         )
+        if settings.PROJECTS_ENABLED:
+            context["projects"] = self.projects()
+            context["active_invoices"] = self.active_invoices()
+            context["paf_for_review"] = self.paf_for_review()
 
         return context
 

--- a/hypha/apply/funds/models/utils.py
+++ b/hypha/apply/funds/models/utils.py
@@ -1,3 +1,4 @@
+from django.conf import settings
 from django.db import models
 from django.shortcuts import redirect
 from django.urls import reverse
@@ -144,11 +145,15 @@ class WorkflowStreamForm(WorkflowHelpers, AbstractStreamForm):  # type: ignore
             help_text="Add a form to be used by external reviewers.",
         ),
         InlinePanel("determination_forms", label=_("Determination Forms")),
-        InlinePanel("approval_forms", label=_("Project Approval Form"), max_num=1),
-        InlinePanel("sow_forms", label=_("Project SOW Form"), max_num=1),
-        # The models technically allow for multiple Report forms but to start we permit only one in the UIs.
-        InlinePanel("report_forms", label=_("Project Report Form"), max_num=1),
     ]
+
+    if settings.PROJECTS_ENABLED:
+        content_panels += [
+            InlinePanel("approval_forms", label=_("Project Approval Form"), max_num=1),
+            InlinePanel("sow_forms", label=_("Project SOW Form"), max_num=1),
+            # The models technically allow for multiple Report forms but to start we permit only one in the UIs.
+            InlinePanel("report_forms", label=_("Project Report Form"), max_num=1),
+        ]
 
 
 class EmailForm(AbstractEmailForm):

--- a/hypha/apply/funds/urls.py
+++ b/hypha/apply/funds/urls.py
@@ -1,3 +1,4 @@
+from django.conf import settings
 from django.urls import include, path
 from django.views.generic import RedirectView
 
@@ -238,9 +239,12 @@ rounds_urls = (
     "rounds",
 )
 
-
 urlpatterns = [
     path("submissions/", include(submission_urls)),
     path("rounds/", include(rounds_urls)),
-    path("projects/", include(projects_urls)),
 ]
+
+if settings.PROJECTS_ENABLED:
+    urlpatterns += [
+        path("projects/", include(projects_urls)),
+    ]

--- a/hypha/apply/projects/wagtail_hooks.py
+++ b/hypha/apply/projects/wagtail_hooks.py
@@ -1,5 +1,7 @@
+from django.conf import settings
 from wagtail.contrib.modeladmin.options import modeladmin_register
 
 from .admin import ProjectAdminGroup
 
-modeladmin_register(ProjectAdminGroup)
+if settings.PROJECTS_ENABLED:
+    modeladmin_register(ProjectAdminGroup)

--- a/hypha/apply/utils/views.py
+++ b/hypha/apply/utils/views.py
@@ -1,3 +1,4 @@
+from django.conf import settings
 from django.contrib.auth.decorators import login_required
 from django.db.models import ProtectedError
 from django.forms.models import ModelForm
@@ -57,9 +58,9 @@ class ViewDispatcher(View):
             view = self.partner_view
         elif self.community_check(request):
             view = self.community_view
-        elif self.finance_check(request):
+        elif settings.PROJECTS_ENABLED and self.finance_check(request):
             view = self.finance_view
-        elif self.contracting_check(request):
+        elif settings.PROJECTS_ENABLED and self.contracting_check(request):
             view = self.contracting_view
         elif self.applicant_check(request):
             view = self.applicant_view


### PR DESCRIPTION
- do not register project urls
- do not register project menu in wagtail
- do not enable contracting/finance dashboard

Fixes #3606

Project settings and vendor settings will still be present, I could not find a way to hide/disable them conditionally. 

![Screenshot 2024-05-08 at 4  16 29@2x](https://github.com/HyphaApp/hypha/assets/236356/2adcb044-1a2b-4318-8814-4049e03e0c94)


## Test Steps
<!-- 
If step does not require manual testing, skip/remove this section.

Give a brief overview of the steps required for a user/dev to test this contribution. Important things to include:
 - Required user roles for where necessary (ie. "As a Staff Admin...")
 - Clear & validatable expected results (ie. "Confirm the submit button is now not clickable")
 - Language that can be understood by non-technical testers if being tested by users
-->

 - [ ] Set PROJECTS_ENABLED=False
 - [ ] check dashboard, wagtail admin and finance roles
 - [ ] general site-wide checks
 - [ ] try visit the urls related to project/finance directly