### PR TITLE
Make lead update modals UI same for both projects and applications

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -51,6 +51,7 @@ npm-debug.log
 
 # IntelliJ
 out/
+.idea/*
 
 # JIRA plugin
 atlassian-ide-plugin.xml

--- a/hypha/apply/funds/forms.py
+++ b/hypha/apply/funds/forms.py
@@ -83,7 +83,9 @@ class UpdateSubmissionLeadForm(ApplicationSubmissionModelForm):
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
         lead_field = self.fields["lead"]
-        lead_field.label = _("New lead")
+        lead_field.label = _("Update lead from {lead} to").format(
+            lead=self.instance.lead
+        )
         lead_field.queryset = lead_field.queryset.exclude(id=self.instance.lead.id)
 
 

--- a/hypha/apply/funds/templates/submissions/partials/submission-lead.html
+++ b/hypha/apply/funds/templates/submissions/partials/submission-lead.html
@@ -1,12 +1,13 @@
-{% load i18n %}
+{% load i18n heroicons %}
 {% if request.user.is_apply_staff %}
-    <span>
-        {% trans "Lead" %}:
-        <a class="text-white underline"
-           href="{% url 'apply:submissions:list' %}?lead={{ submission.lead.id }}">
-            {{ submission.lead }}
-        </a>
-    </span>
+    <a class="link link--edit-lead is-active link--transparent hover:opacity-70 transition-opacity"
+       href="{% url 'funds:submissions:lead_update' pk=submission.pk %}"
+       hx-get="{% url 'funds:submissions:lead_update' pk=submission.pk %}"
+       hx-target="#htmx-modal"
+    >
+        <u>{% trans "Lead" %}: {{ submission.lead }}</u>
+        {% heroicon_micro "pencil-square" class="inline ms-1" aria_hidden=true %}
+    </a>
 {% elif request.user.is_org_faculty or not HIDE_STAFF_IDENTITY %}
     <span>{% trans "Lead" %}: {{ submission.lead }}</span>
 {% endif %}

--- a/hypha/apply/funds/views/submission_edit.py
+++ b/hypha/apply/funds/views/submission_edit.py
@@ -533,7 +533,7 @@ class UpdateLeadView(View):
             self.template,
             context={
                 "form": lead_form,
-                "value": _("Submit"),
+                "value": _("Update"),
                 "object": self.object,
             },
         )

--- a/hypha/apply/projects/templates/application_projects/modals/lead_update.html
+++ b/hypha/apply/projects/templates/application_projects/modals/lead_update.html
@@ -1,7 +1,14 @@
 {% load i18n %}
-{% modal_title %}{% trans "Assign Lead" %}{% endmodal_title %}
+{% modal_title %}{% trans "Update Lead" %}{% endmodal_title %}
 
 <div class="p-4">
+    <div>
+        <dl class="mb-4">
+            <dt class="font-semibold">{% trans "Current Lead" %}</dt>
+            <dd class="truncate">{{ object.lead }} &lt;{{object.lead.email}}&gt;</dd>
+        </dl>
+    </div>
+
     {% url 'apply:projects:lead_update' object.id as url %}
     {% include 'funds/includes/dialog_form_base.html' with form=form value=value url=url %}
 </div>


### PR DESCRIPTION
<!--
Thanks for contributing to Hypha!

Please ensure your contributions pass all necessary linting/testing and that the appropriate documentation has been updated.
-->

<!--
Describe briefly what your pull request changes. If this is resolving an issue, please specify below via "Fixes #<Github Issue ID>"
-->
Fixes #4288 

For projects:
![image](https://github.com/user-attachments/assets/ba92f030-f245-446d-a91c-472dce7641d5)

For applications:
![image](https://github.com/user-attachments/assets/a8de93a4-4c95-4784-ac9e-0207838ea92e)



## Test Steps
<!-- 
If step does not require manual testing, skip/remove this section.

Give a brief overview of the steps required for a user/dev to test this contribution. Important things to include:
 - Required user roles for where necessary (ie. "As a Staff Admin...")
 - Clear & validatable expected results (ie. "Confirm the submit button is now not clickable")
 - Language that can be understood by non-technical testers if being tested by users
-->

 - [ ] …