### PR TITLE
Give lists etc. same formatting in all forms as in application forms.

### DIFF
--- a/hypha/apply/determinations/templates/determinations/base_determination_form.html
+++ b/hypha/apply/determinations/templates/determinations/base_determination_form.html
@@ -46,7 +46,9 @@
                     {% if field.field %}
                         {% include "forms/includes/field.html" %}
                     {% else %}
-                        {{ field.block }}
+                        <div class="max-w-none field-block prose">
+                            {{ field.block }}
+                        </div>
                     {% endif %}
                 {% endfor %}
                 {% block form_buttons %}

--- a/hypha/apply/funds/templates/funds/application_preview.html
+++ b/hypha/apply/funds/templates/funds/application_preview.html
@@ -25,7 +25,9 @@
                             {% include "forms/includes/field.html" with is_application=True %}
                         {% endif %}
                     {% else %}
-                        {{ field.block }}
+                        <div class="max-w-none field-block prose">
+                            {{ field.block }}
+                        </div>
                     {% endif %}
                 {% endfor %}
 

--- a/hypha/apply/projects/templates/application_projects/project_approval_form.html
+++ b/hypha/apply/projects/templates/application_projects/project_approval_form.html
@@ -27,7 +27,9 @@
                                 {% include "forms/includes/field.html" %}
                             {% endif %}
                         {% else %}
-                            {{ field.block }}
+                            <div class="max-w-none field-block prose">
+                                {{ field.block }}
+                            </div>
                         {% endif %}
                     {% endfor %}
 

--- a/hypha/apply/projects/templates/application_projects/project_sow_form.html
+++ b/hypha/apply/projects/templates/application_projects/project_sow_form.html
@@ -26,7 +26,9 @@
                                 {% include "forms/includes/field.html" %}
                             {% endif %}
                         {% else %}
-                            {{ field.block }}
+                            <div class="max-w-none field-block prose">
+                                {{ field.block }}
+                            </div>
                         {% endif %}
                     {% endfor %}
 

--- a/hypha/apply/projects/templates/application_projects/report_form.html
+++ b/hypha/apply/projects/templates/application_projects/report_form.html
@@ -42,7 +42,9 @@
                                 {% include "forms/includes/field.html" %}
                             {% endif %}
                         {% else %}
-                            {{ field.block }}
+                            <div class="max-w-none field-block prose">
+                                {{ field.block }}
+                            </div>
                         {% endif %}
                     {% endfor %}
 

--- a/hypha/apply/review/templates/review/review_edit_form.html
+++ b/hypha/apply/review/templates/review/review_edit_form.html
@@ -49,7 +49,9 @@
                 {% if field.field %}
                     {% include "forms/includes/field.html" %}
                 {% else %}
-                    {{ field }}
+                    <div class="max-w-none field-block prose">
+                        {{ field }}
+                    </div>
                 {% endif %}
             {% endfor %}
             <div class="flex flex-wrap gap-4 items-center">

--- a/hypha/apply/review/templates/review/review_form.html
+++ b/hypha/apply/review/templates/review/review_form.html
@@ -59,7 +59,9 @@
                     {% if field.field %}
                         {% include "forms/includes/field.html" %}
                     {% else %}
-                        {{ field.block }}
+                        <div class="max-w-none field-block prose">
+                            {{ field.block }}
+                        </div>
                     {% endif %}
                 {% endfor %}
 


### PR DESCRIPTION
Fixes #4369

Applied fix from application forms to other stream field form templates. A div wrapper with some tailwind classes.

## Test Steps

 - [ ] Check that lists have nice formatting in e.g. help text and paragraph in review, determination, report forms.