### PR TITLE
Added ability to set initial status when creating a project

### DIFF
--- a/docs/setup/administrators/configuration.md
+++ b/docs/setup/administrators/configuration.md
@@ -157,6 +157,14 @@ Auto create projects for approved applications.
 
 ----
 
+Default status for projects, must be a string literal of "draft" (default), "contracting", "invoicing_and_reporting" or "closing".
+
+Will be used for auto-create or be the default selection in the project creation form.
+    
+    PROJECTS_DEFAULT_STATUS = env.str('PROJECTS_DEFAULT_STATUS', 'draft')
+
+----
+
 Send out e-mail, slack messages etc. from Hypha. Set to true for production.
 
     SEND_MESSAGES = env.bool('SEND_MESSAGES', False)

--- a/hypha/apply/activity/adapters/activity_feed.py
+++ b/hypha/apply/activity/adapters/activity_feed.py
@@ -48,7 +48,9 @@ class ActivityAdapter(AdapterBase):
         MESSAGES.DELETE_REVIEW_OPINION: _(
             "deleted the opinion for review: {review_opinion.review}"
         ),
-        MESSAGES.CREATED_PROJECT: _("Created project"),
+        MESSAGES.CREATED_PROJECT: _(
+            'Created project with initial status of "{status}"'
+        ),
         MESSAGES.PROJECT_TRANSITION: "handle_project_transition",
         MESSAGES.UPDATE_PROJECT_TITLE: _(
             "updated the project title from {old_title} to {source.title}"

--- a/hypha/apply/activity/tests/test_messaging.py
+++ b/hypha/apply/activity/tests/test_messaging.py
@@ -223,7 +223,11 @@ class TestActivityAdapter(TestCase):
         submission = ApplicationSubmissionFactory()
 
         self.adapter.send_message(
-            message, user=user, source=submission, sources=[], related=None
+            message,
+            user=user,
+            source=submission,
+            sources=[],
+            related=None,
         )
 
         self.assertEqual(Activity.objects.count(), 1)
@@ -786,6 +790,7 @@ class TestAdaptersForProject(AdapterMixin, TestCase):
             adapter=self.activity(),
             source=project,
             related=project.submission,
+            status="Draft",
         )
         self.assertEqual(Activity.objects.count(), 1)
         activity = Activity.objects.first()

