### PR TITLE
Small fixes to the submissions table

### DIFF
--- a/hypha/apply/funds/templates/submissions/all.html
+++ b/hypha/apply/funds/templates/submissions/all.html
@@ -1,7 +1,7 @@
 {% extends base_template %}
 
 {% load i18n static %}
-{% load querystrings heroicons %}
+{% load querystrings heroicons table_tags %}
 {% load humanize %}
 
 {% block title %}{% trans "Submissions" %}{% endblock %}
@@ -205,43 +205,43 @@
 
             {% if selected_statuses %}
                 <span class="inline-flex items-center py-1 px-2 text-xs font-medium text-blue-800 bg-blue-100 rounded select-none me-2">
-                    status:{% for s in selected_statuses %}{{ s }}{% endfor %}
+                    Status: {% for s in selected_statuses %}{{ s }}{% endfor %}
                     <a href="{% remove_from_query "status" %}" role="button" class="inline-flex items-center p-0.5 text-xs text-blue-400 bg-transparent rounded-sm hover:text-blue-900 hover:bg-blue-200 ms-1" aria-label="Remove">
                         {% heroicon_mini "x-mark" aria_hidden="true" fill="currentColor" %}
                         <span class="sr-only">{% trans "Remove status filter" %}</span>
                     </a>
                 </span>
             {% endif %}
-            {% if selected_fund_objects %}
+            {% for fund in selected_fund_objects %}
                 <span class="inline-flex items-center py-1 px-2 text-xs font-medium text-blue-800 bg-blue-100 rounded select-none me-2">
-                    fund:{% for s in selected_fund_objects %}"{{ s }}"{% endfor %}
-                    <a href="{% remove_from_query "fund" %}" role="button" class="inline-flex items-center p-0.5 text-xs text-blue-400 bg-transparent rounded-sm hover:text-blue-900 hover:bg-blue-200 ms-1 dark:hover:bg-blue-800 dark:hover:text-blue-300" aria-label="Remove">
+                    Fund: {{ fund }}
+                    <a href="{% remove_from_query fund=fund.id %}" role="button" class="inline-flex items-center p-0.5 text-xs text-blue-400 bg-transparent rounded-sm hover:text-blue-900 hover:bg-blue-200 ms-1 dark:hover:bg-blue-800 dark:hover:text-blue-300" aria-label="Remove">
                         {% heroicon_mini "x-mark" aria_hidden="true" fill="currentColor" %}
                         <span class="sr-only">{% trans "Remove fund filter" %}</span>
                     </a>
                 </span>
-            {% endif %}
-            {% if selected_round_objects %}
+            {% endfor %}
+            {% for round in selected_round_objects %}
                 <span class="inline-flex items-center py-1 px-2 text-xs font-medium text-blue-800 bg-blue-100 rounded select-none me-2">
-                    round:{% for s in selected_round_objects %}"{{ s }}"{% endfor %}
-                    <a href="{% remove_from_query "round" %}" role="button" class="inline-flex items-center p-0.5 text-xs text-blue-400 bg-transparent rounded-sm hover:text-blue-900 hover:bg-blue-200 ms-1 dark:hover:bg-blue-800 dark:hover:text-blue-300" aria-label="Remove">
+                    Round: {{ round }}
+                    <a href="{% remove_from_query round=round.id %}" role="button" class="inline-flex items-center p-0.5 text-xs text-blue-400 bg-transparent rounded-sm hover:text-blue-900 hover:bg-blue-200 ms-1 dark:hover:bg-blue-800 dark:hover:text-blue-300" aria-label="Remove">
                         {% heroicon_mini "x-mark" aria_hidden="true" fill="currentColor" %}
                         <span class="sr-only">{% trans "Remove round filter" %}</span>
                     </a>
                 </span>
-            {% endif %}
-            {% if selected_leads %}
+            {% endfor %}
+            {% for s in selected_leads %}
                 <span class="inline-flex items-center py-1 px-2 text-xs font-medium text-blue-800 bg-blue-100 rounded select-none me-2">
-                    Lead:{% for s in selected_leads %}{{ s }}{% endfor %}
-                    <a href="{% remove_from_query "lead" %}" role="button" class="inline-flex items-center p-0.5 text-xs text-blue-400 bg-transparent rounded-sm hover:text-blue-900 hover:bg-blue-200 ms-1 dark:hover:bg-blue-800 dark:hover:text-blue-300" aria-label="Remove">
+                    Lead: {{ s|get_display_name_from_id }}
+                    <a href="{% remove_from_query lead=s %}" role="button" class="inline-flex items-center p-0.5 text-xs text-blue-400 bg-transparent rounded-sm hover:text-blue-900 hover:bg-blue-200 ms-1 dark:hover:bg-blue-800 dark:hover:text-blue-300" aria-label="Remove">
                         {% heroicon_mini "x-mark" aria_hidden="true" fill="currentColor" %}
                         <span class="sr-only">{% trans "Remove leads filter" %}</span>
                     </a>
                 </span>
-            {% endif %}
+            {% endfor %}
             {% if selected_applicants %}
                 <span class="inline-flex items-center py-1 px-2 text-xs font-medium text-blue-800 bg-blue-100 rounded select-none me-2">
