### PR TITLE
Replace doc_title filter with existing title_text_display property

### DIFF
--- a/hypha/apply/funds/templates/funds/applicationsubmission_admin_detail.html
+++ b/hypha/apply/funds/templates/funds/applicationsubmission_admin_detail.html
@@ -98,7 +98,6 @@
     <script src="{% static 'js/jquery.fancybox.min.js' %}"></script>
     <script src="{% static 'js/fancybox-global.js' %}"></script>
     <script src="{% static 'js/behaviours/collapse.js' %}"></script>
-    <script src="{% static 'js/toggle-related.js' %}"></script>
     {% if request.user|can_translate_submission %}
         <script src="{% static 'js/translate-application.js' %}"></script>
     {% endif %}

--- a/hypha/apply/funds/templates/funds/applicationsubmission_detail.html
+++ b/hypha/apply/funds/templates/funds/applicationsubmission_detail.html
@@ -2,7 +2,7 @@
 {% load i18n static workflow_tags wagtailcore_tags statusbar_tags archive_tags submission_tags translate_tags %}
 {% load heroicons %}
 
-{% block title %}{{ object|doc_title }}{% endblock %}
+{% block title %}{{ object.title_text_display }}{% endblock %}
 {% block body_class %}{% endblock %}
 
 {% block content %}

--- a/hypha/apply/funds/templatetags/submission_tags.py
+++ b/hypha/apply/funds/templatetags/submission_tags.py
@@ -32,12 +32,6 @@ def submission_links(value):
     return mark_safe(value)
 
 
-@register.filter
-def doc_title(submission) -> str:
-    id = submission.public_id if submission.public_id else object.id
-    return f"#{id}: { submission.title }"
-
-
 @register.simple_tag
 def user_can_delete_submission(submission, user):
     permission, _ = has_permission(

--- a/hypha/apply/funds/views_partials.py
+++ b/hypha/apply/funds/views_partials.py
@@ -27,7 +27,6 @@ from hypha.apply.funds.models.screening import ScreeningStatus
 from hypha.apply.funds.permissions import has_permission
 from hypha.apply.funds.reviewers.services import get_all_reviewers
 from hypha.apply.funds.services import annotate_review_recommendation_and_count
-from hypha.apply.funds.templatetags.submission_tags import doc_title
 from hypha.apply.review.options import REVIEWER
 from hypha.apply.translate.utils import get_lang_name, get_translation_params
 from hypha.apply.users.groups import REVIEWER_GROUP_NAME
@@ -591,7 +590,7 @@ def partial_translate_answers(request: HttpRequest, pk: int) -> HttpResponse:
             {
                 "translatedSubmission": {
                     "appTitle": title,
-                    "docTitle": doc_title(submission),
+                    "docTitle": submission.title_text_display,
                 }
             }
         )


### PR DESCRIPTION
The doc title filter had a small bug and we already have the title_text_display property that make use of the `SUBMISSION_TITLE_TEXT_TEMPLATE`.