### PR TITLE
CSV export from all submissions

### DIFF
--- a/hypha/apply/funds/templates/funds/base_submissions_table.html
+++ b/hypha/apply/funds/templates/funds/base_submissions_table.html
@@ -9,7 +9,7 @@
 
 {% block content %}
     {% block table %}
-        {% include "funds/includes/table_filter_and_search.html" with filter_form=filter_form search_term=search_term use_search=True filter_action=filter_action use_batch_actions=True filter_classes="filters-open" %}
+        {% include "funds/includes/table_filter_and_search.html" with filter_form=filter_form search_term=search_term use_search=True filter_action=filter_action use_batch_actions=True filter_classes="filters-open" can_export=can_export %}
 
         {% render_table table %}
     {% endblock %}

--- a/hypha/apply/funds/templates/funds/includes/table_filter_and_search.html
+++ b/hypha/apply/funds/templates/funds/includes/table_filter_and_search.html
@@ -66,6 +66,9 @@
                     <a href="{% modify_query archived='1' %}">{% trans "Show archived" %}</a>
                 {% endif %}
             {% endif %}
+            {% with request.get_full_path as path %}
+                <a href="{{path}}{% if '?' in path %}&{%else%}?{% endif %}export=true"><button type="submit" class="button--primary">{% trans 'Export all submissions' %}</button></a>
+            {% endwith %}
             {% if filter_classes != 'filters-open' %}
                 <button class="button js-toggle-filters">
                     {% heroicon_mini "adjustments-horizontal" class="inline me-1 text-dark-blue align-text-bottom" aria_hidden=true %}

--- a/hypha/apply/funds/templates/funds/includes/table_filter_and_search.html
+++ b/hypha/apply/funds/templates/funds/includes/table_filter_and_search.html
@@ -66,9 +66,11 @@
                     <a href="{% modify_query archived='1' %}">{% trans "Show archived" %}</a>
                 {% endif %}
             {% endif %}
-            {% with request.get_full_path as path %}
-                <a href="{{path}}{% if '?' in path %}&{%else%}?{% endif %}export=true"><button type="submit" class="button--primary">{% trans 'Export all submissions' %}</button></a>
-            {% endwith %}
+            {% if request.user.is_apply_staff or request.user.is_staff %}
+                {% with request.get_full_path as path %}
+                    <a href="{{path}}{% if '?' in path %}&{%else%}?{% endif %}export=true"><button type="submit" class="button--primary">{% trans 'Export all submissions' %}</button></a>
+                {% endwith %}
+            {% endif %}
             {% if filter_classes != 'filters-open' %}
                 <button class="button js-toggle-filters">
                     {% heroicon_mini "adjustments-horizontal" class="inline me-1 text-dark-blue align-text-bottom" aria_hidden=true %}

--- a/hypha/apply/funds/templates/funds/includes/table_filter_and_search.html
+++ b/hypha/apply/funds/templates/funds/includes/table_filter_and_search.html
@@ -66,7 +66,7 @@
                     <a href="{% modify_query archived='1' %}">{% trans "Show archived" %}</a>
                 {% endif %}
             {% endif %}
-            {% if request.user.is_apply_staff or request.user.is_staff %}
+            {% if can_export %}
                 {% with request.get_full_path as path %}
                     <a href="{{path}}{% if '?' in path %}&{%else%}?{% endif %}export=true"><button type="submit" class="button--primary">{% trans 'Export CSV' %}</button></a>
                 {% endwith %}

--- a/hypha/apply/funds/templates/funds/includes/table_filter_and_search.html
+++ b/hypha/apply/funds/templates/funds/includes/table_filter_and_search.html
@@ -68,7 +68,7 @@
             {% endif %}
             {% if request.user.is_apply_staff or request.user.is_staff %}
                 {% with request.get_full_path as path %}
