### PR TITLE
Remove None reviewers from validation

### DIFF
--- a/hypha/apply/funds/forms.py
+++ b/hypha/apply/funds/forms.py
@@ -396,7 +396,7 @@ class BatchUpdateReviewersForm(forms.Form):
         role_reviewers = [
             user
             for field, user in self.cleaned_data.items()
-            if field in self.role_fields
+            if field in self.role_fields and user
         ]
 
         # If any of the users match and are set to multiple roles, throw an error

--- a/hypha/apply/funds/forms.py
+++ b/hypha/apply/funds/forms.py
@@ -270,7 +270,7 @@ class UpdateReviewersForm(ApplicationSubmissionModelForm):
         role_reviewers = [
             user
             for field, user in self.cleaned_data.items()
-            if field in self.role_fields
+            if field in self.role_fields and user
         ]
 
         for field, role in self.role_fields.items():


### PR DESCRIPTION
Fixes #4020

This was caused by an issue where the "---" (None) reviewers were causing the validation to fail, meaning that you had to fill out n-1 reviewers in the submission page in order for the save to go through.

The solution was to only check for duplicates with reviewers that were selected.