### PR TITLE
Clean test files from disk after test are finished

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -19,6 +19,7 @@ help:
 	@echo "  make serve              run Django and docs preview server, also watch and compile frontend changes"
 	@echo "  make watch              watch js and css resources for development"
 	@echo "  make download-esm-modules  download esm modules from npm and copy to static_src"
+	@echo "  make clean-test-files  remove test files during test"
 
 .PHONY: serve
 serve:
@@ -73,8 +74,17 @@ py-test:
 serve-django:
 	python manage.py runserver 0.0.0.0:$(DJANGO_PORT) --settings=hypha.settings.dev
 
+.PHONY: clean-test-files
+clean-test-files:
+	@echo "Removing test files generated during test"
+	find media/ -iname 'test_*.pdf' -delete
+	find media/ -iname 'test_image*' -delete
+	find media/ -iname '*.dat' -delete
+	find media/ -type d -empty -delete
+	rm -rf media/temp_uploads/*
+
 .PHONY: test
-test: lint py-test cov-html
+test: lint py-test cov-html clean-test-files
 
 .PHONY: serve-docs
 serve-docs:

--- a/hypha/apply/funds/tests/test_models.py
+++ b/hypha/apply/funds/tests/test_models.py
@@ -437,7 +437,7 @@ class TestApplicationSubmission(TestCase):
         self.assertNotIn(str(value), submission.search_data)
 
     def test_file_gets_uploaded(self):
-        filename = "file_name.png"
+        filename = "test_image.png"
         submission = self.make_submission(form_data__image__filename=filename)
         path = os.path.join(settings.MEDIA_ROOT, "submission", str(submission.id))
 

--- a/hypha/apply/projects/tests/test_forms.py
+++ b/hypha/apply/projects/tests/test_forms.py
@@ -421,9 +421,11 @@ class TestCreateInvoiceForm(TestCase):
             "comment": "test comment",
         }
 
-        document = SimpleUploadedFile("invoice.pdf", BytesIO(b"somebinarydata").read())
+        document = SimpleUploadedFile(
+            "test_invoice.pdf", BytesIO(b"somebinarydata").read()
+        )
         supporting_documents = [
-            SimpleUploadedFile("invoice.pdf", BytesIO(b"somebinarydata").read())
+            SimpleUploadedFile("test_invoice.pdf", BytesIO(b"somebinarydata").read())
         ]
         files = {"document": document, "supporting_documents": supporting_documents}
 
@@ -446,7 +448,9 @@ class TestCreateInvoiceForm(TestCase):
             "comment": "test comment",
         }
 
-        document = SimpleUploadedFile("invoice.pdf", BytesIO(b"somebinarydata").read())
+        document = SimpleUploadedFile(
+            "test_invoice.pdf", BytesIO(b"somebinarydata").read()
+        )
         files = {
             "document": document,
         }
@@ -516,7 +520,7 @@ class TestEditInvoiceForm(TestCase):
         self.assertEqual(invoice.supporting_documents.count(), 0)
 
         supporting_document = [
-            SimpleUploadedFile("invoice.pdf", BytesIO(b"somebinarydata").read())
+            SimpleUploadedFile("test_invoice.pdf", BytesIO(b"somebinarydata").read())
         ]
         form = EditInvoiceForm(
             data={
@@ -564,7 +568,9 @@ class TestSelectDocumentForm(TestCase):
 
 
 class TestStaffContractUploadForm(TestCase):
-    mock_file = SimpleUploadedFile("contract.pdf", BytesIO(b"somebinarydata").read())
+    mock_file = SimpleUploadedFile(
+        "test_contract.pdf", BytesIO(b"somebinarydata").read()
+    )
 
     def test_staff_can_upload_unsigned(self):
         form = StaffUploadContractForm(data={}, files={"file": self.mock_file})
@@ -580,7 +586,9 @@ class TestStaffContractUploadForm(TestCase):
 
 
 class TestContractUploadForm(TestCase):
-    mock_file = SimpleUploadedFile("contract.pdf", BytesIO(b"somebinarydata").read())
+    mock_file = SimpleUploadedFile(
+        "test_contract.pdf", BytesIO(b"somebinarydata").read()
+    )
 
     def test_applicant_cant_upload_unsigned(self):
         form = UploadContractForm(data={}, files={"file": self.mock_file})

--- a/hypha/apply/projects/tests/test_views.py
+++ b/hypha/apply/projects/tests/test_views.py
@@ -441,7 +441,7 @@ class TestApplicantUploadContractView(BaseViewTestCase):
         contract_count = project.contracts.count()
 
         test_doc = BytesIO(b"somebinarydata")
-        test_doc.name = "contract.pdf"
+        test_doc.name = "test_contract.pdf"
 
         response = self.post_page(
             project,
@@ -527,7 +527,7 @@ class TestUploadDocumentView(BaseViewTestCase):
         project = ProjectFactory()
 
         test_doc = BytesIO(b"somebinarydata")
-        test_doc.name = "document.pdf"
+        test_doc.name = "test_document.pdf"
 
         response = self.post_page(
             project,
@@ -1015,7 +1015,7 @@ class TestStaffEditInvoiceView(BaseViewTestCase):
         supporting_document = SupportingDocumentFactory(invoice=invoice)
 
         document = BytesIO(b"somebinarydata")
-        document.name = "invoice.pdf"
+        document.name = "test_invoice.pdf"
 
         response = self.post_page(
             invoice,

--- a/hypha/apply/stream_forms/testing/factories.py
+++ b/hypha/apply/stream_forms/testing/factories.py
@@ -229,7 +229,7 @@ class UploadableMediaFactory(FormFieldBlockFactory):
         params = params or {}
         params.setdefault("data", b"this is some content")
         if params.get("filename") is None:
-            params["filename"] = "example.pdf"
+            params["filename"] = "test_example.pdf"
         file_name, file = cls.default_value._make_content(params)
         return SimpleUploadedFile(file_name, file.read())
 


### PR DESCRIPTION
There might be a better way to do in each of the test iteslf
but consider this a temporary fix, right now test generate a huge number
of files that are left as it is after the tests are finished.

This PR updates the test file names to be more consistent and then
deletes them based on generated file name pattern

<!--
Thanks for contributing to Hypha!

Please ensure your contributions pass all necessary linting/testing and that the appropriate documentation has been updated.
-->

<!--
Describe briefly what your pull request changes. If this is resolving an issue, please specify below via "Fixes #<Github Issue ID>"
-->


## Test Steps
<!-- 
If step does not require manual testing, skip/remove this section.

Give a brief overview of the steps required for a user/dev to test this contribution. Important things to include:
 - Required user roles for where necessary (ie. "As a Staff Admin...")
 - Clear & validatable expected results (ie. "Confirm the submit button is now not clickable")
 - Language that can be understood by non-technical testers if being tested by users
-->

 - [ ] deletes the generated file during testing locally