-                    <a href="{{path}}{% if '?' in path %}&{%else%}?{% endif %}export=true"><button type="submit" class="button--primary">{% trans 'Export all submissions' %}</button></a>
+                    <a href="{{path}}{% if '?' in path %}&{%else%}?{% endif %}export=true"><button type="submit" class="button--primary">{% trans 'Export CSV' %}</button></a>
                 {% endwith %}
             {% endif %}
             {% if filter_classes != 'filters-open' %}

--- a/hypha/apply/funds/templates/funds/includes/table_filter_and_search.html
+++ b/hypha/apply/funds/templates/funds/includes/table_filter_and_search.html
@@ -68,7 +68,7 @@
             {% endif %}
             {% with request.get_full_path as path %}
                 {% if 'submission' in path and can_export %}
-                    <a href="{{path}}{% if '?' in path %}&{%else%}?{% endif %}export=true"><button type="submit" class="export-btn-width button--primary">{% trans 'Export CSV' %}</button></a>
+                    <a href="{{path}}{% if '?' in path %}&{%else%}?{% endif %}export=true" class="button button--primary">{% trans 'Export CSV' %}</a>
                 {% endif %}
             {% endwith %}
             {% if filter_classes != 'filters-open' %}

--- a/hypha/apply/funds/templates/funds/includes/table_filter_and_search.html
+++ b/hypha/apply/funds/templates/funds/includes/table_filter_and_search.html
@@ -66,11 +66,11 @@
                     <a href="{% modify_query archived='1' %}">{% trans "Show archived" %}</a>
                 {% endif %}
             {% endif %}
-            {% if can_export %}
-                {% with request.get_full_path as path %}
+            {% with request.get_full_path as path %}
+                {% if 'submission' in path and can_export %}
                     <a href="{{path}}{% if '?' in path %}&{%else%}?{% endif %}export=true"><button type="submit" class="button--primary">{% trans 'Export CSV' %}</button></a>
-                {% endwith %}
-            {% endif %}
+                {% endif %}
+            {% endwith %}
             {% if filter_classes != 'filters-open' %}
                 <button class="button js-toggle-filters">
                     {% heroicon_mini "adjustments-horizontal" class="inline me-1 text-dark-blue align-text-bottom" aria_hidden=true %}

--- a/hypha/apply/funds/templates/funds/includes/table_filter_and_search.html
+++ b/hypha/apply/funds/templates/funds/includes/table_filter_and_search.html
@@ -68,7 +68,7 @@
             {% endif %}
             {% with request.get_full_path as path %}
                 {% if 'submission' in path and can_export %}
-                    <a href="{{path}}{% if '?' in path %}&{%else%}?{% endif %}export=true"><button type="submit" class="button--primary">{% trans 'Export CSV' %}</button></a>
+                    <a href="{{path}}{% if '?' in path %}&{%else%}?{% endif %}export=true"><button type="submit" class="export-btn-width button--primary">{% trans 'Export CSV' %}</button></a>
                 {% endif %}
             {% endwith %}
             {% if filter_classes != 'filters-open' %}

--- a/hypha/apply/funds/templates/funds/rounds.html
+++ b/hypha/apply/funds/templates/funds/rounds.html
@@ -17,7 +17,7 @@
     {% endadminbar %}
 
     <div class="wrapper wrapper--large wrapper--inner-space-medium">
-        {% include "funds/includes/table_filter_and_search.html" with filter_form=filter_form search_term=search_term use_batch_actions=False %}
+        {% include "funds/includes/table_filter_and_search.html" with filter_form=filter_form search_term=search_term use_batch_actions=False can_export=can_export %}
         {% render_table table %}
     </div>
 

--- a/hypha/apply/funds/templates/funds/submissions.html
+++ b/hypha/apply/funds/templates/funds/submissions.html
@@ -34,7 +34,7 @@
         {% endif %}
 
         {% block table %}
