### PR TITLE
Add missing submission export to submission list view & update styling

### DIFF
--- a/docs/setup/administrators/configuration.md
+++ b/docs/setup/administrators/configuration.md
@@ -189,13 +189,13 @@ Should staff admins be able to access/see draft submissions.
 
 Should staff be able to export submissions.
 
-    SUBMISSIONS_EXPORT_ACCESS_STAFF = env.bool('SUBMISSIONS_EXPORT_ACCESS_STAFF', True)
+    SUBMISSIONS_EXPORT_ACCESS_STAFF = env.bool('SUBMISSIONS_EXPORT_ACCESS_STAFF', False)
 
 ----
 
 Should staff admins be able to export submissions.
 
-    SUBMISSIONS_EXPORT_ACCESS_STAFF_ADMIN = env.bool('SUBMISSIONS_EXPORT_ACCESS_STAFF_ADMIN', True)
+    SUBMISSIONS_EXPORT_ACCESS_STAFF_ADMIN = env.bool('SUBMISSIONS_EXPORT_ACCESS_STAFF_ADMIN', False)
 
 ----
 

--- a/hypha/apply/funds/templates/funds/includes/table_filter_and_search.html
+++ b/hypha/apply/funds/templates/funds/includes/table_filter_and_search.html
@@ -6,7 +6,7 @@
         {# Left #}
         <div class="actions-bar__inner actions-bar__inner--left">
             {% if heading %}
-                <h2 class="text-xl mb-2">{{ heading }}</h2>
+                <h2 class="mb-2 text-xl">{{ heading }}</h2>
             {% endif %}
 
 
@@ -57,33 +57,49 @@
         </div>
 
         {# Right #}
-        <div class="actions-bar__inner actions-bar__inner--right">
+        <div class="flex items-center gap-4">
             {% get_query 'archived' as archived_param %}
             {% if show_archive %}
                 {% if request.GET.archived == '1' %}
-                    <a href="{% modify_query archived='0' %}">{% trans "Hide archived" %}</a>
+                    <a
+                        class="px-3 py-1.5 flex items-center transition-colors rounded hover:bg-gray-100 hover:shadow-sm"
+                        href="{% modify_query archived='0' %}"
+                    >{% trans "Hide Archived" %}</a>
                 {% else %}
-                    <a href="{% modify_query archived='1' %}">{% trans "Show archived" %}</a>
+                    <a
+                        class="px-3 py-1.5 flex items-center transition-colors rounded hover:bg-gray-100 hover:shadow-sm"
+                        href="{% modify_query archived='1' %}"
+                    >{% trans "Show Archived" %}</a>
                 {% endif %}
             {% endif %}
             {% with request.get_full_path as path %}
                 {% if 'submission' in path and can_export %}
-                    <a href="{{path}}{% if '?' in path %}&{%else%}?{% endif %}export=true" class="button button--primary">{% trans 'Export CSV' %}</a>
+                    <a
+                        class="px-2 py-1.5 flex items-center transition-colors border rounded hover:bg-gray-100 shadow-sm"
+                        aria-label="Submissions: Download as CSV"
+                        href="{{path}}{% if '?' in path %}&{%else%}?{% endif %}export=true"
+                        role="button"
+                        data-tippy-content="Export as CSV"
+                    >
+
+                        {% heroicon_mini "arrow-down-tray" class="inline me-1" %}
+                        Export
+                    </a>
                 {% endif %}
             {% endwith %}
             {% if filter_classes != 'filters-open' %}
                 <button class="button js-toggle-filters">
-                    {% heroicon_mini "adjustments-horizontal" class="inline me-1 text-dark-blue align-text-bottom" aria_hidden=true %}
+                    {% heroicon_mini "adjustments-horizontal" class="inline align-text-bottom me-1 text-dark-blue" aria_hidden=true %}
                     {% trans "Filters" %}
                 </button>
             {% endif %}
 
             <button class="button button--filters js-toggle-filters" id="show-filters-button">
-                {% heroicon_mini "adjustments-horizontal" class="inline me-1 text-dark-blue align-text-bottom" aria_hidden=true %}
+                {% heroicon_mini "adjustments-horizontal" class="inline align-text-bottom me-1 text-dark-blue" aria_hidden=true %}
                 {% trans "Filters" %}
             </button>
             {% if use_search|default:False %}
-                <form action="{{ search_action }}" method="get" role="search" class="form form--search-desktop">
+                <form action="{{ search_action }}" method="get" role="search" class="relative form">
                     <button class="button button--search" type="submit">
                         <span class="sr-only">{% trans "Search" %}</span>
                         {% heroicon_mini "magnifying-glass" size=20 class="text-fg-muted" aria_hidden=true %}
@@ -92,7 +108,14 @@
                         <input type="hidden" value="{{ archived_param }}" name="archived">
                     {% endif %}
                     {% trans "submissions" as submissions %}
-                    <input class="input input--search input--secondary" type="text" placeholder="{% trans 'Search' %} {{ search_placeholder|default:submissions }}" name="query"{% if search_term %} value="{{ search_term }}"{% endif %} aria-label="{% trans 'Search input' %}">
+                    <input
+                        class="rounded shadow-sm input input--search input--secondary md:w-48"
+                        type="text"
+                        placeholder="{% trans 'Search' %} {{ search_placeholder|default:submissions }}"
+                        name="query"
+                        {% if search_term %}value="{{ search_term }}"{% endif %}
+                        aria-label="{% trans 'Search input' %}"
+                    >
                 </form>
             {% endif %}
         </div>

--- a/hypha/apply/funds/templates/submissions/all.html
+++ b/hypha/apply/funds/templates/submissions/all.html
@@ -121,6 +121,16 @@
                 </label>
             </span>
         {% endif %}
+        {% if can_export_submissions %}
+            <a
+                class="px-2 py-1.5 transition-colors border rounded hover:bg-gray-100 shadow-sm"
+                aria-label="Submissions: Download as CSV"
+                href="{% modify_query "page" format="csv" %}"
+                data-tippy-content="Export as CSV"
+            >
+                {% heroicon_mini "arrow-down-tray" %}
+            </a>
+        {% endif %}
     </form>
 
     {% if is_filtered %}

--- a/hypha/settings/base.py
+++ b/hypha/settings/base.py
@@ -129,7 +129,7 @@ SUBMISSIONS_DRAFT_ACCESS_STAFF_ADMIN = env.bool(
 )
 
 # Should staff be able to export submissions.
-SUBMISSIONS_EXPORT_ACCESS_STAFF = env.bool("SUBMISSIONS_EXPORT_ACCESS_STAFF", True)
+SUBMISSIONS_EXPORT_ACCESS_STAFF = env.bool("SUBMISSIONS_EXPORT_ACCESS_STAFF", False)
 
 # Should staff admins be able to export submissions.
 SUBMISSIONS_EXPORT_ACCESS_STAFF_ADMIN = env.bool(

--- a/hypha/static_src/sass/components/_form.scss
+++ b/hypha/static_src/sass/components/_form.scss
@@ -21,17 +21,6 @@
         }
     }
 
-    &--search-desktop {
-        position: relative;
-        max-width: 300px;
-        margin-block-start: $mobile-gutter;
-
-        @include media-query(lg) {
-            max-width: 280px;
-            margin: 0 0 0 30px;
-        }
-    }
-
     &--error-inline {
         // stylelint-disable-next-line selector-class-pattern
         .form__error-text {


### PR DESCRIPTION
Update the styling on the table view (de-emphasized, and used an icon)
On list view, added the icon for export with a tooltip and also added a separate export handler the old table view is depreciated now.

- Update default value of SUBMISSIONS_EXPORT_ACCESS_STAFF to False

---

![Screenshot 2024-07-05 at 8  38 52@2x](https://github.com/HyphaApp/hypha/assets/236356/71e5e422-ff1f-40f6-8afd-74bf19db4e88)

---

![Screenshot 2024-07-05 at 8  38 18@2x](https://github.com/HyphaApp/hypha/assets/236356/fc8e58a9-f58d-4040-bed8-46428c4d392b)


## Test Steps
<!-- 
If step does not require manual testing, skip/remove this section.

Give a brief overview of the steps required for a user/dev to test this contribution. Important things to include:
 - Required user roles for where necessary (ie. "As a Staff Admin...")
 - Clear & validatable expected results (ie. "Confirm the submit button is now not clickable")
 - Language that can be understood by non-technical testers if being tested by users
-->

 - [ ] to table and list view of submissions all, logged in as staff
 - [ ] you can see the add/update buttons