### PR TITLE
Sanitize user `full_name` without roadblocks

### DIFF
--- a/hypha/apply/users/forms.py
+++ b/hypha/apply/users/forms.py
@@ -1,5 +1,6 @@
 from re import match
 
+import nh3
 from django import forms
 from django.conf import settings
 from django.contrib.auth import get_user_model
@@ -159,7 +160,10 @@ class CustomUserCreationForm(CustomUserAdminFormBase, UserCreationForm):
 
 
 class ProfileForm(forms.ModelForm):
-    error_messages = {"invalid_full_name": _("Full Name is Invalid")}
+    error_messages = {
+        "invalid_full_name": _("Full name is invalid"),
+        "no_html": _("Full name may not contain HTML"),
+    }
 
     class Meta:
         model = User
@@ -204,6 +208,8 @@ class ProfileForm(forms.ModelForm):
 
     def clean_full_name(self):
         full_name = self.cleaned_data["full_name"]
+        if nh3.is_html(full_name):
+            raise forms.ValidationError(self.error_messages["no_html"])
         for regex in settings.INVALID_FULL_NAME_REGEXES:
             if match(regex, full_name):
                 raise forms.ValidationError(self.error_messages["invalid_full_name"])

--- a/hypha/apply/users/forms.py
+++ b/hypha/apply/users/forms.py
@@ -1,4 +1,3 @@
-import nh3
 from django import forms
 from django.conf import settings
 from django.contrib.auth import get_user_model
@@ -9,6 +8,7 @@ from django_select2.forms import Select2Widget
 from wagtail.users.forms import UserCreationForm, UserEditForm
 
 from .models import AuthSettings, GroupDesc
+from .utils import strip_html_and_nerf_urls
 
 User = get_user_model()
 
@@ -200,13 +200,7 @@ class ProfileForm(forms.ModelForm):
         return email
 
     def clean_full_name(self):
-        full_name = self.cleaned_data["full_name"]
-        # Remove all HTML tags. This prohibits HTML without creating hurdles.
-        cleaned_full_name = nh3.clean(full_name, tags=set())
-        # Remove all colons and slashes to nerf URLs regardless of HTML tags.
-        cleaned_full_name = cleaned_full_name.replace(":", "")
-        cleaned_full_name = cleaned_full_name.replace("/", "")
-        return cleaned_full_name
+        return strip_html_and_nerf_urls(self.cleaned_data["full_name"])
 
 
 class BecomeUserForm(forms.Form):

--- a/hypha/apply/users/forms.py
+++ b/hypha/apply/users/forms.py
@@ -1,3 +1,5 @@
+from re import match
+
 from django import forms
 from django.conf import settings
 from django.contrib.auth import get_user_model
@@ -157,6 +159,8 @@ class CustomUserCreationForm(CustomUserAdminFormBase, UserCreationForm):
 
 
 class ProfileForm(forms.ModelForm):
+    error_messages = {"invalid_full_name": _("Full Name is Invalid")}
+
     class Meta:
         model = User
         fields = ["full_name", "email", "slack"]
@@ -197,6 +201,13 @@ class ProfileForm(forms.ModelForm):
                 self.instance.email
             )  # updated email to avoid email existing message, fix information leak.
         return email
+
+    def clean_full_name(self):
+        full_name = self.cleaned_data["full_name"]
+        for regex in settings.INVALID_FULL_NAME_REGEXES:
+            if match(regex, full_name):
+                raise forms.ValidationError(self.error_messages["invalid_full_name"])
+        return full_name
 
 
 class BecomeUserForm(forms.Form):

--- a/hypha/apply/users/forms.py
+++ b/hypha/apply/users/forms.py
@@ -1,5 +1,3 @@
-from re import match
-
 import nh3
 from django import forms
 from django.conf import settings
@@ -160,11 +158,6 @@ class CustomUserCreationForm(CustomUserAdminFormBase, UserCreationForm):
 
 
 class ProfileForm(forms.ModelForm):
-    error_messages = {
-        "invalid_full_name": _("Full name is invalid"),
-        "no_html": _("Full name may not contain HTML"),
-    }
-
     class Meta:
         model = User
         fields = ["full_name", "email", "slack"]
@@ -208,12 +201,12 @@ class ProfileForm(forms.ModelForm):
 
     def clean_full_name(self):
         full_name = self.cleaned_data["full_name"]
-        if nh3.is_html(full_name):
-            raise forms.ValidationError(self.error_messages["no_html"])
-        for regex in settings.INVALID_FULL_NAME_REGEXES:
-            if match(regex, full_name):
-                raise forms.ValidationError(self.error_messages["invalid_full_name"])
-        return full_name
+        # Remove all HTML tags. This prohibits HTML without creating hurdles.
+        cleaned_full_name = nh3.clean(full_name, tags=set())
+        # Remove all colons and slashes to nerf URLs regardless of HTML tags.
+        cleaned_full_name = cleaned_full_name.replace(":", "")
+        cleaned_full_name = cleaned_full_name.replace("/", "")
+        return cleaned_full_name
 
 
 class BecomeUserForm(forms.Form):

--- a/hypha/apply/users/models.py
+++ b/hypha/apply/users/models.py
@@ -1,3 +1,5 @@
+from re import match
+
 from django.conf import settings
 from django.contrib.auth.hashers import make_password
 from django.contrib.auth.models import AbstractUser, BaseUserManager, Group
@@ -170,6 +172,10 @@ class UserManager(BaseUserManager.from_queryset(UserQuerySet)):
             elif not user.is_active:
                 raise IntegrityError("Found an inactive account")
         else:
