### PR TITLE
Improve cloned forms naming

### DIFF
--- a/hypha/apply/funds/admin_views.py
+++ b/hypha/apply/funds/admin_views.py
@@ -9,6 +9,7 @@ from wagtail.admin.views.pages.utils import get_valid_next_url_from_request
 from wagtail.contrib.modeladmin.views import CreateView, EditView
 from wagtail.models import Page
 
+from hypha.apply.funds.utils import get_copied_form_name
 from hypha.apply.utils.blocks import show_admin_form_error_messages
 
 
@@ -110,7 +111,7 @@ class CopyApplicationFormViewClass(CreateView):
 
     def get_initial(self):
         return {
-            "name": f"[CHANGE] Copy of {self.form_instance.name}",
+            "name": get_copied_form_name(self.form_instance.name),
             "form_fields": self.form_instance.form_fields,
         }
 

--- a/hypha/apply/funds/models/applications.py
+++ b/hypha/apply/funds/models/applications.py
@@ -42,6 +42,7 @@ from wagtail.fields import RichTextField
 from wagtail.models import Page, PageManager
 from wagtail.query import PageQuerySet
 
+from hypha.apply.funds.utils import get_copied_form_name
 from hypha.core.wagtail.admin.panels import ReadOnlyInlinePanel
 
 from ..admin_forms import RoundBasePageAdminForm, WorkflowFormAdminForm
@@ -367,9 +368,8 @@ class RoundBase(WorkflowStreamForm, SubmittableStreamForm):  # type: ignore
         # Create a copy of the existing form object
         new_form = form.form
         new_form.id = None
-        new_form.name = "{} for {} ({})".format(
-            new_form.name, self.title, self.get_parent().title
-        )
+        new_form.name = get_copied_form_name(new_form.name)
+
         new_form.save()
         if hasattr(form, "stage"):
             new_class.objects.create(round=self, form=new_form, stage=form.stage)

--- a/hypha/apply/funds/tests/test_utils.py
+++ b/hypha/apply/funds/tests/test_utils.py
@@ -1,0 +1,24 @@
+import pytest
+from freezegun import freeze_time
+
+from hypha.apply.funds.utils import get_copied_form_name
+
+date = "2024-10-16 15:05:13.721861"
+
+form_name_dataset = [
+    ("Test Form", "Test Form (Copied on 2024-10-16 15:05:13.72)"),
+    (
+        "A Copied Form! (Copied on 2022-09-25 16:30:26.04)",
+        "A Copied Form! (Copied on 2024-10-16 15:05:13.72)",
+    ),
+    (
+        "(Copied on 2020-10-30 18:13:26.04) Out of place timestamp",
+        "(Copied on 2020-10-30 18:13:26.04) Out of place timestamp (Copied on 2024-10-16 15:05:13.72)",
+    ),
+]
+
+
+@freeze_time(date)
+@pytest.mark.parametrize("original_name,expected", form_name_dataset)
+def test_get_copied_form_name(original_name, expected):
+    assert get_copied_form_name(original_name) == expected

--- a/hypha/apply/funds/utils.py
+++ b/hypha/apply/funds/utils.py
@@ -164,7 +164,7 @@ def is_filter_empty(filter: filters.FilterSet) -> bool:
     return any(reduce(iconcat, [param[1] for param in query.lists()], []))
 
 
