### PR TITLE
Enable group stream boxes when in draft and edit mode

### DIFF
--- a/hypha/apply/funds/templates/funds/application_base.html
+++ b/hypha/apply/funds/templates/funds/application_base.html
@@ -58,9 +58,9 @@
                     {% for field in form %}
                         {% if field.field %}
                             {% if field.field.multi_input_field %}
-                                {% include "forms/includes/multi_input_field.html" with is_application=True %}
+                                {% include "forms/includes/multi_input_field.html" %}
                             {% else %}
-                                {% include "forms/includes/field.html" with is_application=True %}
+                                {% include "forms/includes/field.html" %}
                             {% endif %}
                         {% else %}
                             {% if field.group_number > 1 %}

--- a/hypha/apply/funds/templates/funds/application_preview.html
+++ b/hypha/apply/funds/templates/funds/application_preview.html
@@ -20,9 +20,9 @@
                 {% for field in form %}
                     {% if field.field %}
                         {% if field.field.multi_input_field %}
-                            {% include "forms/includes/multi_input_field.html" with is_application=True %}
+                            {% include "forms/includes/multi_input_field.html" %}
                         {% else %}
-                            {% include "forms/includes/field.html" with is_application=True %}
+                            {% include "forms/includes/field.html" %}
                         {% endif %}
                     {% else %}
                         <div class="max-w-none field-block prose">

--- a/hypha/apply/funds/views/submission_edit.py
+++ b/hypha/apply/funds/views/submission_edit.py
@@ -38,7 +38,6 @@ from hypha.apply.determinations.views import (
 )
 from hypha.apply.projects.forms import ProjectCreateForm
 from hypha.apply.projects.models.project import PROJECT_STATUS_CHOICES
-from hypha.apply.stream_forms.blocks import GroupToggleBlock
 from hypha.apply.todo.options import PROJECT_WAITING_PF, PROJECT_WAITING_SOW
 from hypha.apply.todo.views import add_task_to_user
 from hypha.apply.users.decorators import (
@@ -281,9 +280,6 @@ class BaseSubmissionEditView(UpdateView):
         When trying to save as draft, this method will return a version of form
         class that doesn't validate required fields while saving.
 
-        The method also disables any group toggle fields in the form, as they
-        are not supported on edit forms.
-
         Returns:
             class: The form class for the view.
         """
@@ -291,11 +287,6 @@ class BaseSubmissionEditView(UpdateView):
         form_fields = self.object.get_form_fields(
             draft=is_draft, form_data=self.object.raw_data, user=self.request.user
         )
-        field_blocks = self.object.get_defined_fields()
-        for field_block in field_blocks:
-            if isinstance(field_block.block, GroupToggleBlock):
-                # Disable group toggle field as it is not supported on edit forms.
-                form_fields[field_block.id].disabled = True
         return type(
             "WagtailStreamForm", (self.object.submission_form_class,), form_fields
         )

--- a/hypha/apply/templates/forms/includes/field.html
+++ b/hypha/apply/templates/forms/includes/field.html
@@ -1,13 +1,13 @@
 {% load i18n util_tags heroicons %}
 
 {% with widget_type=field|widget_type field_type=field|field_type %}
-    <div class="form__group {{ field.id_for_label }} form__group--{{ widget_type }} {% if widget_type == 'checkbox_input' %} form__group--checkbox{% endif %}{% if widget_type == 'clearable_file_input' or widget_type == 'multi_file_input' or widget_type == 'single_file_field_widget' or widget_type == 'multi_file_field_widget' %} form__group--file{% endif %}{% if field.help_text %} form__group--wrap{% endif %}{% if field.errors %} form__error{% endif %}{% if is_application and field.field.group_number > 1 %} field-group field-group-{{ field.field.group_number }}{% endif %}{% if is_application and field.field.grouper_for %} form-fields-grouper{% endif %}"
-         {% if is_application and field.field.grouper_for %}
+    <div class="form__group {{ field.id_for_label }} form__group--{{ widget_type }} {% if widget_type == 'checkbox_input' %} form__group--checkbox{% endif %}{% if widget_type == 'clearable_file_input' or widget_type == 'multi_file_input' or widget_type == 'single_file_field_widget' or widget_type == 'multi_file_field_widget' %} form__group--file{% endif %}{% if field.help_text %} form__group--wrap{% endif %}{% if field.errors %} form__error{% endif %}{% if field.field.group_number > 1 %} field-group field-group-{{ field.field.group_number }}{% endif %}{% if field.field.grouper_for %} form-fields-grouper{% endif %}"
+         {% if field.field.grouper_for %}
              data-grouper-for="{{ field.field.grouper_for }}"
              data-toggle-on="{{ field.field.choices.0.0 }}"
              data-toggle-off="{{ field.field.choices.1.0 }}"
          {% endif %}
-         {% if is_application and field.field.group_number > 1 %}
+         {% if field.field.group_number > 1 %}
              data-hidden="{% if not show_all_group_fields and not field.field.visible %}true{% else %}false{% endif %}"
              data-required="{{ field.field.required_when_visible }}"
          {% endif %}

--- a/hypha/apply/templates/forms/includes/multi_input_field.html
+++ b/hypha/apply/templates/forms/includes/multi_input_field.html
@@ -1,7 +1,7 @@
 {% load heroicons %}
 <div
-    class="form__item{% if field.help_text %} form__group--wrap{% endif %}{% if field.errors %} form__error{% endif %}{% if not field.initial %} multi-input-field-hidden{% endif %}{% if is_application and field.field.group_number > 1 %} field-group field-group-{{ field.field.group_number }}{% endif %}"
-    {% if is_application and field.field.group_number > 1 %} data-hidden="{% if not show_all_group_fields %}true{% else %}false{% endif %}"{% endif %}
+    class="form__item{% if field.help_text %} form__group--wrap{% endif %}{% if field.errors %} form__error{% endif %}{% if not field.initial %} multi-input-field-hidden{% endif %}{% if field.field.group_number > 1 %} field-group field-group-{{ field.field.group_number }}{% endif %}"
+    {% if field.field.group_number > 1 %} data-hidden="{% if not show_all_group_fields %}true{% else %}false{% endif %}"{% endif %}
     data-multi-field-for="{{ field.field.multi_input_id }}"
 >
     {{ field }}
@@ -11,7 +11,7 @@
 
 {% if field.field.multi_input_add_button %}
     <button
-        class="button button--primary button--narrow multi-input-add-btn my-2{% if is_application and field.field.group_number > 1 %} field-group field-group-{{ field.field.group_number }}{% endif %}"
+        class="button button--primary button--narrow multi-input-add-btn my-2{% if field.field.group_number > 1 %} field-group field-group-{{ field.field.group_number }}{% endif %}"
         type="button" data-multi-field-id="{{ field.field.multi_input_id }}"
         data-multi-visibility-index="{{ field.field.visibility_index }}"
         data-multi-max-index="{{ field.field.max_index }}"


### PR DESCRIPTION
Fixes #4031

They are disabled when editing a proposal in general, but in the case of a draft, the users sometimes need to be able to edit them in order to finish an application.

This fix may be incomplete, as it does not allow the group forms to have the full functionality of hiding the followup forms when "No" is selected, and showing them when "Yes" is selected.