+            for regex in settings.INVALID_FULL_NAME_REGEXES:
+                if "full_name" in kwargs and match(regex, kwargs["full_name"]):
+                    raise IntegrityError("Invalid Full name")
+
             if "password" in kwargs:
                 # Coming from registration without application
                 temp_pass = kwargs.pop("password")

--- a/hypha/apply/users/models.py
+++ b/hypha/apply/users/models.py
@@ -9,7 +9,6 @@ from django.urls import reverse
 from django.utils.crypto import get_random_string
 from django.utils.functional import cached_property
 from django.utils.translation import gettext_lazy as _
-from nh3 import nh3
 from wagtail.admin.panels import FieldPanel, MultiFieldPanel
 from wagtail.contrib.settings.models import BaseGenericSetting, register_setting
 from wagtail.fields import RichTextField
@@ -29,6 +28,7 @@ from .utils import (
     get_user_by_email,
     is_user_already_registered,
     send_activation_email,
+    strip_html_and_nerf_urls,
 )
 
 
@@ -172,12 +172,7 @@ class UserManager(BaseUserManager.from_queryset(UserQuerySet)):
                 raise IntegrityError("Found an inactive account")
         else:
             if kwargs.get("full_name", False):
-                # Remove all HTML tags. This prohibits HTML without creating hurdles.
-                cleaned_full_name = nh3.clean(kwargs["full_name"], tags=set())
-                # Remove all colons and slashes to nerf URLs regardless of HTML tags.
-                cleaned_full_name = cleaned_full_name.replace(":", "")
-                cleaned_full_name = cleaned_full_name.replace("/", "")
-                kwargs["full_name"] = cleaned_full_name
+                kwargs["full_name"] = strip_html_and_nerf_urls(kwargs["full_name"])
             if "password" in kwargs:
                 # Coming from registration without application
                 temp_pass = kwargs.pop("password")

--- a/hypha/apply/users/utils.py
+++ b/hypha/apply/users/utils.py
@@ -1,5 +1,6 @@
 import string
 
+import nh3
 from django.conf import settings
 from django.contrib.auth import get_user_model
 from django.contrib.auth.tokens import PasswordResetTokenGenerator
@@ -193,3 +194,12 @@ def update_is_staff(request, user):
     elif user.is_staff and not user.is_apply_staff_admin:
         user.is_staff = False
         user.save()
+
+
+def strip_html_and_nerf_urls(value: str):
+    # Remove all HTML tags. This prohibits HTML without creating hurdles.
+    cleaned_value = nh3.clean(value, tags=set())
+    # Remove all colons and slashes to nerf URLs regardless of HTML tags.
+    cleaned_value = cleaned_value.replace(":", "")
+    cleaned_value = cleaned_value.replace("/", "")
+    return cleaned_value

--- a/hypha/settings/base.py
+++ b/hypha/settings/base.py
@@ -158,7 +158,6 @@ REVIEW_VISIBILITY_DEFAULT = env.str("REVIEW_VISIBILITY_DEFAULT", "private")
 # Require an applicant to view their rendered application before submitting
 SUBMISSION_PREVIEW_REQUIRED = env.bool("SUBMISSION_PREVIEW_REQUIRED", True)
 
-
 # Project settings.
 
 # SECRET_KEY is required

--- a/hypha/settings/base.py
+++ b/hypha/settings/base.py
@@ -158,6 +158,9 @@ REVIEW_VISIBILITY_DEFAULT = env.str("REVIEW_VISIBILITY_DEFAULT", "private")
 # Require an applicant to view their rendered application before submitting
 SUBMISSION_PREVIEW_REQUIRED = env.bool("SUBMISSION_PREVIEW_REQUIRED", True)
 
+# Array of regexes that match to invalid full names (like ".*http://.*" to prevent attachs)
+INVALID_FULL_NAME_REGEXES = env.list("INVALID_FULL_NAME_REGEXES", [])
+
 # Project settings.
 
 # SECRET_KEY is required

--- a/hypha/settings/base.py
+++ b/hypha/settings/base.py
@@ -158,8 +158,6 @@ REVIEW_VISIBILITY_DEFAULT = env.str("REVIEW_VISIBILITY_DEFAULT", "private")
 # Require an applicant to view their rendered application before submitting
 SUBMISSION_PREVIEW_REQUIRED = env.bool("SUBMISSION_PREVIEW_REQUIRED", True)
 
-# Array of regexes that match to invalid full names (like ".*http://.*" to prevent attachs)
-INVALID_FULL_NAME_REGEXES = env.list("INVALID_FULL_NAME_REGEXES", [])
 
 # Project settings.
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -44,6 +44,7 @@ htmldocx==0.0.6
 lark==1.1.9
 mistune==3.0.2
 more-itertools==10.2.0
+nh3==0.2.18
 phonenumberslite==8.13.32
 Pillow==10.3.0
 psycopg[binary]==3.1.18


### PR DESCRIPTION
Rather than impeding the flow of users setting full name or requiring a new variable to be set by administrators, clean up users' given full names. This means removing all HTML tags and removing colons and slashes. It may be unfriendly to people such as "David-Wynn: Miller" but this is the cost of nerfing spam URLs in full names.

Issue #4060

## Test Steps

 - [ ] Create a user with the full name `<a href="https://myspam.com">Somebody: somewhere</a>`
 - [ ] The resulting user name should be `Somebody somewhere` (no HTML tags, no colons, no slashes).