-def get_copied_form_name(orignal_form_name: str) -> str:
+def get_copied_form_name(original_form_name: str) -> str:
     """Create the name of the form to be copied
 
     By default, takes the orginal forms name and adds `(Copied on %Y-%m-%d %H:%M:%S.%f)`
@@ -181,10 +181,13 @@ def get_copied_form_name(orignal_form_name: str) -> str:
     copy_str = _("Copied on {copy_time}")
     copy_time = datetime.now().strftime("%Y-%m-%d %H:%M:%S.%f")[:-4]
     date_reg = r"(\d{2,4}-?){3} (\d{2}(:|.)?){4}"  # match the strftime pattern of %Y-%m-%d %H:%M:%S.%f
+
+    # Escape the `copy_str` to allow for translations to be matched & replace the
+    # `{copy_time}` var with the `date_reg` regex
     name_reg = r" \({}\)$".format(
         re.escape(copy_str).replace(r"\{copy_time\}", date_reg)
     )
 
     # If a copied timestamp already exists, remove it
-    new_name = re.sub(name_reg, "", orignal_form_name)
+    new_name = re.sub(name_reg, "", original_form_name)
     return f"{new_name} ({copy_str.format(copy_time=copy_time)})"

--- a/hypha/apply/funds/utils.py
+++ b/hypha/apply/funds/utils.py
@@ -1,4 +1,6 @@
 import csv
+import re
+from datetime import datetime
 from functools import reduce
 from io import StringIO
 from itertools import chain
@@ -6,6 +8,7 @@ from operator import iconcat
 
 import django_filters as filters
 from django.utils.html import strip_tags
+from django.utils.translation import gettext as _
 
 from hypha.apply.utils.image import generate_image_tag
 
@@ -159,3 +162,29 @@ def is_filter_empty(filter: filters.FilterSet) -> bool:
 
     # Flatten the QueryDict values in filter.data to a single list, check for validity with any()
     return any(reduce(iconcat, [param[1] for param in query.lists()], []))
+
+
+def get_copied_form_name(orignal_form_name: str) -> str:
+    """Create the name of the form to be copied
+
+    By default, takes the orginal forms name and adds `(Copied on %Y-%m-%d %H:%M:%S.%f)`
+
+    If a timestamp exists on the original_form_name, it will be replaced.
+    This works even if the `Copied on` string is translated.
+
+    Args:
+        original_form_name: the name of the form being duplicated
+
+    Returns:
+        str: name of the copied form
+    """
+    copy_str = _("Copied on {copy_time}")
+    copy_time = datetime.now().strftime("%Y-%m-%d %H:%M:%S.%f")[:-4]
+    date_reg = r"(\d{2,4}-?){3} (\d{2}(:|.)?){4}"  # match the strftime pattern of %Y-%m-%d %H:%M:%S.%f
+    name_reg = r" \({}\)$".format(
+        re.escape(copy_str).replace(r"\{copy_time\}", date_reg)
+    )
+
+    # If a copied timestamp already exists, remove it
+    new_name = re.sub(name_reg, "", orignal_form_name)
+    return f"{new_name} ({copy_str.format(copy_time=copy_time)})"

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -9,6 +9,7 @@ djhtml==3.0.6
 dslr==0.4.0
 factory_boy==3.2.1
 Faker==19.13.0
+freezegun==1.5.1
 model-bakery==1.17.0
 pre-commit==3.6.2
 pytest-cov==4.1.0


### PR DESCRIPTION
<!--
Thanks for contributing to Hypha!

Please ensure your contributions pass all necessary linting/testing and that the appropriate documentation has been updated.
-->

<!--
Describe briefly what your pull request changes. If this is resolving an issue, please specify below via "Fixes #<Github Issue ID>"
-->
Fixes #3546. Improves the naming of cloned forms by changing the format to `<original form name> (Copied on <%Y-%m-%d %H:%M:%S.%f>)`, ie. cloning `Test Form` would result in a duplicated form with the name `Test Form (Copied on 2024-08-27 17:34:32.004)`. If a form name with a timestamp already exists on a form it will be subbed via RegEx matching.


## Test Steps
<!-- 
If step does not require manual testing, skip/remove this section.

Give a brief overview of the steps required for a user/dev to test this contribution. Important things to include:
 - Required user roles for where necessary (ie. "As a Staff Admin...")
 - Clear & validatable expected results (ie. "Confirm the submit button is now not clickable")
 - Language that can be understood by non-technical testers if being tested by users
-->

 - [ ] Ensure when cloning a form (either manually or via the creation of a new round) that the form's name gets `(Copied on <%Y-%m-%d %H:%M:%S.%f>)` appended to it
 - [ ] Ensure if a timestamp string already exists on a cloned form, it is replaced with an updated timestamp