### PR TITLE
Add @view-transition auto to root element.

### DIFF
--- a/hypha/static_src/tailwind/base/core.css
+++ b/hypha/static_src/tailwind/base/core.css
@@ -2,3 +2,8 @@ body {
     color: var(--color-fg-default);
     background-color: var(--color-bg-default);
 }
+
+/* Transitioning page view. */
+@view-transition {
+    navigation: auto;
+}


### PR DESCRIPTION
The latest version of most modern browsers have support for the new @view-transition that animate the transition from one page to another within the same origin. By default subtle and nice I think.

Browsers that do not support it yet will ignore it and work just as before.

Read  up on @view-transition her:

https://developer.mozilla.org/en-US/docs/Web/CSS/@view-transition

For hands on examples and explanations see https://www.youtube.com/watch?v=quvE1uu1f_I