### PR TITLE
Truncated assigned comments & added more context

### DIFF
--- a/hypha/apply/todo/options.py
+++ b/hypha/apply/todo/options.py
@@ -50,7 +50,9 @@ TASKS_CODE_CHOICES = (
 template_map = {
     # ADD Manual Task
     COMMENT_TASK: {
-        "text": _("{msg}"),
+        "text": _(
+            '{related.user} assigned you a comment on [<span class="truncate inline-block max-w-32 align-bottom ">{related.source.title}</span>]({link} "{related.source.title}"):\n<span class="line-clamp-2 italic align-bottom ">{msg}</span>'
+        ),
         "icon": "comment",
         "url": "{link}",
         "type": _("Comment"),
@@ -217,7 +219,8 @@ def get_task_template(request, task, **kwargs):
         "link": link_to(related_obj, request),
     }
     if task.code == COMMENT_TASK:
-        template_kwargs["msg"] = related_obj.message
+        # Replace all newlines with spaces
+        template_kwargs["msg"] = " ".join(related_obj.message.splitlines())
     template["text"] = template["text"].format(**template_kwargs)
     template["url"] = template["url"].format(**template_kwargs)
     # additional field


### PR DESCRIPTION
<!--
Thanks for contributing to Hypha!

Please ensure your contributions pass all necessary linting/testing and that the appropriate documentation has been updated.
-->

<!--
Describe briefly what your pull request changes. If this is resolving an issue, please specify below via "Fixes #<Github Issue ID>"
-->
Fixes #4327. Adds a little more context to an assigned comment and will give a sample of the comment, truncating it if it goes over 2 lines.

## Screenshots

*The assigned comment in the comms tab*
<img width="892" alt="Screenshot 2025-01-09 at 11 41 44" src="https://github.com/user-attachments/assets/a1049922-cd00-4644-bc99-c1277985c7aa" />

*The resulting tasks*
<img width="892" alt="Screenshot 2025-01-09 at 11 43 29" src="https://github.com/user-attachments/assets/f6642fcf-1953-482a-b1eb-3fe162239ae7" />



## Test Steps
<!-- 
If step does not require manual testing, skip/remove this section.

Give a brief overview of the steps required for a user/dev to test this contribution. Important things to include:
 - Required user roles for where necessary (ie. "As a Staff Admin...")
 - Clear & validatable expected results (ie. "Confirm the submit button is now not clickable")
 - Language that can be understood by non-technical testers if being tested by users
-->

 - [ ] Ensure assigned comments are truncated in the My Tasks list and include the comment author/source project or application