### PR TITLE
Staff role should not suppress reviewer emails

### DIFF
--- a/hypha/apply/activity/adapters/emails.py
+++ b/hypha/apply/activity/adapters/emails.py
@@ -438,7 +438,6 @@ class EmailAdapter(AdapterBase):
             reviewer.email
             for reviewer in source.missing_reviewers.all()
             if source.phase.permissions.can_review(reviewer)
-            and not reviewer.is_apply_staff
         ]
 
     def partners_updated_applicant(self, added, removed, **kwargs):


### PR DESCRIPTION
Reviewer email notification for assigned application behavior corrected.

Fixes #3983

## Test Steps

Set up a dummy email SMTP server or use file-based email.

- Update a user to be both Staff and Admin
- Assign that user to review an application/submission
- See emails go through to that user