### PR TITLE
Removing break word style in data tables styles

### DIFF
--- a/hypha/static_src/sass/components/_data-block.scss
+++ b/hypha/static_src/sass/components/_data-block.scss
@@ -124,10 +124,6 @@
             &:hover {
                 box-shadow: none;
             }
-
-            td {
-                word-break: break-word;
-            }
         }
     }
 


### PR DESCRIPTION
Fixes #4246
