### PR TITLE
Fix primary nav background color on gray background

### DIFF
--- a/hypha/core/templates/core/navigation/primarynav-apply.html
+++ b/hypha/core/templates/core/navigation/primarynav-apply.html
@@ -9,7 +9,7 @@
     x-transition:leave="transition ease-in duration-150"
     x-transition:leave-start="transform opacity-100 translate-x-0"
     x-transition:leave-end="transform opacity-0 translate-x-full"
-    class="fixed md:static pt-10 md:pt-0 top-0 md:top-auto end-0 bottom-0 bg-white z-20 md:z-10 shadow-xl md:shadow-none overflow-y-auto md:overflow-clip"
+    class="fixed md:static pt-10 md:pt-0 top-0 md:top-auto end-0 bottom-0 bg-white md:bg-transparent z-20 md:z-10 shadow-xl md:shadow-none overflow-y-auto md:overflow-clip"
 >
     <!-- Mobile Menu Opener -->
     <button


### PR DESCRIPTION
On the desktop view, esp. for applicant the top nav shows a white background.

This fixes and applies the nav bg only when the mobile menu is active

## Before

![Screenshot 2024-08-08 at 7  15 15@2x](https://github.com/user-attachments/assets/b053bc51-4315-4889-9207-b62d9384ad2b)

## After
![Screenshot 2024-08-08 at 7  14 42@2x](https://github.com/user-attachments/assets/8588f032-8173-47ff-b9b7-cffb9a375305)

