### PR TITLE
Add "templates_custom" folder to tailwind search path

### DIFF
--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -2,6 +2,7 @@
 module.exports = {
     content: [
         "./hypha/templates/**/*.html",
+        "./hypha/templates_custom/**/*.html",
         "./hypha/**/templates/**/*.html",
         "./hypha/**/*.{py,js}",
     ],


### PR DESCRIPTION
Right now, the custom templates put in the recommended "template_custom" doesn't checked by tailwindcss. So, the custom templates are not styled by tailwindcss.