--- a/hypha/apply/funds/tests/test_views.py
+++ b/hypha/apply/funds/tests/test_views.py
@@ -28,6 +28,7 @@ from hypha.apply.funds.tests.factories import (
 from hypha.apply.funds.views.submission_detail import SubmissionDetailView
 from hypha.apply.funds.workflows import INITIAL_STATE
 from hypha.apply.projects.models import Project
+from hypha.apply.projects.models.project import CONTRACTING
 from hypha.apply.projects.tests.factories import ProjectFactory
 from hypha.apply.review.tests.factories import ReviewFactory
 from hypha.apply.users.tests.factories import (
@@ -327,6 +328,7 @@ class TestStaffSubmissionView(BaseSubmissionViewTestCase):
             {
                 "project_create_form": "",
                 "project_lead": self.user.id,
+                "project_initial_status": CONTRACTING,
                 "submission": self.submission.id,
             },
             view_name="create_project",
@@ -337,6 +339,7 @@ class TestStaffSubmissionView(BaseSubmissionViewTestCase):
 
         self.assertTrue(hasattr(submission, "project"))
         self.assertEqual(submission.project.id, project.id)
+        self.assertEqual(submission.project.status, CONTRACTING)
 
     def test_can_see_add_determination_primary_action(self):
         def assert_add_determination_displayed(submission, button_text):

--- a/hypha/apply/funds/views/submission_edit.py
+++ b/hypha/apply/funds/views/submission_edit.py
@@ -437,7 +437,9 @@ class CreateProjectView(View):
             project = form.save()
 
             readable_project_status = next(
-                x[1] for x in PROJECT_STATUS_CHOICES if x[0] == project.status
+                status[1]
+                for status in PROJECT_STATUS_CHOICES
+                if status[0] == project.status
             )
 
             # Record activity

--- a/hypha/apply/funds/views/submission_edit.py
+++ b/hypha/apply/funds/views/submission_edit.py
@@ -37,6 +37,7 @@ from hypha.apply.determinations.views import (
     DeterminationCreateOrUpdateView,
 )
 from hypha.apply.projects.forms import ProjectCreateForm
+from hypha.apply.projects.models.project import PROJECT_STATUS_CHOICES
 from hypha.apply.stream_forms.blocks import GroupToggleBlock
 from hypha.apply.todo.options import PROJECT_WAITING_PF, PROJECT_WAITING_SOW
 from hypha.apply.todo.views import add_task_to_user
@@ -434,11 +435,17 @@ class CreateProjectView(View):
         form = ProjectCreateForm(self.request.POST, instance=self.submission)
         if form.is_valid():
             project = form.save()
+
+            readable_project_status = next(
+                x[1] for x in PROJECT_STATUS_CHOICES if x[0] == project.status
+            )
+
             # Record activity
             messenger(
                 MESSAGES.CREATED_PROJECT,
                 request=self.request,
                 user=self.request.user,
+                status=readable_project_status,
                 source=project,
                 related=project.submission,
             )

--- a/hypha/apply/projects/forms/project.py
+++ b/hypha/apply/projects/forms/project.py
@@ -6,6 +6,10 @@ from django.utils.translation import gettext_lazy as _
 from django_file_form.forms import FileFormMixin
 
 from hypha.apply.funds.models import ApplicationSubmission
+from hypha.apply.projects.forms.utils import (
+    get_project_default_status,
+    get_project_status_options,
+)
 from hypha.apply.stream_forms.fields import SingleFileField
 from hypha.apply.stream_forms.forms import StreamBaseForm
 from hypha.apply.users.roles import STAFF_GROUP_NAME
@@ -85,6 +89,13 @@ class ProjectCreateForm(forms.Form):
         label=_("Select Project Lead"), queryset=User.objects.all()
     )
 
+    # Set the initial value to the settings default if valid, otherwise fall back to draft
+    project_initial_status = forms.ChoiceField(
+        label=_("Initial Project Status"),
+        choices=get_project_status_options(),
+        initial=get_project_default_status(),
+    )
+
     def __init__(self, *args, instance=None, **kwargs):
         super().__init__(*args, **kwargs)
 
@@ -107,7 +118,8 @@ class ProjectCreateForm(forms.Form):
     def save(self, *args, **kwargs):
         submission = self.cleaned_data["submission"]
         lead = self.cleaned_data["project_lead"]
-        return Project.create_from_submission(submission, lead=lead)
+        status = self.cleaned_data["project_initial_status"]
+        return Project.create_from_submission(submission, lead=lead, status=status)
 
 
 class MixedMetaClass(type(StreamBaseForm), type(forms.ModelForm)):

--- a/hypha/apply/projects/forms/utils.py
+++ b/hypha/apply/projects/forms/utils.py
@@ -15,9 +15,11 @@ def get_project_status_options() -> List[Tuple[str, str]]:
     Filters out complete & internal approval statuses as there isn't value in
     being able to set these
     """
-    return filter(
-        lambda x: x[0] not in [COMPLETE, INTERNAL_APPROVAL], PROJECT_STATUS_CHOICES
-    )
+    return [
+        status
+        for status in PROJECT_STATUS_CHOICES
+        if status[0] not in [COMPLETE, INTERNAL_APPROVAL]
+    ]
 
 
 def get_project_default_status() -> Tuple[str, str]:
@@ -27,6 +29,10 @@ def get_project_default_status() -> Tuple[str, str]:
     to draft
     """
     return next(
-        (x for x in PROJECT_STATUS_CHOICES if x[0] == settings.PROJECTS_DEFAULT_STATUS),
+        (
+            status
+            for status in PROJECT_STATUS_CHOICES
+            if status[0] == settings.PROJECTS_DEFAULT_STATUS
+        ),
         PROJECT_STATUS_CHOICES[0],
     )

--- a/hypha/apply/projects/forms/utils.py
+++ b/hypha/apply/projects/forms/utils.py
@@ -1,0 +1,32 @@
+from typing import List, Tuple
+
+from django.conf import settings
+
+from hypha.apply.projects.models.project import (
+    COMPLETE,
+    INTERNAL_APPROVAL,
+    PROJECT_STATUS_CHOICES,
+)
+
+
+def get_project_status_options() -> List[Tuple[str, str]]:
+    """Gets settable project status options
+
+    Filters out complete & internal approval statuses as there isn't value in
+    being able to set these
+    """
+    return filter(
+        lambda x: x[0] not in [COMPLETE, INTERNAL_APPROVAL], PROJECT_STATUS_CHOICES
+    )
+
+
+def get_project_default_status() -> Tuple[str, str]:
+    """Gets the default project status based off the settings
+
+    If the `PROJECTS_DEFAULT_STATUS` setting is invalid, status will fall back
+    to draft
+    """
+    return next(
+        (x for x in PROJECT_STATUS_CHOICES if x[0] == settings.PROJECTS_DEFAULT_STATUS),
+        PROJECT_STATUS_CHOICES[0],
+    )

--- a/hypha/apply/projects/models/project.py
+++ b/hypha/apply/projects/models/project.py
@@ -312,7 +312,7 @@ class Project(BaseStreamForm, AccessFormData, models.Model):
         return ""  # todo: need to figure out
 
     @classmethod
-    def create_from_submission(cls, submission, lead=None):
+    def create_from_submission(cls, submission, lead=None, status=None):
         """
         Create a Project from the given submission.
 
@@ -331,10 +331,22 @@ class Project(BaseStreamForm, AccessFormData, models.Model):
         if hasattr(submission, "project"):
             return submission.project
 
+        # If default status is valid and status arg is None, use it otherwise fallback to draft
+        if status is None:
+            status = next(
+                (
+                    x[0]
+                    for x in PROJECT_STATUS_CHOICES
+                    if x[0] == settings.PROJECTS_DEFAULT_STATUS
+                ),
+                DRAFT,
+            )
+
         return Project.objects.create(
             submission=submission,
             user=submission.user,
             title=submission.title,
+            status=status,
             lead=lead if lead else None,
             value=submission.form_data.get("value", 0),
         )

--- a/hypha/apply/projects/utils.py
+++ b/hypha/apply/projects/utils.py
@@ -1,4 +1,3 @@
-from django.conf import settings
 from django.utils.translation import gettext_lazy as _
 from django_file_form.uploaded_file import PlaceholderUploadedFile
 
@@ -58,18 +57,6 @@ def save_project_details(project_id, data):
     project = Project.objects.get(id=project_id)
     project.external_project_information = data
     project.save()
-
-
-def create_invoice(invoice):
-    """
-    Creates invoice at enabled payment service.
-    """
-    if settings.INTACCT_ENABLED:
-        from hypha.apply.projects.services.sageintacct.utils import (
-            create_intacct_invoice,
-        )
-
-        create_intacct_invoice(invoice)
 
 
 def get_paf_status_display(paf_status):

--- a/hypha/settings/base.py
+++ b/hypha/settings/base.py
@@ -92,6 +92,10 @@ PROJECTS_ENABLED = env.bool("PROJECTS_ENABLED", False)
 # Auto create projects for approved applications.
 PROJECTS_AUTO_CREATE = env.bool("PROJECTS_AUTO_CREATE", False)
 
+# Default status for projects, must be a string literal of "draft" (default), "contracting", "invoicing_and_reporting" or "closing"
+# Will be used for auto-create or be the default selection in the project creation form
+PROJECTS_DEFAULT_STATUS = env.str("PROJECTS_DEFAULT_STATUS", "draft")
+
 # Send out e-mail, slack messages etc. from Hypha. Set to true for production.
 SEND_MESSAGES = env.bool("SEND_MESSAGES", False)
 


### PR DESCRIPTION
<!--
Thanks for contributing to Hypha!

Please ensure your contributions pass all necessary linting/testing and that the appropriate documentation has been updated.
-->

<!--
Describe briefly what your pull request changes. If this is resolving an issue, please specify below via "Fixes #<Github Issue ID>"
-->
Closes #4388. Adds a new field to the "Create Project" modal that allows for setting the initial status of the project. The default for this field can be set with the `PROJECTS_DEFAULT_STATUS` environment setting, which would also set the initial status when `PROJECTS_AUTO_CREATE` is enabled. This settings needs to match one of the string literals here:
https://github.com/HyphaApp/hypha/blob/cc174b61b6af7dfd9403cdb2fe3a13a9364e37f7/hypha/apply/projects/models/project.py#L75-L80

In the modal the statuses of `INTERNAL_APPROVAL` and `COMPLETE` were removed as choices as I didn't see them being useful statuses to be manually set (internal approval would only be approving the items created in the `DRAFT` step)

Also updated the activity message to reflect what status the project was created with

## Screenshots

*Create project prompt with `PROJECTS_DEFAULT_STATUS="contracting"`*
![Screenshot 2025-02-11 at 17 35 40](https://github.com/user-attachments/assets/0aa071e9-61cd-4e66-9cbb-8aec15b81feb)
![Screenshot 2025-02-11 at 17 35 52](https://github.com/user-attachments/assets/d6631da7-07c7-4a92-831f-38afea7a9432)

*Activity message*
![Screenshot 2025-02-11 at 17 36 14](https://github.com/user-attachments/assets/c1e7e614-54bd-4117-a05c-6c62f149c342)


## Test Steps
<!-- 
If step does not require manual testing, skip/remove this section.

Give a brief overview of the steps required for a user/dev to test this contribution. Important things to include:
 - Required user roles for where necessary (ie. "As a Staff Admin...")
 - Clear & validatable expected results (ie. "Confirm the submit button is now not clickable")
 - Language that can be understood by non-technical testers if being tested by users
-->

Confirm...
 - [ ] ...the project creation prompt allows for setting of initial status
 - [ ] ...setting `PROJECTS_DEFAULT_STATUS` with a valid status results in that being the default option of the project creation prompt
 - [ ] ...setting `PROJECTS_DEFAULT_STATUS` when PROJECTS_AUTO_CREATE` is enabled causes projects to be created in the set status