### PR TITLE
Add a reporting table for projects

### DIFF
--- a/hypha/apply/funds/templates/funds/includes/table_filter_and_search.html
+++ b/hypha/apply/funds/templates/funds/includes/table_filter_and_search.html
@@ -88,7 +88,7 @@
                     </a>
                 {% endif %}
             {% endwith %}
-            {% if filter_classes != 'filters-open' %}
+            {% if 'filters-open' not in filter_classes %}
                 <button class="button js-toggle-filters">
                     {% heroicon_mini "adjustments-horizontal" class="inline align-text-bottom me-1 text-dark-blue" aria_hidden=true %}
                     {% trans "Filters" %}

--- a/hypha/apply/projects/filters.py
+++ b/hypha/apply/projects/filters.py
@@ -101,6 +101,17 @@ class DateRangeInputWidget(filters.widgets.SuffixedMultiWidget):
         return [None, None]
 
 
+class ReportingFilter(filters.FilterSet):
+    current_report_status = Select2MultipleChoiceFilter(
+        label=_("Status"),
+        choices=[
+            ("Not started", "Not started"),
+            ("In progress", "In progress"),
+            ("Submitted", "Submitted"),
+        ],
+    )
+
+
 class ReportListFilter(filters.FilterSet):
     reporting_period = filters.DateFromToRangeFilter(
         label=_("Reporting Period"),

--- a/hypha/apply/projects/models/report.py
+++ b/hypha/apply/projects/models/report.py
@@ -360,6 +360,18 @@ class ReportConfig(models.Model):
         )
         return report
 
+    def current_report(self):
+        """This is different from current_due_report as it will return a completed report
+        if that one is the current one."""
+        today = timezone.now().date()
+
+        last_report = self.last_report()
+
+        if last_report and last_report.end_date >= today:
+            return last_report
+
+        return self.current_due_report()
+
     def next_date(self, last_date):
         delta_frequency = self.frequency + "s"
         delta = relativedelta(**{delta_frequency: self.occurrence})

--- a/hypha/apply/projects/tables.py
+++ b/hypha/apply/projects/tables.py
@@ -2,6 +2,7 @@ import json
 import textwrap
 
 import django_tables2 as tables
+from django.utils.html import format_html
 from django.utils.safestring import mark_safe
 from django.utils.text import slugify
 from django.utils.translation import gettext_lazy as _
@@ -293,6 +294,51 @@ class ProjectsListTable(BaseProjectsTable):
 
     def order_end_date(self, qs, desc):
         return qs.by_end_date(desc), True
+
+
+class ReportingTable(tables.Table):
+    pk = tables.Column(
+        verbose_name=_("Project #"),
+    )
+    submission_id = tables.Column(
+        verbose_name=_("Submission #"),
+    )
+    title = tables.LinkColumn("funds:projects:detail", args=[tables.utils.A("pk")])
+    organization_name = tables.Column(
+        accessor="submission__organization_name", verbose_name="Organization name"
+    )
+    current_report_status = tables.Column(
+        attrs={"td": {"class": "status"}}, verbose_name="Status"
+    )
+
+    def render_current_report_status(self, value):
+        return format_html("<span>{}</span>", value)
+
+    current_report_submitted_date = tables.Column(
+        verbose_name="Submitted date", accessor="current_report_submitted_date__date"
+    )
+    current_report_due_date = tables.Column(
+        verbose_name="Due Date", accessor="report_config__current_report__end_date"
+    )
+    current_report_last_notified_date = tables.Column(
+        verbose_name="Last Notified",
+        accessor="report_config__current_report__notified__date",
+    )
+
+    class Meta:
+        fields = [
+            "pk",
+            "title",
+            "submission_id",
+            "organization_name",
+            "current_report_due_date",
+            "current_report_status",
+            "current_report_submitted_date",
+            "current_report_last_notified_date",
+        ]
+        model = Project
+        orderable = True
+        attrs = {"class": "reporting-table"}
 
 
 class ReportListTable(tables.Table):

--- a/hypha/apply/projects/templates/application_projects/report_list.html
+++ b/hypha/apply/projects/templates/application_projects/report_list.html
@@ -14,7 +14,7 @@
 
     <div class="wrapper wrapper--large wrapper--inner-space-medium">
         {% if table %}
-            {% include "funds/includes/table_filter_and_search.html" with filter_form=filter_form use_search=False filter_action=filter_action filter_classes="filters--dates" %}
+            {% include "funds/includes/table_filter_and_search.html" with filter_form=filter_form filter_action=filter_action filter_classes="filters-open filters--dates" %}
             {% render_table table %}
         {% else %}
             <p>{% trans "No Reports Available." %}</p>