-                    Applicant:{% for s in selected_applicants %}{{ s }}{% endfor %}
+                    Applicant: {% for s in selected_applicants %}{{ s }}{% endfor %}
                     <a href="{% remove_from_query "applicants" %}" role="button" class="inline-flex items-center p-0.5 text-xs text-blue-400 bg-transparent rounded-sm hover:text-blue-900 hover:bg-blue-200 ms-1 dark:hover:bg-blue-800 dark:hover:text-blue-300" aria-label="Remove">
                         {% heroicon_mini "x-mark" aria_hidden="true" fill="currentColor" %}
                         <span class="sr-only">{% trans "Remove applicant filter" %}</span>
@@ -250,7 +250,7 @@
             {% endif %}
             {% for s in selected_reviewers %}
                 <span class="inline-flex items-center py-1 px-2 text-xs font-medium text-blue-800 bg-blue-100 rounded select-none me-2">
-                    Reviewer:{{ s }}
+                    Reviewer: {{ s|get_display_name_from_id }}
                     <a href="{% remove_from_query reviewers=s %}" role="button" class="inline-flex items-center p-0.5 text-xs text-blue-400 bg-transparent rounded-sm hover:text-blue-900 hover:bg-blue-200 ms-1 dark:hover:bg-blue-800 dark:hover:text-blue-300" aria-label="Remove">
                         {% heroicon_mini "x-mark" aria_hidden="true" fill="currentColor" %}
                         <span class="sr-only">{% trans "Remove reviewer filter" %}</span>
@@ -259,7 +259,7 @@
             {% endfor %}
             {% for s in selected_meta_terms %}
                 <span class="inline-flex items-center py-1 px-2 text-xs font-medium text-blue-800 bg-blue-100 rounded select-none me-2">
-                    Meta Term:{{ s }}
+                    Meta Term: {{ s }}
                     <a href="{% remove_from_query meta_terms=s %}" role="button" class="inline-flex items-center p-0.5 text-xs text-blue-400 bg-transparent rounded-sm hover:text-blue-900 hover:bg-blue-200 ms-1 dark:hover:bg-blue-800 dark:hover:text-blue-300" aria-label="Remove">
                         {% heroicon_mini "x-mark" aria_hidden="true" fill="currentColor" %}
                         <span class="sr-only">{% trans "Remove meta term filter" %}</span>
@@ -268,7 +268,7 @@
             {% endfor %}
             {% for s in selected_category_options %}
                 <span class="inline-flex items-center py-1 px-2 text-xs font-medium text-blue-800 bg-blue-100 rounded select-none me-2">
-                    Category:{{ s.value }}
+                    Category: {{ s.value }}
                     <a href="{% remove_from_query category_options=s.id %}" role="button" class="inline-flex items-center p-0.5 text-xs text-blue-400 bg-transparent rounded-sm hover:text-blue-900 hover:bg-blue-200 ms-1 dark:hover:bg-blue-800 dark:hover:text-blue-300" aria-label="Remove">
                         {% heroicon_mini "x-mark" aria_hidden="true" fill="currentColor" %}
                         <span class="sr-only">{% trans "Remove category filter" %}</span>
@@ -277,7 +277,7 @@
             {% endfor %}
             {% for s in selected_screening_statuses_objects %}
                 <span class="inline-flex items-center py-1 px-2 text-xs font-medium text-blue-800 bg-blue-100 rounded select-none me-2">
-                    screening:"{{ s.title }}"
+                    Screening: "{{ s.title }}"
                     <a href="{% remove_from_query screening_statuses=s.slug %}" role="button" class="inline-flex items-center p-0.5 text-xs text-blue-400 bg-transparent rounded-sm hover:text-blue-900 hover:bg-blue-200 ms-1 dark:hover:bg-blue-800 dark:hover:text-blue-300" aria-label="Remove">
                         {% heroicon_mini "x-mark" aria_hidden="true" fill="currentColor" %}
                         <span class="sr-only">{% trans "Remove screening decisions filter" %}</span>
@@ -286,7 +286,7 @@
             {% endfor %}
             {% if selected_sort %}
                 <span class="inline-flex items-center py-1 px-2 text-xs font-medium text-blue-800 bg-blue-100 rounded select-none me-2">
-                    sort:{{ selected_sort }}
+                    Sort: {{ selected_sort }}
                     <a href="{% remove_from_query "sort" %}" role="button" class="inline-flex items-center p-0.5 text-xs text-blue-400 bg-transparent rounded-sm hover:text-blue-900 hover:bg-blue-200 ms-1 dark:hover:bg-blue-800 dark:hover:text-blue-300" aria-label="Remove">
                         {% heroicon_mini "x-mark" aria_hidden="true" fill="currentColor" %}
                         <span class="sr-only">{% trans "Remove sort filter" %}</span>
@@ -374,7 +374,7 @@
 
                 {% dropdown_menu title="Status" heading="Filter by current status" enable_search=True %}
                     <ul
-                        class="flex overflow-scroll flex-col max-h-80 text-gray-700 divide-y"
+                        class="flex overflow-auto flex-col max-h-80 text-gray-700 divide-y"
                         data-filter-list>
                         {% if selected_statuses %}
                             <li>