-            {% include "funds/includes/table_filter_and_search.html" with filter_form=filter_form search_term=search_term use_search=True filter_action=filter_action use_batch_actions=True filter_classes="filters-open" show_archive=show_archive %}
+            {% include "funds/includes/table_filter_and_search.html" with filter_form=filter_form search_term=search_term use_search=True filter_action=filter_action use_batch_actions=True filter_classes="filters-open" show_archive=show_archive can_export=can_export %}
 
             {% render_table table %}
         {% endblock %}

--- a/hypha/apply/funds/utils.py
+++ b/hypha/apply/funds/utils.py
@@ -1,4 +1,8 @@
+import csv
+from io import StringIO
 from itertools import chain
+
+from django.utils.html import strip_tags
 
 from hypha.apply.utils.image import generate_image_tag
 
@@ -92,3 +96,31 @@ def get_statuses_as_params(statuses):
     for status in statuses:
         params += "status=" + status + "&"
     return params
+
+
+def export_submissions_to_csv(submissions_list):
+    csv_stream = StringIO()
+    header_row = ["Application #"]
+    index = 1
+    data_list = []
+    for submission in submissions_list:
+        values = {}
+        values["Application #"] = submission.id
+        for field_id in submission.question_text_field_ids:
+            question_field = submission.serialize(field_id)
+            field_name = question_field["question"]
+            field_value = question_field["answer"]
+            if field_name not in header_row:
+                if field_id not in submission.named_blocks:
+                    header_row.append(field_name)
+                else:
+                    header_row.insert(index, field_name)
+                    index = index + 1
+            values[field_name] = strip_tags(field_value)
+        data_list.append(values)
+    writer = csv.DictWriter(csv_stream, fieldnames=header_row, restval="")
+    writer.writeheader()
+    for data in data_list:
+        writer.writerow(data)
+    csv_stream.seek(0)
+    return csv_stream

--- a/hypha/apply/funds/views.py
+++ b/hypha/apply/funds/views.py
@@ -231,7 +231,9 @@ class BaseAdminSubmissionsTable(SingleTableMixin, FilterView):
 
     def dispatch(self, request, *args, **kwargs):
         disp = super().dispatch(request, *args, **kwargs)
-        if "export" in request.GET:
+        if "export" in request.GET and (
+            self.request.user.is_staff or self.request.user.is_apply_staff
+        ):
             csv_data = self.export_applications(self.object_list)
             return csv_data
         return disp

--- a/hypha/apply/funds/views.py
+++ b/hypha/apply/funds/views.py
@@ -224,14 +224,13 @@ class BaseAdminSubmissionsTable(SingleTableMixin, FilterView):
             search_term=search_term,
             search_action=self.search_action,
             filter_action=self.filter_action,
+            can_export=can_export_submissions(self.request.user),
             **kwargs,
         )
 
     def dispatch(self, request, *args, **kwargs):
         disp = super().dispatch(request, *args, **kwargs)
-        if "export" in request.GET and (
-            self.request.user.is_staff or self.request.user.is_apply_staff
-        ):
+        if "export" in request.GET and can_export_submissions(request.user):
             csv_data = export_submissions_to_csv(self.object_list)
             response = HttpResponse(csv_data.readlines(), content_type="text/csv")
             response["Content-Disposition"] = "attachment; filename=submissions.csv"

--- a/hypha/static_src/sass/components/_button.scss
+++ b/hypha/static_src/sass/components/_button.scss
@@ -437,3 +437,7 @@
         }
     }
 }
+
+.export-btn-width {
+    width: max-content;
+}

--- a/hypha/static_src/sass/components/_button.scss
+++ b/hypha/static_src/sass/components/_button.scss
@@ -437,7 +437,3 @@
         }
     }
 }
-
-.export-btn-width {
-    width: max-content;
-}


### PR DESCRIPTION

Fixes #3981


## Test Steps

- As reviewer, visit All Submissions, see no CSV export button
- As staff, visit All Submissions
- Filter the submissions by one or more columns such that some submissions are removed and some remain
- Click Export CSV
- Download and open the CSV file
- Verify that only the filtered submissions show up in the CSV
- Verify that application/submission columns with data are present