### PR TITLE
Allow org_faculty to view Project Document Categories.

### DIFF
--- a/hypha/apply/projects/views/project.py
+++ b/hypha/apply/projects/views/project.py
@@ -1741,15 +1741,10 @@ class ProjectPrivateMediaView(UserPassesTestMixin, PrivateMediaView):
             return self.storage.open(path_to_file)
 
     def test_func(self):
-        if self.request.user.is_apply_staff:
+        if self.request.user.is_org_faculty:
             return True
 
         if self.request.user == self.project.user:
-            return True
-
-        if self.request.user.id in self.project.paf_approvals.filter(
-            approved=False
-        ).values_list("user__id", flat=True):
             return True
 
         return False


### PR DESCRIPTION
Fixes #4274


## Test Steps

 - [ ] Confirm that staff, finance and contracting roles can view Project Document Categories.