@@ -412,7 +412,7 @@
 
                 {% dropdown_menu title="Screening" heading="Filter by screening decision"  %}
                     <ul
-                        class="flex overflow-scroll flex-col max-h-80 text-gray-700 divide-y"
+                        class="flex overflow-auto flex-col max-h-80 text-gray-700 divide-y"
                     >
                         {% for s in screening_options %}
                             <li>

--- a/hypha/apply/funds/templates/submissions/all.html
+++ b/hypha/apply/funds/templates/submissions/all.html
@@ -259,7 +259,7 @@
             {% endfor %}
             {% for s in selected_meta_terms %}
                 <span class="inline-flex items-center py-1 px-2 text-xs font-medium text-blue-800 bg-blue-100 rounded select-none me-2">
-                    {% trans "Meta Term:" %} {{ s }}
+                    {% trans "Meta Term:" %} {{ s|get_meta_term_from_id }}
                     <a href="{% remove_from_query meta_terms=s %}" role="button" class="inline-flex items-center p-0.5 text-xs text-blue-400 bg-transparent rounded-sm hover:text-blue-900 hover:bg-blue-200 ms-1 dark:hover:bg-blue-800 dark:hover:text-blue-300" aria-label="Remove">
                         {% heroicon_mini "x-mark" aria_hidden="true" fill="currentColor" %}
                         <span class="sr-only">{% trans "Remove meta term filter" %}</span>

--- a/hypha/apply/funds/templates/submissions/all.html
+++ b/hypha/apply/funds/templates/submissions/all.html
@@ -176,10 +176,10 @@
         {% if can_export_submissions %}
             <a
                 class="py-1.5 px-2 rounded border shadow-sm transition-colors hover:bg-gray-100"
-                aria-label="Submissions: Download as CSV"
+                aria-label="{% trans 'Submissions: Download as CSV' %}"
                 href="{% modify_query "page" format="csv" %}"
                 onclick="return confirm('{% blocktrans %}Are you sure you want to download the submissions as a csv file? This file may contain sensitive information, so please handle it carefully.{% endblocktrans %}');"
-                data-tippy-content="Export as CSV"
+                data-tippy-content="{% trans 'Export as CSV' %}"
             >
                 {% heroicon_mini "arrow-down-tray" %}
             </a>
@@ -205,7 +205,7 @@
 
             {% if selected_statuses %}
                 <span class="inline-flex items-center py-1 px-2 text-xs font-medium text-blue-800 bg-blue-100 rounded select-none me-2">
-                    Status: {% for s in selected_statuses %}{{ s }}{% endfor %}
+                    {% trans "Status:" %} {% for s in selected_statuses %}{{ s }}{% endfor %}
                     <a href="{% remove_from_query "status" %}" role="button" class="inline-flex items-center p-0.5 text-xs text-blue-400 bg-transparent rounded-sm hover:text-blue-900 hover:bg-blue-200 ms-1" aria-label="Remove">
                         {% heroicon_mini "x-mark" aria_hidden="true" fill="currentColor" %}
                         <span class="sr-only">{% trans "Remove status filter" %}</span>
@@ -214,7 +214,7 @@
             {% endif %}
             {% for fund in selected_fund_objects %}
                 <span class="inline-flex items-center py-1 px-2 text-xs font-medium text-blue-800 bg-blue-100 rounded select-none me-2">
-                    Fund: {{ fund }}
+                    {% trans "Fund:" %} {{ fund }}
                     <a href="{% remove_from_query fund=fund.id %}" role="button" class="inline-flex items-center p-0.5 text-xs text-blue-400 bg-transparent rounded-sm hover:text-blue-900 hover:bg-blue-200 ms-1 dark:hover:bg-blue-800 dark:hover:text-blue-300" aria-label="Remove">
                         {% heroicon_mini "x-mark" aria_hidden="true" fill="currentColor" %}
                         <span class="sr-only">{% trans "Remove fund filter" %}</span>
@@ -223,7 +223,7 @@
             {% endfor %}
             {% for round in selected_round_objects %}
                 <span class="inline-flex items-center py-1 px-2 text-xs font-medium text-blue-800 bg-blue-100 rounded select-none me-2">
-                    Round: {{ round }}
+                    {% trans "Round:" %} {{ round }}
                     <a href="{% remove_from_query round=round.id %}" role="button" class="inline-flex items-center p-0.5 text-xs text-blue-400 bg-transparent rounded-sm hover:text-blue-900 hover:bg-blue-200 ms-1 dark:hover:bg-blue-800 dark:hover:text-blue-300" aria-label="Remove">
                         {% heroicon_mini "x-mark" aria_hidden="true" fill="currentColor" %}
                         <span class="sr-only">{% trans "Remove round filter" %}</span>
@@ -232,7 +232,7 @@
             {% endfor %}
             {% for s in selected_leads %}
                 <span class="inline-flex items-center py-1 px-2 text-xs font-medium text-blue-800 bg-blue-100 rounded select-none me-2">
-                    Lead: {{ s|get_display_name_from_id }}
+                    {% trans "Lead:" %} {{ s|get_display_name_from_id }}
                     <a href="{% remove_from_query lead=s %}" role="button" class="inline-flex items-center p-0.5 text-xs text-blue-400 bg-transparent rounded-sm hover:text-blue-900 hover:bg-blue-200 ms-1 dark:hover:bg-blue-800 dark:hover:text-blue-300" aria-label="Remove">
                         {% heroicon_mini "x-mark" aria_hidden="true" fill="currentColor" %}
                         <span class="sr-only">{% trans "Remove leads filter" %}</span>