--- a/hypha/apply/projects/templates/application_projects/reporting.html
+++ b/hypha/apply/projects/templates/application_projects/reporting.html
@@ -14,7 +14,7 @@
 
     <div class="wrapper wrapper--large wrapper--inner-space-medium">
         {% if table %}
-            {% include "funds/includes/table_filter_and_search.html" with filter_form=filter_form filter_action=filter_action use_batch_actions=True filter_classes="filters-open" %}
+            {% include "funds/includes/table_filter_and_search.html" with filter_form=filter_form filter_action=filter_action filter_classes="filters-open" %}
             {% render_table table %}
         {% else %}
             <p>{% trans "No Projects Currently Reporting." %}</p>
@@ -24,11 +24,10 @@
 {% endblock content %}
 
 {% block extra_css %}
-    <link rel="stylesheet" href="{% static 'css/apply/fancybox.css' %}">
     {{ filter.form.media.css }}
 {% endblock %}
 
 {% block extra_js %}
     {{ filter.form.media.js }}
-    <script src="{% static 'js/apply/submission-filters.js' %}"></script>
+    <script src="{% static 'js/submission-filters.js' %}"></script>
 {% endblock %}

--- a/hypha/apply/projects/templates/application_projects/reporting.html
+++ b/hypha/apply/projects/templates/application_projects/reporting.html
@@ -1,0 +1,34 @@
+{% extends "base-apply.html" %}
+
+{% load render_table from django_tables2 %}
+{% load i18n static %}
+
+{% block title %}{% trans "Reporting" %}{% endblock %}
+
+{% block content %}
+
+    {% adminbar %}
+        {% slot header %}{% trans "Reporting" %} ({{ table.rows|length }}){% endslot %}
+        {% slot sub_heading %}{% trans "View, Search and filter reporting statuses" %}{% endslot %}
+    {% endadminbar %}
+
+    <div class="wrapper wrapper--large wrapper--inner-space-medium">
+        {% if table %}
+            {% include "funds/includes/table_filter_and_search.html" with filter_form=filter_form filter_action=filter_action use_batch_actions=True filter_classes="filters-open" %}
+            {% render_table table %}
+        {% else %}
+            <p>{% trans "No Projects Currently Reporting." %}</p>
+        {% endif %}
+    </div>
+
+{% endblock content %}
+
+{% block extra_css %}
+    <link rel="stylesheet" href="{% static 'css/apply/fancybox.css' %}">
+    {{ filter.form.media.css }}
+{% endblock %}
+
+{% block extra_js %}
+    {{ filter.form.media.js }}
+    <script src="{% static 'js/apply/submission-filters.js' %}"></script>
+{% endblock %}

--- a/hypha/apply/projects/urls.py
+++ b/hypha/apply/projects/urls.py
@@ -23,6 +23,7 @@ from .views import (
     ProjectSOWView,
     RemoveDocumentView,
     ReportDetailView,
+    ReportingView,
     ReportListView,
     ReportPrivateMedia,
     ReportSkipView,
@@ -48,6 +49,7 @@ urlpatterns = [
     path("all/", ProjectListView.as_view(), name="all"),
     path("statuses/", get_project_status_counts, name="projects_status_counts"),
     path("invoices/", InvoiceListView.as_view(), name="invoices"),
+    path("reporting/", ReportingView.as_view(), name="reporting"),
     path(
         "invoices/statuses/", get_invoices_status_counts, name="invoices_status_counts"
     ),

--- a/hypha/apply/projects/urls.py
+++ b/hypha/apply/projects/urls.py
@@ -49,7 +49,6 @@ urlpatterns = [
     path("all/", ProjectListView.as_view(), name="all"),
     path("statuses/", get_project_status_counts, name="projects_status_counts"),
     path("invoices/", InvoiceListView.as_view(), name="invoices"),
-    path("reporting/", ReportingView.as_view(), name="reporting"),
     path(
         "invoices/statuses/", get_invoices_status_counts, name="invoices_status_counts"
     ),
@@ -221,4 +220,5 @@ urlpatterns = [
             )
         ),
     ),
+    path("reporting/", ReportingView.as_view(), name="reporting"),
 ]

