### PR TITLE
Combine the reports/reporting nav items

### DIFF
--- a/hypha/apply/projects/templates/application_projects/report_list.html
+++ b/hypha/apply/projects/templates/application_projects/report_list.html
@@ -9,7 +9,10 @@
 
     {% adminbar %}
         {% slot header %}{% trans "Submitted Reports" %} ({{ table.rows|length }}){% endslot %}
-        {% slot sub_heading %}{% trans "View and filter all Submitted Reports" %}{% endslot %}
+        {% slot sub_heading %}
+            {% trans "View and filter all Submitted Reports" %} •
+            <a href="{% url 'apply:projects:reports:all' %}" class="text-blue-300 hover:underline">View all reports</a>
+        {% endslot %}
     {% endadminbar %}
 
     <div class="wrapper wrapper--large wrapper--inner-space-medium">

--- a/hypha/apply/projects/templates/application_projects/reporting.html
+++ b/hypha/apply/projects/templates/application_projects/reporting.html
@@ -9,7 +9,10 @@
 
     {% adminbar %}
         {% slot header %}{% trans "Reporting" %} ({{ table.rows|length }}){% endslot %}
-        {% slot sub_heading %}{% trans "View, Search and filter reporting statuses" %}{% endslot %}
+        {% slot sub_heading %}
+            {% trans "View, Search and filter reporting statuses" %} •
+            <a href="{% url 'apply:projects:reports:submitted' %}" class="text-blue-300 hover:underline">View submitted reports</a>
+        {% endslot %}
     {% endadminbar %}
 
     <div class="wrapper wrapper--large wrapper--inner-space-medium">

--- a/hypha/apply/projects/urls.py
+++ b/hypha/apply/projects/urls.py
@@ -235,7 +235,8 @@ urlpatterns = [
         include(
             (
                 [
-                    path("", ReportListView.as_view(), name="all"),
+                    path("", ReportListView.as_view(), name="submitted"),
+                    path("all/", ReportingView.as_view(), name="all"),
                     path(
                         "<int:pk>/",
                         include(
@@ -256,5 +257,4 @@ urlpatterns = [
             )
         ),
     ),
-    path("reporting/", ReportingView.as_view(), name="reporting"),
 ]

--- a/hypha/core/navigation.py
+++ b/hypha/core/navigation.py
@@ -91,12 +91,7 @@ def get_primary_navigation_items(user):
                 },
                 {
                     "title": _("Reports"),
-                    "url": reverse_lazy("apply:projects:reports:all"),
-                    "permission_method": "hypha.apply.users.decorators.is_apply_staff_or_finance",
-                },
-                {
-                    "title": _("Reporting"),
-                    "url": reverse_lazy("apply:projects:reporting"),
+                    "url": reverse_lazy("apply:projects:reports:submitted"),
                     "permission_method": "hypha.apply.users.decorators.is_apply_staff_or_finance",
                 },
             ],


### PR DESCRIPTION
<!--
Thanks for contributing to Hypha!

Please ensure your contributions pass all necessary linting/testing and that the appropriate documentation has been updated.
-->

<!--
Describe briefly what your pull request changes. If this is resolving an issue, please specify below via "Fixes #<Github Issue ID>"
-->
Building off of the conversation had in #4051, this adds the navigation to the reporting table to be under the submitted reports view rather than being in the main nav bar

This makes things a little simpler and explicit for the user but I think this is a temp fix, with #4239 being a permanent solution 


## Test Steps
<!-- 
If step does not require manual testing, skip/remove this section.

Give a brief overview of the steps required for a user/dev to test this contribution. Important things to include:
 - Required user roles for where necessary (ie. "As a Staff Admin...")
 - Clear & validatable expected results (ie. "Confirm the submit button is now not clickable")
 - Language that can be understood by non-technical testers if being tested by users
-->

 - [ ] Ensure the reporting table is accessible via `Reports` in the nav menu -> `View all reports` in the heading