@@ -241,7 +241,7 @@
             {% endfor %}
             {% if selected_applicants %}
                 <span class="inline-flex items-center py-1 px-2 text-xs font-medium text-blue-800 bg-blue-100 rounded select-none me-2">
-                    Applicant: {% for s in selected_applicants %}{{ s }}{% endfor %}
+                    {% trans "Applicant:" %} {% for s in selected_applicants %}{{ s }}{% endfor %}
                     <a href="{% remove_from_query "applicants" %}" role="button" class="inline-flex items-center p-0.5 text-xs text-blue-400 bg-transparent rounded-sm hover:text-blue-900 hover:bg-blue-200 ms-1 dark:hover:bg-blue-800 dark:hover:text-blue-300" aria-label="Remove">
                         {% heroicon_mini "x-mark" aria_hidden="true" fill="currentColor" %}
                         <span class="sr-only">{% trans "Remove applicant filter" %}</span>
@@ -250,7 +250,7 @@
             {% endif %}
             {% for s in selected_reviewers %}
                 <span class="inline-flex items-center py-1 px-2 text-xs font-medium text-blue-800 bg-blue-100 rounded select-none me-2">
-                    Reviewer: {{ s|get_display_name_from_id }}
+                    {% trans "Reviewer:" %} {{ s|get_display_name_from_id }}
                     <a href="{% remove_from_query reviewers=s %}" role="button" class="inline-flex items-center p-0.5 text-xs text-blue-400 bg-transparent rounded-sm hover:text-blue-900 hover:bg-blue-200 ms-1 dark:hover:bg-blue-800 dark:hover:text-blue-300" aria-label="Remove">
                         {% heroicon_mini "x-mark" aria_hidden="true" fill="currentColor" %}
                         <span class="sr-only">{% trans "Remove reviewer filter" %}</span>
@@ -259,7 +259,7 @@
             {% endfor %}
             {% for s in selected_meta_terms %}
                 <span class="inline-flex items-center py-1 px-2 text-xs font-medium text-blue-800 bg-blue-100 rounded select-none me-2">
-                    Meta Term: {{ s }}
+                    {% trans "Meta Term:" %} {{ s }}
                     <a href="{% remove_from_query meta_terms=s %}" role="button" class="inline-flex items-center p-0.5 text-xs text-blue-400 bg-transparent rounded-sm hover:text-blue-900 hover:bg-blue-200 ms-1 dark:hover:bg-blue-800 dark:hover:text-blue-300" aria-label="Remove">
                         {% heroicon_mini "x-mark" aria_hidden="true" fill="currentColor" %}
                         <span class="sr-only">{% trans "Remove meta term filter" %}</span>
@@ -268,7 +268,7 @@
             {% endfor %}
             {% for s in selected_category_options %}
                 <span class="inline-flex items-center py-1 px-2 text-xs font-medium text-blue-800 bg-blue-100 rounded select-none me-2">
-                    Category: {{ s.value }}
+                    {% trans "Category:" %} {{ s.value }}
                     <a href="{% remove_from_query category_options=s.id %}" role="button" class="inline-flex items-center p-0.5 text-xs text-blue-400 bg-transparent rounded-sm hover:text-blue-900 hover:bg-blue-200 ms-1 dark:hover:bg-blue-800 dark:hover:text-blue-300" aria-label="Remove">
                         {% heroicon_mini "x-mark" aria_hidden="true" fill="currentColor" %}
                         <span class="sr-only">{% trans "Remove category filter" %}</span>
@@ -277,7 +277,7 @@
             {% endfor %}
             {% for s in selected_screening_statuses_objects %}
                 <span class="inline-flex items-center py-1 px-2 text-xs font-medium text-blue-800 bg-blue-100 rounded select-none me-2">
-                    Screening: "{{ s.title }}"
+                    {% trans "Screening:" %} "{{ s.title }}"
                     <a href="{% remove_from_query screening_statuses=s.slug %}" role="button" class="inline-flex items-center p-0.5 text-xs text-blue-400 bg-transparent rounded-sm hover:text-blue-900 hover:bg-blue-200 ms-1 dark:hover:bg-blue-800 dark:hover:text-blue-300" aria-label="Remove">
                         {% heroicon_mini "x-mark" aria_hidden="true" fill="currentColor" %}
                         <span class="sr-only">{% trans "Remove screening decisions filter" %}</span>
@@ -286,7 +286,7 @@
             {% endfor %}
             {% if selected_sort %}
                 <span class="inline-flex items-center py-1 px-2 text-xs font-medium text-blue-800 bg-blue-100 rounded select-none me-2">
-                    Sort: {{ selected_sort }}
+                    {% trans "Sort:" %} {{ selected_sort }}
                     <a href="{% remove_from_query "sort" %}" role="button" class="inline-flex items-center p-0.5 text-xs text-blue-400 bg-transparent rounded-sm hover:text-blue-900 hover:bg-blue-200 ms-1 dark:hover:bg-blue-800 dark:hover:text-blue-300" aria-label="Remove">
                         {% heroicon_mini "x-mark" aria_hidden="true" fill="currentColor" %}
                         <span class="sr-only">{% trans "Remove sort filter" %}</span>
