### PR TITLE
Fix dependencies, freeze python-bidi to 0.4.2, v5 breaks installation

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -56,4 +56,5 @@ tomd==0.1.3
 wagtail==5.2.6
 whitenoise==6.6.0
 xhtml2pdf==0.2.15
+python-bidi==0.4.2
 xmltodict==0.13.0


### PR DESCRIPTION
Right now, the dependency installation is broken, the xhtml2pdf fails for
latest version python-bidi. 

https://stackoverflow.com/a/78776520
<!--
Thanks for contributing to Hypha!

Please ensure your contributions pass all necessary linting/testing and that the appropriate documentation has been updated.
-->

<!--
Describe briefly what your pull request changes. If this is resolving an issue, please specify below via "Fixes #<Github Issue ID>"
-->
Fixes #ISSUEID


## Test Steps
<!-- 
If step does not require manual testing, skip/remove this section.

Give a brief overview of the steps required for a user/dev to test this contribution. Important things to include:
 - Required user roles for where necessary (ie. "As a Staff Admin...")
 - Clear & validatable expected results (ie. "Confirm the submit button is now not clickable")
 - Language that can be understood by non-technical testers if being tested by users
-->

 - [ ] …