### PR TITLE
Update Wagtail to v5.2.5

### DIFF
--- a/hypha/apply/dashboard/wagtail_hooks.py
+++ b/hypha/apply/dashboard/wagtail_hooks.py
@@ -13,6 +13,6 @@ def register_dashboard_menu_item():
     return MenuItem(
         "Apply Dashboard",
         urljoin(apply_home.url, reverse("dashboard:dashboard", "hypha.urls")),
-        classnames="icon icon-arrow-left",
+        classname="icon icon-arrow-left",
         order=100000,
     )

--- a/requirements.txt
+++ b/requirements.txt
@@ -55,7 +55,7 @@ tablib==3.5.0
 tomd==0.1.3
 wagtail-cache==2.4.0
 wagtail-purge==0.3.0
-wagtail==5.2.3
+wagtail==5.2.5
 whitenoise==6.6.0
 xhtml2pdf==0.2.15
 xmltodict==0.13.0


### PR DESCRIPTION
Also fixes one instance of "The `classnames` kwarg for MenuItem is deprecated - use `classname` instead.".