### PR TITLE
Make the application view more printer friendly

### DIFF
--- a/hypha/apply/funds/templates/funds/applicationsubmission_detail.html
+++ b/hypha/apply/funds/templates/funds/applicationsubmission_detail.html
@@ -123,7 +123,7 @@
                                     {% display_submission_author True %}
                                 </strong>
                             </span>
-                            <div class="flex gap-4 justify-end flex-1 items-center">
+                            <div class="flex gap-4 justify-end flex-1 items-center no-print">
                                 {% can "delete_submission" object as can_delete_submission %}
                                 {% if can_delete_submission %}
                                     <a

--- a/hypha/static_src/sass/print.scss
+++ b/hypha/static_src/sass/print.scss
@@ -96,6 +96,9 @@ footer,
 .tabs__container,
 .js-actions-toggle,
 .js-actions-sidebar,
+.cookieconsent,
+.djhj,
+.no-print,
 .section--share {
     display: none !important;
 }

--- a/hypha/templates/base-apply.html
+++ b/hypha/templates/base-apply.html
@@ -20,7 +20,7 @@
             {% endif %}
         {% endblock %}
 
-        <div class="flex gap-2">
+        <div class="flex gap-2 no-print">
             {% if request.user.is_authenticated and request.user.is_apply_staff %}
                 {% include "includes/menu-notifications.html" %}
             {% endif %}


### PR DESCRIPTION
<!--
Thanks for contributing to Hypha!

Please ensure your contributions pass all necessary linting/testing and that the appropriate documentation has been updated.
-->

<!--
Describe briefly what your pull request changes. If this is resolving an issue, please specify below via "Fixes #<Github Issue ID>"
-->
Fixes #4228. Makes hypha more printer friendly by not printing user menus, the cookie consent prompt, or the hijack prompt.


## Test Steps
<!-- 
If step does not require manual testing, skip/remove this section.

Give a brief overview of the steps required for a user/dev to test this contribution. Important things to include:
 - Required user roles for where necessary (ie. "As a Staff Admin...")
 - Clear & validatable expected results (ie. "Confirm the submit button is now not clickable")
 - Language that can be understood by non-technical testers if being tested by users
-->

 - [ ] Attempt to print an application that is two pages or longer
 - [ ] Confirm the application has all essential information and is not obstructed (ie. by the cookie consent prompt)