@@ -349,7 +349,7 @@
                         id="id_select_all"
                         type="checkbox"
                         x-ref="checkboxSelectAll"
-                        aria-label="Select all submissions"
+                        aria-label="{% trans 'Select all submissions' %}"
                         class="w-4 h-4 text-blue-600 bg-gray-100 rounded border-gray-300 focus:ring-2 focus:ring-blue-500"
                         @click="toggleAllCheckboxes()"
                     >
@@ -513,7 +513,7 @@
                     <button
                         hx-post="{% url 'apply:submissions:bulk-archive' %}"
                         hx-include="[name='selectedSubmissionIds']"
-                        hx-confirm="Are you sure you want to archive the selected submissions?"
+                        hx-confirm="{% trans 'Are you sure you want to archive the selected submissions?' %}"
                         class="flex items-center py-1 px-2 bg-gray-100 border hover:bg-gray-200"
                     >
                         {% heroicon_outline "lock-closed" aria_hidden="true" size=14 class="inline stroke-gray-600 me-1" %}
@@ -525,7 +525,7 @@
                     <button
                         hx-post="{% url 'apply:submissions:bulk-delete' %}"
                         hx-include="[name='selectedSubmissionIds']"
-                        hx-confirm="Are you sure you want to delete the selected submissions? This action cannot be undone."
+                        hx-confirm="{% trans 'Are you sure you want to delete the selected submissions? This action cannot be undone.' %}"
                         class="flex items-center py-1 px-2 bg-gray-100 border hover:bg-red-300"
                     >
                         {% heroicon_outline "trash" aria_hidden="true" size=14 class="inline stroke-gray-600 me-1" %}
@@ -558,14 +558,14 @@
                     <a
                         href="{% modify_query page=1 %}"
                         class="py-1.5 px-3 font-semibold border hover:bg-slate-200"
-                        aria-label="{% trans "First Page" %}"
+                        aria-label="{% trans 'First Page' %}"
                     >
                         &laquo; {% trans "First" %}
                     </a>
                     <a
                         href="{% modify_query page=page.previous_page_number %}"
                         class="py-1.5 px-3 font-semibold border hover:bg-slate-200"
-                        aria-label={% trans "Previous Page" %}
+                        aria-label="{% trans 'Previous Page' %}"
                     >
                         {% trans "Previous" %}
                     </a>
@@ -579,14 +579,14 @@
                     <a
                         href="{% modify_query page=page.next_page_number %}"
                         class="py-1.5 px-3 font-semibold border hover:bg-slate-200"
-                        aria-label="{% trans "Next Page" %}"
+                        aria-label="{% trans 'Next Page' %}"
                     >
                         {% trans "Next" %}
                     </a>
                     <a
                         href="{% modify_query page=page.paginator.num_pages %}"
                         class="py-1.5 px-3 font-semibold border hover:bg-slate-200"
-                        aria-label="{% trans "Last Page" %}"
+                        aria-label="{% trans 'Last Page' %}"
                     >
                         {% trans "Last" %} &raquo;
                     </a>
@@ -611,12 +611,12 @@
                 startDate: start,
                 endDate: end,
                 ranges: {
-                    'Today': [moment(), moment()],
-                    'Yesterday': [moment().subtract(1, 'days'), moment().subtract(1, 'days')],
-                    'Last 7 Days': [moment().subtract(6, 'days'), moment()],
-                    'Last 30 Days': [moment().subtract(29, 'days'), moment()],
-                    'This Month': [moment().startOf('month'), moment().endOf('month')],
-                    'Last Month': [moment().subtract(1, 'month').startOf('month'), moment().subtract(1, 'month').endOf('month')]
+                    '{% trans "Today" %}': [moment(), moment()],
+                    '{% trans "Yesterday" %}': [moment().subtract(1, 'days'), moment().subtract(1, 'days')],
+                    '{% trans "Last 7 Days" %}': [moment().subtract(6, 'days'), moment()],
+                    '{% trans "Last 30 Days" %}': [moment().subtract(29, 'days'), moment()],
+                    '{% trans "This Month" %}': [moment().startOf('month'), moment().endOf('month')],
+                    '{% trans "Last Month" %}': [moment().subtract(1, 'month').startOf('month'), moment().subtract(1, 'month').endOf('month')]
                 }
             });
 

--- a/hypha/apply/funds/templates/submissions/submenu/bulk-update-lead.html
+++ b/hypha/apply/funds/templates/submissions/submenu/bulk-update-lead.html
@@ -1,6 +1,6 @@
 {% load i18n %}
 {% load querystrings %}
-<ul class="overflow-scroll max-h-80 text-gray-700 divide-y" aria-labelledby="dropdown-change-status" data-filter-list>
+<ul class="overflow-auto max-h-80 text-gray-700 divide-y" aria-labelledby="dropdown-change-status" data-filter-list>
     {% for user in leads %}
         <li data-filter-item-text>
             <a

