### PR TITLE
Fix submit contract document category permission with required remaining categories instead of remaining categories

### DIFF
--- a/hypha/apply/projects/templates/application_projects/includes/contracting_documents.html
+++ b/hypha/apply/projects/templates/application_projects/includes/contracting_documents.html
@@ -18,10 +18,11 @@
         </div>
         {% user_can_upload_contract object request.user as can_upload_contract %}
         {% user_can_submit_contract object user contract as can_submit_contract %}
+        {% required_remaining_contracting_doc_categories remaining_contract_document_categories as required_remaining_contract_document_categories %}
         {% if can_submit_contract %}
             <a data-fancybox
                data-src="#submit-contract-documents"
-               class="button button--project-action {% if remaining_contract_document_categories or not contract.signed_by_applicant %}is-disabled{% endif %}"
+               class="button button--project-action {% if required_remaining_contract_document_categories or not contract.signed_by_applicant %}is-disabled{% endif %}"
                href="#">
                 {% trans "Submit contract documents" %}
             </a>

--- a/hypha/apply/projects/templatetags/contract_tools.py
+++ b/hypha/apply/projects/templatetags/contract_tools.py
@@ -53,6 +53,11 @@ def user_can_submit_contract(project, user, contract):
 
 
 @register.simple_tag
+def required_remaining_contracting_doc_categories(remaining_categories):
+    return [category for category in remaining_categories if category.required]
+
+
+@register.simple_tag
 def user_can_upload_contract(project, user):
     can_upload, _ = has_permission(
         "contract_upload", user, object=project, raise_exception=False

--- a/hypha/apply/projects/views/project.py
+++ b/hypha/apply/projects/views/project.py
@@ -698,7 +698,7 @@ class SubmitContractDocumentsView(DelegatedViewMixin, UpdateView):
     def dispatch(self, request, *args, **kwargs):
         project = self.get_object()
         if ContractDocumentCategory.objects.filter(
-            ~Q(contract_packet_files__project=project)
+            ~Q(contract_packet_files__project=project) & Q(required=True)
         ).exists():
             raise PermissionDenied
         contract = project.contracts.order_by("-created_at").first()


### PR DESCRIPTION
<!--
Thanks for contributing to Hypha!

Please ensure your contributions pass all necessary linting/testing and that the appropriate documentation has been updated.
-->

<!--
Describe briefly what your pull request changes. If this is resolving an issue, please specify below via "Fixes #<Github Issue ID>"
-->
Fix bug for submit contract document by applicant.

Right now, there is an option in wagtail to set a contract document category optional/required but in Ui for applicants we are just checking for remaining contract document categories for submit contract document permissions while it should be checking for required only because others are optional.

## Test Steps
<!-- 
If step does not require manual testing, skip/remove this section.

Give a brief overview of the steps required for a user/dev to test this contribution. Important things to include:
 - Required user roles for where necessary (ie. "As a Staff Admin...")
 - Clear & validatable expected results (ie. "Confirm the submit button is now not clickable")
 - Language that can be understood by non-technical testers if being tested by users
-->

 - [ ] Look for the project in the contracting state where it is waiting for contract document submission from the applicant.
 - [ ] Look in wagtail Project>contract document categories and mark any of them optional.
 - [ ] Check if applicant can see the submit contract button even without uploading the optional document.