### PR TITLE
Order invoice table on project page by date, newest on top.

### DIFF
--- a/hypha/apply/projects/models/payment.py
+++ b/hypha/apply/projects/models/payment.py
@@ -119,10 +119,10 @@ class InvoiceQueryset(models.QuerySet):
         return []
 
     def rejected(self):
-        return self.filter(status=DECLINED)
+        return self.filter(status=DECLINED).order_by("-requested_at")
 
     def not_rejected(self):
-        return self.exclude(status=DECLINED)
+        return self.exclude(status=DECLINED).order_by("-requested_at")
 
     def total_value(self, field):
         return self.aggregate(


### PR DESCRIPTION
Does it make sense to put newest invoices on top on the project detail page?

New ordering put new invoices on top:

<img width="797" alt="Skärmavbild 2024-08-15 kl  10 23 55" src="https://github.com/user-attachments/assets/93113353-74e3-43b1-8baa-ad6a2c15a78e">

Old ordering put oldest on top.

<img width="799" alt="Skärmavbild 2024-08-15 kl  10 24 12" src="https://github.com/user-attachments/assets/8209caee-5618-4378-a996-cc2c216dae8b">