--- a/hypha/apply/funds/templates/submissions/submenu/category.html
+++ b/hypha/apply/funds/templates/submissions/submenu/category.html
@@ -1,6 +1,6 @@
 {% load i18n %}
 {% load querystrings %}
-<ul class="overflow-scroll max-h-80 text-gray-700" aria-labelledby="dropdown-categories"
+<ul class="overflow-auto max-h-80 text-gray-700" aria-labelledby="dropdown-categories"
     data-filter-list>
     {% if selected_category_options %}
         <li data-filter-item-text>

--- a/hypha/apply/funds/templates/submissions/submenu/change-status.html
+++ b/hypha/apply/funds/templates/submissions/submenu/change-status.html
@@ -1,6 +1,6 @@
 {% load i18n %}
 {% load querystrings %}
-<ul class="overflow-scroll max-h-80 text-gray-700 divide-y" aria-labelledby="dropdown-change-status">
+<ul class="overflow-auto max-h-80 text-gray-700 divide-y" aria-labelledby="dropdown-change-status">
     {% for slug, value in statuses %}
         <li data-filter-for="change-status-filter-field">
             <a

--- a/hypha/apply/funds/templates/submissions/submenu/funds.html
+++ b/hypha/apply/funds/templates/submissions/submenu/funds.html
@@ -1,7 +1,7 @@
 {% load i18n %}
 {% load querystrings heroicons %}
 
-<ul class="overflow-scroll max-h-80 text-gray-700 divide-y" aria-labelledby="dropdownBgHoverButton" data-filter-list>
+<ul class="overflow-auto max-h-80 text-gray-700 divide-y" aria-labelledby="dropdownBgHoverButton" data-filter-list>
     {% if selected_funds %}
         <li data-filter-item-text>
             <a href="{% url "apply:submissions:list" %}{% remove_from_query "only_query_string" "page" "fund" %}"
@@ -19,8 +19,8 @@
                     href="{% url "apply:submissions:list" %}{% remove_from_query "only_query_string" "page" fund=f.id %}"
                     hx-get="{% url "apply:submissions:list" %}{% remove_from_query "only_query_string" "page" fund=f.id %}"
                 {% else %}
-                    href="{% url "apply:submissions:list" %}{% modify_query "only_query_string" "page" "round" fund=f.id %}"
-                    hx-get="{% url "apply:submissions:list" %}{% modify_query "only_query_string" "page" "round" fund=f.id %}"
+                    href="{% url "apply:submissions:list" %}{% add_to_query "only_query_string" "page" "round" fund=f.id %}"
+                    hx-get="{% url "apply:submissions:list" %}{% add_to_query "only_query_string" "page" "round" fund=f.id %}"
                 {% endif %}
                 hx-push-url="true"
                 class="flex {% if f.selected %}ps-2 font-medium{% else %}ps-8{% endif %} pe-3 py-2 text-gray-600 items-center hover:bg-gray-100 focus:bg-gray-100{% if f.selected %}bg-gray-100{% endif %}">

--- a/hypha/apply/funds/templates/submissions/submenu/leads.html
+++ b/hypha/apply/funds/templates/submissions/submenu/leads.html
@@ -1,6 +1,6 @@
 {% load i18n %}
 {% load querystrings heroicons %}
-<ul class="overflow-scroll max-h-80 text-gray-700 divide-y" aria-labelledby="dropdownBgHoverButton" data-filter-list>
+<ul class="overflow-auto max-h-80 text-gray-700 divide-y" aria-labelledby="dropdownBgHoverButton" data-filter-list>
     {% if selected_leads %}
         <li data-filter-item-text>
             <a href="{% url "apply:submissions:list" %}{% remove_from_query "only_query_string" "page" "lead" %}"
@@ -14,8 +14,13 @@
     {% for user in leads %}
         <li data-filter-item-text>
             <a
-                href="{% url "apply:submissions:list" %}{% modify_query "only_query_string" "page" lead=user.id %}"
-                hx-get="{% url "apply:submissions:list" %}{% modify_query "only_query_string" "page" lead=user.id %}"
+                {% if user.selected %}
+                    href="{% url "apply:submissions:list" %}{% remove_from_query "only_query_string" "page" lead=user.id %}"
+                    hx-get="{% url "apply:submissions:list" %}{% remove_from_query "only_query_string" "page" lead=user.id %}"
+                {% else %}
+                    href="{% url "apply:submissions:list" %}{% add_to_query "only_query_string" "page" lead=user.id %}"
+                    hx-get="{% url "apply:submissions:list" %}{% add_to_query "only_query_string" "page" lead=user.id %}"
+                {% endif %}
                 hx-push-url="true"
                 class="flex {% if user.selected %}ps-2 font-medium bg-gray-100{% else %}ps-8{% endif %} pe-3 py-2 text-gray-600 items-center hover:bg-gray-100 focus:bg-gray-100"
                 aria-selected="{% if user.selected %}true{% else %}false{% endif %}"

--- a/hypha/apply/funds/templates/submissions/submenu/meta-terms.html
+++ b/hypha/apply/funds/templates/submissions/submenu/meta-terms.html
@@ -1,6 +1,6 @@
 {% load i18n %}
 {% load querystrings %}
