### PR TITLE
Fix editing comment updates the comment visibility

### DIFF
--- a/hypha/apply/api/v1/serializers.py
+++ b/hypha/apply/api/v1/serializers.py
@@ -450,6 +450,7 @@ class CommentEditSerializer(CommentCreateSerializer):
     class Meta(CommentCreateSerializer.Meta):
         read_only_fields = (
             "timestamp",
+            "visibility",
             "edited",
         )
 

--- a/hypha/apply/api/v1/tests/test_views.py
+++ b/hypha/apply/api/v1/tests/test_views.py
@@ -78,7 +78,7 @@ class TestCommentEdit(TestCase):
 
         self.assertEqual(Activity.objects.count(), 1)
 
-    def test_staff_can_change_visibility(self):
+    def test_staff_can_not_change_visibility(self):
         user = StaffFactory()
         comment = CommentFactory(user=user, visibility=APPLICANT)
         self.client.force_login(user)
@@ -93,7 +93,7 @@ class TestCommentEdit(TestCase):
         )
 
         self.assertEqual(response.status_code, 200, response.json())
-        self.assertEqual(response.json()["visibility"], ALL)
+        self.assertEqual(response.json()["visibility"], APPLICANT)
 
     def test_out_of_order_does_nothing(self):
         user = ApplicantFactory()  # any role assigned user

--- a/hypha/apply/api/v1/views.py
+++ b/hypha/apply/api/v1/views.py
@@ -384,9 +384,7 @@ class CommentViewSet(viewsets.GenericViewSet):
         serializer = self.get_serializer(comment_to_edit, data=request.data)
         serializer.is_valid(raise_exception=True)
 
-        if (serializer.validated_data["message"] != comment_to_update.message) or (
-            serializer.validated_data["visibility"] != comment_to_update.visibility
-        ):
+        if serializer.validated_data["message"] != comment_to_update.message:
             self.perform_create(serializer)
             comment_to_update.current = False
             comment_to_update.save()


### PR DESCRIPTION
Editing a comment which is for internal team changes it's visibility to applicant + staff

How to reproduce:
- Login as staff
- Add a comment and then edit the same comment
- Refresh the page and see the visibility becomes Applicant + staff

When editing the comment, I didn't see staff getting a UI to update the visibility so not allowing the visibility change in the commit edit api seems to be the right thing to do as well

## Test Steps
<!-- 
If step does not require manual testing, skip/remove this section.

Give a brief overview of the steps required for a user/dev to test this contribution. Important things to include:
 - Required user roles for where necessary (ie. "As a Staff Admin...")
 - Clear & validatable expected results (ie. "Confirm the submit button is now not clickable")
 - Language that can be understood by non-technical testers if being tested by users
-->

 - [ ] login as staff and leave and edit the comment, make sure the visibility is not updated