### PR TITLE
Set dir auto via js on all p tags in applications.

### DIFF
--- a/hypha/static_src/javascript/submission-text-cleanup.js
+++ b/hypha/static_src/javascript/submission-text-cleanup.js
@@ -2,16 +2,20 @@
     // Select all rich text answers.
     const richtextanswers = document.querySelector(".rich-text--answers");
 
-    // Remove p tags with only whitespace inside.
+    // Select all rich text answers paragraphes.
     const richtextanswers_paras = richtextanswers.querySelectorAll("p");
     richtextanswers_paras.forEach(function (para) {
+        // Remove p tags with only whitespace inside.
         if (para.textContent.trim() === "") {
             para.remove();
         }
+        // Set dir="auto" so browsers sets the correct directionality (ltr/rtl).
+        para.setAttribute('dir', 'auto');
     });
 
-    // Wrap all tables in a div so overflow auto works.
+    // Select all rich text answers tables.
     const richtextanswers_tables = richtextanswers.querySelectorAll("table");
+    // Wrap all tables in a div so overflow auto works.
     richtextanswers_tables.forEach(function (table) {
         const table_wrapper = document.createElement("div");
         table_wrapper.classList.add("rich-text__table");


### PR DESCRIPTION
Fixes #4265

With dir auto:

<img width="804" alt="Skärmavbild 2024-12-09 kl  08 31 35" src="https://github.com/user-attachments/assets/ab9e5b15-01e2-4978-aab0-c3bd1e192a89">

Without dir auto:

<img width="806" alt="Skärmavbild 2024-12-09 kl  08 31 53" src="https://github.com/user-attachments/assets/d3870f68-a6b0-462e-ba84-1dc631dd6cdf">



## Test Steps

 - [ ] Submit an application with some answers in ltr langiage and some in rtl languages (e.g. Arabic). The paragraphs with rtl languages should show up as rtl automatically.