### PR TITLE
Check for `403_title` & `403_body` in SystemMessagesSettings migration

### DIFF
--- a/hypha/core/migrations/0004_move_system_settings_data.py
+++ b/hypha/core/migrations/0004_move_system_settings_data.py
@@ -11,6 +11,14 @@ def copy_public_system_messages_settings(apps, schema_editor):
     PublicSystemMessages = apps.get_model("utils", "SystemMessagesSettings")
 
     for old_settings in PublicSystemMessages.objects.all():
+        settings_kwargs = {}
+
+        if hasattr(old_settings, "title_403"):
+            settings_kwargs["title_403"] = old_settings.title_403
+
+        if hasattr(old_settings, "body_403"):
+            settings_kwargs["body_403"] = old_settings.body_403
+
         SystemSettings.objects.create(
             site_logo_default=old_settings.site_logo_default,
             site_logo_mobile=old_settings.site_logo_mobile,
@@ -19,8 +27,7 @@ def copy_public_system_messages_settings(apps, schema_editor):
             footer_content=old_settings.footer_content,
             title_404=old_settings.title_404,
             body_404=old_settings.body_404,
-            title_403=old_settings.title_403,
-            body_403=old_settings.body_403,
+            **settings_kwargs,
         )
 
 


### PR DESCRIPTION
<!--
Thanks for contributing to Hypha!

Please ensure your contributions pass all necessary linting/testing and that the appropriate documentation has been updated.
-->

<!--
Describe briefly what your pull request changes. If this is resolving an issue, please specify below via "Fixes #<Github Issue ID>"
-->
Small one - I have a few older databases I always revert to & migrations always fail at this step because they're missing `403_title` & `403_body` for some reason. I also saw this when migrating the sandbox database a few months back.
