### PR TITLE
Remove 'drf-yasg' swagger docs viewer

### DIFF
--- a/hypha/apply/api/urls.py
+++ b/hypha/apply/api/urls.py
@@ -1,7 +1,4 @@
 from django.urls import include, path
-from drf_yasg import openapi
-from drf_yasg.views import get_schema_view
-from rest_framework import permissions
 
 from .v1 import urls as v1_urls
 
@@ -11,22 +8,6 @@ schema_url_patterns_v1 = [
     path("api/v1/", include(v1_urls)),
 ]
 
-schema_view_v1 = get_schema_view(
-    openapi.Info(
-        title="Hypha API",
-        default_version="v1",
-        description="Hypha APIs specification",
-    ),
-    public=False,
-    patterns=schema_url_patterns_v1,
-    permission_classes=(permissions.AllowAny,),
-)
-
 urlpatterns = [
     path("v1/", include(v1_urls)),
-    path(
-        "v1/doc/",
-        schema_view_v1.with_ui("swagger", cache_timeout=0),
-        name="schema-swagger-ui",
-    ),
 ]

--- a/hypha/settings/django.py
+++ b/hypha/settings/django.py
@@ -66,7 +66,6 @@ INSTALLED_APPS = [
     "django_otp.plugins.otp_totp",
     "django_otp.plugins.otp_static",
     "two_factor",
-    "drf_yasg",
     "rest_framework",
     "rest_framework_api_key",
     "django_file_form",

--- a/requirements.txt
+++ b/requirements.txt
@@ -35,7 +35,6 @@ django==4.2.16
 djangorestframework-api-key==3.0.0
 djangorestframework==3.15.2
 drf-nested-routers==0.93.5
-drf-yasg==1.21.7
 environs==11.0.0
 gunicorn==22.0.0
 heroicons==2.6.0


### PR DESCRIPTION
Since the APIs are all depreciated, and APIs are not used by anyone,
this PR starts the depreciation phase and tries to remove the dead load.