-<ul class="overflow-scroll max-h-80 text-gray-700 divide-y" aria-labelledby="dropdown-meta-terms" data-filter-list>
+<ul class="overflow-auto max-h-80 text-gray-700 divide-y" aria-labelledby="dropdown-meta-terms" data-filter-list>
     {% if selected_meta_terms %}
         <li data-filter-item-text>
             <a href="{% url "apply:submissions:list" %}{% remove_from_query "only_query_string" "page" "meta_terms" %}"

--- a/hypha/apply/funds/templates/submissions/submenu/reviewers.html
+++ b/hypha/apply/funds/templates/submissions/submenu/reviewers.html
@@ -1,6 +1,6 @@
 {% load i18n %}
 {% load querystrings %}
-<ul class="overflow-scroll max-h-80 text-gray-700 divide-y" aria-labelledby="dropdown-reviewers" data-filter-list>
+<ul class="overflow-auto max-h-80 text-gray-700 divide-y" aria-labelledby="dropdown-reviewers" data-filter-list>
     {% if selected_reviewers %}
         <li data-filter-item-text>
             <a href="{% url "apply:submissions:list" %}{% remove_from_query "only_query_string" "page" "reviewers" %}"

--- a/hypha/apply/funds/templates/submissions/submenu/rounds.html
+++ b/hypha/apply/funds/templates/submissions/submenu/rounds.html
@@ -42,15 +42,21 @@
 
             <div data-filter-list>
                 {% if closed_rounds %}
-                    <div class="overflow-scroll max-h-80 divide-y tab-closed-rounds"
+                    <div class="overflow-auto max-h-80 divide-y tab-closed-rounds"
                          x-show="tab === 'closed_rounds'"
                          :aria-hidden="tab === 'closed_rounds' ? 'false' : 'true'"
                          role="tabpanel"
                     >
                         {% for f in closed_rounds %}
                             <a data-filter-item-text
-                               href="{% url "apply:submissions:list" %}{% modify_query "only_query_string" "page" round=f.id %}"
-                               hx-get="{% url "apply:submissions:list" %}{% modify_query "only_query_string" "page" round=f.id %}"
+                               {% if f.selected %}
+                                   href="{% url "apply:submissions:list" %}{% remove_from_query "only_query_string" "page" round=f.id %}"
+                                   hx-get="{% url "apply:submissions:list" %}{% remove_from_query "only_query_string" "page" round=f.id %}"
+                               {% else %}
+                                   href="{% url "apply:submissions:list" %}{% add_to_query "only_query_string" "page" round=f.id %}"
+                                   hx-get="{% url "apply:submissions:list" %}{% add_to_query "only_query_string" "page" round=f.id %}"
+                               {% endif %}
+
                                hx-push-url="true"
                                class="flex {% if f.selected %}ps-2 font-medium{% else %}ps-8{% endif %} pe-3 py-2 text-gray-600 items-center hover:bg-gray-100 focus:bg-gray-100{% if f.selected %}bg-gray-100{% endif %}">
                                 {% if f.selected %}
@@ -63,7 +69,7 @@
                 {% endif %}
 
                 {% if open_rounds %}
-                    <div class="overflow-scroll max-h-80 divide-y tab-open-rounds"
+                    <div class="overflow-auto max-h-80 divide-y tab-open-rounds"
                          x-show="tab === 'open_rounds'"
                          :aria-hidden="tab === 'open_rounds' ? 'false' : 'true'"
                          role="tabpanel"
@@ -71,8 +77,13 @@
                         {% for f in open_rounds %}
                             <a
                                 data-filter-item-text
-                                href="{% url "apply:submissions:list" %}{% modify_query "only_query_string" "page" round=f.id %}"
-                                hx-get="{% url "apply:submissions:list" %}{% modify_query "only_query_string" "page" round=f.id %}"
+                                {% if f.selected %}
+                                    href="{% url "apply:submissions:list" %}{% remove_from_query "only_query_string" "page" round=f.id %}"
+                                    hx-get="{% url "apply:submissions:list" %}{% remove_from_query "only_query_string" "page" round=f.id %}"
+                                {% else %}
+                                    href="{% url "apply:submissions:list" %}{% add_to_query "only_query_string" "page" round=f.id %}"
+                                    hx-get="{% url "apply:submissions:list" %}{% add_to_query "only_query_string" "page" round=f.id %}"
+                                {% endif %}
                                 hx-push-url="true"
                                 class="flex {% if f.selected %}ps-2 font-medium{% else %}ps-8{% endif %} pe-3 py-2 text-gray-600 items-center hover:bg-gray-100 focus:bg-gray-100{% if f.selected %}bg-gray-100{% endif %}">
                                 {% if f.selected %}

--- a/hypha/apply/funds/templatetags/table_tags.py
+++ b/hypha/apply/funds/templatetags/table_tags.py
@@ -3,6 +3,8 @@ import math
 
 from django import template
 
+from hypha.apply.users.models import User
+
 register = template.Library()
 
 
@@ -16,3 +18,8 @@ def row_from_record(row, record):
 @register.simple_tag
 def total_num_of_pages(total_no_of_rows, per_page):
     return math.ceil(total_no_of_rows / per_page)
+
+
+@register.filter
+def get_display_name_from_id(user_id: int) -> str:
+    return User.objects.get(id=user_id).get_display_name()