--- a/hypha/apply/projects/views/__init__.py
+++ b/hypha/apply/projects/views/__init__.py
@@ -46,6 +46,7 @@ from .project_partials import (
 from .report import (
     ReportDetailView,
     ReportFrequencyUpdate,
+    ReportingView,
     ReportListView,
     ReportPrivateMedia,
     ReportSkipView,
@@ -92,6 +93,7 @@ __all__ = [
     "ReportSkipView",
     "ReportFrequencyUpdate",
     "ReportListView",
+    "ReportingView",
     "CreateInvoiceView",
     "InvoiceListView",
     "InvoiceView",

--- a/hypha/apply/projects/views/report.py
+++ b/hypha/apply/projects/views/report.py
@@ -15,11 +15,11 @@ from hypha.apply.utils.storage import PrivateMediaView
 from hypha.apply.utils.views import DelegatedViewMixin
 
 from ...stream_forms.models import BaseStreamForm
-from ..filters import ReportListFilter
+from ..filters import ReportingFilter, ReportListFilter
 from ..forms import ReportEditForm, ReportFrequencyForm
-from ..models import Report, ReportConfig, ReportPrivateFiles
+from ..models import Project, Report, ReportConfig, ReportPrivateFiles
 from ..permissions import has_permission
-from ..tables import ReportListTable
+from ..tables import ReportingTable, ReportListTable
 from ..utils import get_placeholder_file
 
 
@@ -311,3 +311,11 @@ class ReportListView(SingleTableMixin, FilterView):
     filterset_class = ReportListFilter
     table_class = ReportListTable
     template_name = "application_projects/report_list.html"
+
+
+@method_decorator(staff_or_finance_required, name="dispatch")
+class ReportingView(SingleTableMixin, FilterView):
+    queryset = Project.objects.for_reporting_table()
+    filterset_class = ReportingFilter
+    table_class = ReportingTable
+    template_name = "application_projects/reporting.html"

--- a/hypha/core/navigation.py
+++ b/hypha/core/navigation.py
@@ -94,6 +94,11 @@ def get_primary_navigation_items(user):
                     "url": reverse_lazy("apply:projects:reports:all"),
                     "permission_method": "hypha.apply.users.decorators.is_apply_staff_or_finance",
                 },
+                {
+                    "title": _("Reporting"),
+                    "url": reverse_lazy("apply:projects:reporting"),
+                    "permission_method": "hypha.apply.users.decorators.is_apply_staff_or_finance",
+                },
             ],
         },
     ]

--- a/hypha/static_src/sass/components/_projects-table.scss
+++ b/hypha/static_src/sass/components/_projects-table.scss
@@ -87,7 +87,7 @@
 }
 
 .reporting-table {
-    @include table-ordering-styles;
+    @include mixins.table-ordering-styles;
 
     tbody {
         td {
@@ -96,10 +96,10 @@
                     display: inline-block;
                     padding: 5px;
                     font-size: 13px;
-                    font-weight: $weight--bold;
-                    color: $color--white;
+                    font-weight: variables.$weight--bold;
+                    color: variables.$color--white;
                     text-align: center;
-                    background-color: $color--dark-blue;
+                    background-color: variables.$color--dark-blue;
                 }
             }
         }

--- a/hypha/static_src/sass/components/_projects-table.scss
+++ b/hypha/static_src/sass/components/_projects-table.scss
@@ -85,3 +85,23 @@
         }
     }
 }
+
+.reporting-table {
+    @include table-ordering-styles;
+
+    tbody {
+        td {
+            &.status {
+                span {
+                    display: inline-block;
+                    padding: 5px;
+                    font-size: 13px;
+                    font-weight: $weight--bold;
+                    color: $color--white;
+                    text-align: center;
+                    background-color: $color--dark-blue;
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
Fixes #4050

What a small line for such a large set of changes.  Those supporting changes include:

* Creating a view for the new Reporting Table
* Creating a current_report() method in report_config that is slightly differnt than current_report_due (see inline doc)
* Adding a ProjectQuerySet method that does some intense subquerying to be able to express the current_report in sql so that the status can be filtered against


## Note from the cherry-picker/integrator

I see that the summary tables for reports was removed from `apply/projects` and that the current dropdown in the main navigation header points to `apply/project/reports`. This new table appears under `apply/project/reporting` and is linked to in the original fork in which this change occurred. As for integration here, the question is: do we want to replace the original table or augment off to the side somehow? Where should the link to this new table live?

## Test Steps

URL is `apply/projects/reporting`.

 - [ ] Get a project to the reporting phase, and it should show up in the table
 - [ ] Filter the table by not started and make sure it shows up
 - [ ] Set the project's report due to various kinds, and the report due date in table should change correspondingly
 - [ ] Save a report as a draft, which should move it to in progress on the table
 - [ ] Filter the table by in progress to make sure it shows up!
 - [ ] Complete the report, which should move it to submitted status on the table
 - [ ] Filter the table by submitted to make sure it shows up.