### PR TITLE
Small user menu improvements

### DIFF
--- a/hypha/templates/includes/user_menu.html
+++ b/hypha/templates/includes/user_menu.html
@@ -4,11 +4,11 @@
     <div x-data="{ show: false }" x-on:keydown.escape="show = false" class="relative flex">
         <button
             x-on:click="show = ! show"
-            class="font-bold flex items-center transition-all rounded-sm px-1.5 bg-gray-100"
+            class="font-bold flex items-center transition-all rounded-sm px-1.5 group"
             type="button"
-            :class="show ? 'bg-gray-900 text-white' : 'hover:bg-light-blue/30'"
+            :class="show ? 'bg-gray-900 text-white' : 'hover:bg-slate-200'"
         >
-            {% heroicon_micro "user-circle" class="inline align-text-bottom w-8 h-8 md:me-1" aria_hidden=true %}
+            {% heroicon_micro "user-circle" class="inline group-hover:scale-110 transition-transform align-text-bottom w-8 h-8 md:me-1" aria_hidden=true %}
             <span class="hidden md:inline-block truncate max-w-36">{{ request.user }}</span>
         </button>
 


### PR DESCRIPTION
<!--
Thanks for contributing to Hypha!

Please ensure your contributions pass all necessary linting/testing and that the appropriate documentation has been updated.
-->

<!--
Describe briefly what your pull request changes. If this is resolving an issue, please specify below via "Fixes #<Github Issue ID>"
-->
Fixes #4046. Changes the user menu button hover color to the same as the "My Tasks" bell, removes the grey background, and adds the same animation that the "My Tasks" bell has
