### PR TITLE
Fix 'Reminder Created' duplicate message, restrict duplicate toast messages

### DIFF
--- a/hypha/apply/funds/views.py
+++ b/hypha/apply/funds/views.py
@@ -1105,9 +1105,7 @@ class ReminderCreateView(View):
             return HttpResponse(
                 status=204,
                 headers={
-                    "HX-Trigger": json.dumps(
-                        {"remindersUpdated": None, "showMessage": _("Reminder created")}
-                    ),
+                    "HX-Trigger": json.dumps({"remindersUpdated": None}),
                 },
             )
         return render(

--- a/hypha/apply/funds/views.py
+++ b/hypha/apply/funds/views.py
@@ -1106,7 +1106,7 @@ class ReminderCreateView(View):
                 status=204,
                 headers={
                     "HX-Trigger": json.dumps(
-                        {"remindersUpdated": None, "showMessage": "Reminder created."}
+                        {"remindersUpdated": None, "showMessage": _("Reminder created")}
                     ),
                 },
             )

--- a/hypha/templates/includes/_toast-placeholder.html
+++ b/hypha/templates/includes/_toast-placeholder.html
@@ -16,31 +16,8 @@ How this works:
             visible: [],
             id: 0,
             timeouts: {}, // Object to keep track of timeouts
-            pendingMessages: new Map(), // To store toasts text temporarily
 
             add(toast) {
-                const existingToast = this.pendingMessages.get(toast.text);
-                if (existingToast) {
-                    // If the toast already exists and is of type 'success', use that instead
-                    if (existingToast.type === 'success') {
-                        toast = existingToast;
-                    }
-                    this.pendingMessages.delete(toast.text);
-                } else {
-                    // If it's a new toast, store it temporarily
-                    this.pendingMessages.set(toast.text, toast);
-                    // Set a timeout to add the toast if no duplicate arrives
-                    setTimeout(() => {
-                        if (this.pendingMessages.has(toast.text)) {
-                            this.addToast(this.pendingMessages.get(toast.text));
-                            this.pendingMessages.delete(toast.text);
-                        }
-                    }, 50);
-                    return;
-                }
-                this.addToast(toast);
-            },
-            addToast(toast) {
                 toast.id = Date.now().toString() + this.id++;
                 this.toasts.push(toast);
                 this.fire(toast.id);

--- a/hypha/templates/includes/_toast-placeholder.html
+++ b/hypha/templates/includes/_toast-placeholder.html
@@ -16,7 +16,31 @@ How this works:
             visible: [],
             id: 0,
             timeouts: {}, // Object to keep track of timeouts
+            pendingMessages: new Map(), // To store toasts text temporarily
+
             add(toast) {
+                const existingToast = this.pendingMessages.get(toast.text);
+                if (existingToast) {
+                    // If the toast already exists and is of type 'success', use that instead
+                    if (existingToast.type === 'success') {
+                        toast = existingToast;
+                    }
+                    this.pendingMessages.delete(toast.text);
+                } else {
+                    // If it's a new toast, store it temporarily
+                    this.pendingMessages.set(toast.text, toast);
+                    // Set a timeout to add the toast if no duplicate arrives
+                    setTimeout(() => {
+                        if (this.pendingMessages.has(toast.text)) {
+                            this.addToast(this.pendingMessages.get(toast.text));
+                            this.pendingMessages.delete(toast.text);
+                        }
+                    }, 50);
+                    return;
+                }
+                this.addToast(toast);
+            },
+            addToast(toast) {
                 toast.id = Date.now().toString() + this.id++;
                 this.toasts.push(toast);
                 this.fire(toast.id);


### PR DESCRIPTION
<!--
Thanks for contributing to Hypha!

Please ensure your contributions pass all necessary linting/testing and that the appropriate documentation has been updated.
-->

<!--
Describe briefly what your pull request changes. If this is resolving an issue, please specify below via "Fixes #<Github Issue ID>"
-->
Fixes #4082 


## Test Steps
<!-- 
If step does not require manual testing, skip/remove this section.

Give a brief overview of the steps required for a user/dev to test this contribution. Important things to include:
 - Required user roles for where necessary (ie. "As a Staff Admin...")
 - Clear & validatable expected results (ie. "Confirm the submit button is now not clickable")
 - Language that can be understood by non-technical testers if being tested by users
-->

 - [ ] Create a reminder and check there should be one Reminder Created toast with info icon only.