--- a/hypha/apply/funds/templatetags/table_tags.py
+++ b/hypha/apply/funds/templatetags/table_tags.py
@@ -3,6 +3,7 @@ import math
 
 from django import template
 
+from hypha.apply.categories.models import MetaTerm
 from hypha.apply.users.models import User
 
 register = template.Library()
@@ -23,3 +24,8 @@ def total_num_of_pages(total_no_of_rows, per_page):
 @register.filter
 def get_display_name_from_id(user_id: int) -> str:
     return User.objects.get(id=user_id).get_display_name()
+
+
+@register.filter
+def get_meta_term_from_id(meta_term_id: int) -> str:
+    return MetaTerm.objects.get(id=meta_term_id).name

--- a/hypha/apply/funds/views/all.py
+++ b/hypha/apply/funds/views/all.py
@@ -22,7 +22,7 @@ from hypha.apply.funds.models.screening import ScreeningStatus
 from hypha.apply.funds.utils import export_submissions_to_csv
 from hypha.apply.funds.workflows import PHASES, get_action_mapping, review_statuses
 from hypha.apply.search.filters import apply_date_filter
-from hypha.apply.search.query_parser import parse_search_query
+from hypha.apply.search.query_parser import filter_non_digits, parse_search_query
 from hypha.apply.users.decorators import (
     is_apply_staff,
     is_apply_staff_or_reviewer_required,
@@ -81,27 +81,24 @@ def submissions_all(
 
     show_archived = request.GET.get("archived", False) == "on"
     show_drafts = request.GET.get("drafts", False) == "on"
-    selected_funds = request.GET.getlist("fund")
-    selected_rounds = request.GET.getlist("round")
-    selected_leads = request.GET.getlist("lead")
-    selected_applicants = request.GET.getlist("applicants")
+    selected_funds = filter_non_digits(request.GET.getlist("fund", []))
+    selected_rounds = filter_non_digits(request.GET.getlist("round", []))
+    selected_leads = filter_non_digits(request.GET.getlist("lead", []))
+    selected_applicants = filter_non_digits(request.GET.getlist("applicants", []))
     selected_statuses = request.GET.getlist("status")
-    selected_screening_statuses = request.GET.getlist("screening_statuses")
-    selected_reviewers = request.GET.getlist("reviewers")
-    selected_meta_terms = request.GET.getlist("meta_terms")
-    selected_category_options = request.GET.getlist("category_options")
+    selected_screening_statuses = filter_non_digits(
+        request.GET.getlist("screening_statuses", [])
+    )
+    selected_reviewers = filter_non_digits(request.GET.getlist("reviewers", []))
+    selected_meta_terms = filter_non_digits(request.GET.getlist("meta_terms", []))
+    selected_category_options = filter_non_digits(
+        request.GET.getlist("category_options", [])
+    )
     selected_sort = request.GET.get("sort")
     page = request.GET.get("page", 1)
 
     can_view_archives = permissions.can_view_archived_submissions(request.user)
     can_access_drafts = permissions.can_access_drafts(request.user)
-
-    # Filter out anything that isn't an int
-    if selected_funds:
-        selected_funds = [id for id in selected_funds if id.isdigit()]
-
-    if selected_rounds:
-        selected_rounds = [id for id in selected_rounds if id.isdigit()]
 
     selected_fund_objects = (
         Page.objects.filter(id__in=selected_funds) if selected_funds else []

--- a/hypha/apply/funds/views/all.py
+++ b/hypha/apply/funds/views/all.py
@@ -96,6 +96,13 @@ def submissions_all(
     can_view_archives = permissions.can_view_archived_submissions(request.user)
     can_access_drafts = permissions.can_access_drafts(request.user)
 
+    # Filter out anything that isn't an int
+    if selected_funds:
+        selected_funds = [id for id in selected_funds if id.isdigit()]
+
+    if selected_rounds:
+        selected_rounds = [id for id in selected_rounds if id.isdigit()]
+
     selected_fund_objects = (
         Page.objects.filter(id__in=selected_funds) if selected_funds else []
     )

--- a/hypha/apply/search/query_parser.py
+++ b/hypha/apply/search/query_parser.py
@@ -1,5 +1,6 @@
 import datetime as dt
 import re
+from typing import List
 
 from lark import Lark, Transformer
 
@@ -127,3 +128,17 @@ def parse_search_query(search_query: str) -> dict:
     }
     """
     return parser.parse(search_query)
+
+
+def filter_non_digits(values: List[str]) -> List[str]:
+    """Filter out all non-digit strings from a list
+
+    ie. ['test', '13', 'uh', '78'] -> ['13', '78']
+
+    Args:
+        values: a list of strings to be filtered
+
+    Returns:
+        list: a filtered list of strings that are all numbers
+    """
+    return [value for value in values if value.isdigit()]


### PR DESCRIPTION
Fixes #4357 & #4358. Multiple small fixes to the all submissions table, including:

- Allowing for the selection of multiple rounds, leads, and funds while filtering
- Updated display tags for filters to reflect multiple selections
- Added template tag to get display names of users in filter tag display (leads + reviewers)
- Added `scroll-auto` to remove the scroll bar gap on some of the submenus
- Caps normalizations
- Handling of non-int values in query params that use int ids
- Added more translatable strings