### PR TITLE
Fixed consent prompt always popping up when `Ok` is the only option

### DIFF
--- a/hypha/cookieconsent/static/js/cookieconsent.js
+++ b/hypha/cookieconsent/static/js/cookieconsent.js
@@ -76,7 +76,7 @@
     // Open the prompt if consent value is undefined OR if analytics has been added since the user ack'd essential cookies
     if (
         getConsentValue() == undefined ||
-        (getConsentValue() === ACK && cookieButtons.length > 1)
+        (getConsentValue() === ACK && cookieButtons.length > 2)
     ) {
         openConsentPrompt();
     }


### PR DESCRIPTION
<!--
Thanks for contributing to Hypha!

Please ensure your contributions pass all necessary linting/testing and that the appropriate documentation has been updated.
-->

<!--
Describe briefly what your pull request changes. If this is resolving an issue, please specify below via "Fixes #<Github Issue ID>"
-->
Fixes #4088. The logic that will reprompt the user if the cookie option changes was getting tripped as it was only checking for 1 button rather than 2 that exist when ack'ing.


## Test Steps
<!-- 
If step does not require manual testing, skip/remove this section.

Give a brief overview of the steps required for a user/dev to test this contribution. Important things to include:
 - Required user roles for where necessary (ie. "As a Staff Admin...")
 - Clear & validatable expected results (ie. "Confirm the submit button is now not clickable")
 - Language that can be understood by non-technical testers if being tested by users
-->

 - [ ] With the analytics prompt disabled, ensure that the cookies acknowledgment is respected and doesn't prompt the user again