### PR TITLE
Added `mailto` URLs (when appropriate) where email addresses are displayed 

### DIFF
--- a/hypha/apply/funds/templates/funds/includes/rendered_answers.html
+++ b/hypha/apply/funds/templates/funds/includes/rendered_answers.html
@@ -42,7 +42,7 @@
         </div>
         <div>
             <h5 class="text-base">{% trans "E-mail" %}</h5>
-            {{ object.get_email_display }}
+            <a href="mailto:{{ object.user.email }}">{{ object.user.email }}</a>
         </div>
         {% if object.get_address_display != "-" %}
             <div class="hypha-grid__cell--span-two">

--- a/hypha/apply/users/templates/wagtailusers/users/list.html
+++ b/hypha/apply/users/templates/wagtailusers/users/list.html
@@ -43,7 +43,7 @@
                         {% user_listing_buttons user %}
                     </ul>
                 </td>
-                <td class="username" valign="top">{{ user.get_username }}</td>
+                <td class="username" valign="top"><a href="mailto:{{user.get_username}}">{{ user.get_username }}</a></td>
                 {% comment %} <td class="level" valign="top">{% if user.is_superuser %}{% trans "Admin" %}{% endif %}</td> {% endcomment %}
                 <td class="level" valign="top">
                     {% if user.is_superuser %}


### PR DESCRIPTION
<!--
Thanks for contributing to Hypha!

Please ensure your contributions pass all necessary linting/testing and that the appropriate documentation has been updated.
-->

<!--
Describe briefly what your pull request changes. If this is resolving an issue, please specify below via "Fixes #<Github Issue ID>"
-->
Fixes #4312. Small fixes to add mailto links in submission detail & wagtail admin user list. I think these are the only places it would make sense to have these URLs to but let me know if I missed anything!


## Test Steps
<!-- 
If step does not require manual testing, skip/remove this section.

Give a brief overview of the steps required for a user/dev to test this contribution. Important things to include:
 - Required user roles for where necessary (ie. "As a Staff Admin...")
 - Clear & validatable expected results (ie. "Confirm the submit button is now not clickable")
 - Language that can be understood by non-technical testers if being tested by users
-->

 - [ ] Ensure the email address shown under the submission detail is now a functional `mailto` link
 - [ ] Ensure the email column in the wagtail admin user list (`/admin/users/`) contains all functional `mailto` links