### PR TITLE
Unsaved changes notification on review form

### DIFF
--- a/hypha/apply/review/templates/review/review_edit_form.html
+++ b/hypha/apply/review/templates/review/review_edit_form.html
@@ -13,7 +13,7 @@
     {% include "forms/includes/form_errors.html" with form=form %}
 
     <div class="wrapper wrapper--medium wrapper--inner-space-medium">
-        <form class="form form--with-p-tags form--scoreable" action="" method="post" novalidate>
+        <form id="review-form-edit" class="form form--with-p-tags form--scoreable" action="" method="post" novalidate>
             {{ form.media }}
             {% csrf_token %}
 

--- a/hypha/apply/review/templates/review/review_edit_form.html
+++ b/hypha/apply/review/templates/review/review_edit_form.html
@@ -1,5 +1,5 @@
 {% extends "base-apply.html" %}
-{% load i18n %}
+{% load i18n static %}
 {% block title %}{{ title }}{% endblock %}
 {% block content %}
 
@@ -43,4 +43,7 @@
             <button class="button button--submit button--top-space button--primary" type="submit" name="submit">{% trans "Submit" %}</button>
         </form>
     </div>
+{% endblock %}
+{% block extra_js %}
+    <script src="{% static 'js/review-form-actions.js' %}"></script>
 {% endblock %}

--- a/hypha/apply/review/templates/review/review_form.html
+++ b/hypha/apply/review/templates/review/review_form.html
@@ -1,5 +1,5 @@
 {% extends "base-apply.html" %}
-{% load i18n %}
+{% load i18n static %}
 {% block title %}{{ title }}{% endblock %}
 {% block content %}
 
@@ -47,4 +47,7 @@
             <p>{% trans "You have already posted a review for this submission" %}</p>
         {% endif %}
     </div>
+{% endblock %}
+{% block extra_js %}
+    <script src="{% static 'js/review-form-actions.js' %}"></script>
 {% endblock %}

--- a/hypha/apply/review/templates/review/review_form.html
+++ b/hypha/apply/review/templates/review/review_form.html
@@ -14,7 +14,7 @@
 
     <div class="wrapper wrapper--medium wrapper--inner-space-medium">
         {% if not has_submitted_review %}
-            <form class="form form--with-p-tags form--scoreable" action="" method="post">
+            <form id="review-form-edit" class="form form--with-p-tags form--scoreable" action="" method="post">
                 {{ form.media }}
                 {% csrf_token %}
 

--- a/hypha/static_src/javascript/review-form-actions.js
+++ b/hypha/static_src/javascript/review-form-actions.js
@@ -1,0 +1,44 @@
+(function ($) {
+    "use strict";
+    $(document).ready(function () {
+        var form = $("form");
+        var original = form.serialize();
+
+        window.onbeforeunload = function () {
+            if (form.serialize() !== original) {
+                return "Are you sure you want to leave?";
+            }
+        };
+
+        form.submit(function () {
+            window.onbeforeunload = null;
+        });
+
+        // grab all the selectors
+        let filtered_selectors;
+        const selectors = Array.prototype.slice.call(
+            document.querySelectorAll("select")
+        );
+        if (selectors.length > 1) {
+            document.querySelector(".form--score-box").style.display = "block";
+            // remove recommendation select box from array
+            filtered_selectors = selectors.filter(
+                (selector) => selector[0].text !== "Need More Info"
+            );
+            filtered_selectors.forEach(function (selector) {
+                selector.onchange = calculate_score;
+            });
+            calculate_score();
+        }
+        function calculate_score() {
+            let score = 0;
+            filtered_selectors.forEach(function (selector) {
+                const value = parseInt(selector.value);
+                if (!isNaN(value) && value !== 99) {
+                    score += value;
+                }
+            });
+            $(".form--score-box").text("Score: " + score);
+        }
+    });
+})(jQuery);

--- a/hypha/static_src/javascript/review-form-actions.js
+++ b/hypha/static_src/javascript/review-form-actions.js
@@ -1,44 +1,24 @@
-(function ($) {
+function formContents(f) {
     "use strict";
-    $(document).ready(function () {
-        var form = $("form");
-        var original = form.serialize();
+    // Thanks to https://stackoverflow.com/a/44033425
+    return Array.from(new FormData(f), function (e) {
+        return e.map(encodeURIComponent).join("=");
+    }).join("&");
+}
 
-        window.onbeforeunload = function () {
-            if (form.serialize() !== original) {
-                return "Are you sure you want to leave?";
-            }
-        };
+document.addEventListener("DOMContentLoaded", function () {
+    "use strict";
+    const form = document.getElementById("review-form-edit");
+    const original = formContents(form);
 
-        form.submit(function () {
-            window.onbeforeunload = null;
-        });
-
-        // grab all the selectors
-        let filtered_selectors;
-        const selectors = Array.prototype.slice.call(
-            document.querySelectorAll("select")
-        );
-        if (selectors.length > 1) {
-            document.querySelector(".form--score-box").style.display = "block";
-            // remove recommendation select box from array
-            filtered_selectors = selectors.filter(
-                (selector) => selector[0].text !== "Need More Info"
-            );
-            filtered_selectors.forEach(function (selector) {
-                selector.onchange = calculate_score;
-            });
-            calculate_score();
+    window.onbeforeunload = function () {
+        const formNow = formContents(form);
+        if (formNow !== original) {
+            return "Are you sure you want to leave?";
         }
-        function calculate_score() {
-            let score = 0;
-            filtered_selectors.forEach(function (selector) {
-                const value = parseInt(selector.value);
-                if (!isNaN(value) && value !== 99) {
-                    score += value;
-                }
-            });
-            $(".form--score-box").text("Score: " + score);
-        }
+    };
+
+    form.addEventListener("submit", function () {
+        window.onbeforeunload = null;
     });
-})(jQuery);
+});


### PR DESCRIPTION
Fixes #3977 

## Test Steps

- As Reviewer, add or edit a review on a submission (example `/apply/submissions/2/reviews/3/`)
- Change one of the fields without clicking Submit
- Close the tab: a notification should require confirmation
- Click back: a notification should require confirmation
- Click another tab: a notification should require confirmation