### PR TITLE
Allow users to select Hypha language

### DIFF
--- a/hypha/core/context_processors.py
+++ b/hypha/core/context_processors.py
@@ -23,4 +23,5 @@ def global_vars(request):
         "SENTRY_PUBLIC_KEY": settings.SENTRY_PUBLIC_KEY,
         "SUBMISSIONS_TABLE_EXCLUDED_FIELDS": settings.SUBMISSIONS_TABLE_EXCLUDED_FIELDS,
         "HIJACK_ENABLE": settings.HIJACK_ENABLE,
+        "LANGUAGE_SWITCHER": settings.LANGUAGE_SWITCHER,
     }

--- a/hypha/core/context_processors.py
+++ b/hypha/core/context_processors.py
@@ -23,5 +23,6 @@ def global_vars(request):
         "SENTRY_PUBLIC_KEY": settings.SENTRY_PUBLIC_KEY,
         "SUBMISSIONS_TABLE_EXCLUDED_FIELDS": settings.SUBMISSIONS_TABLE_EXCLUDED_FIELDS,
         "HIJACK_ENABLE": settings.HIJACK_ENABLE,
+        "LANGUAGES": settings.LANGUAGES,
         "LANGUAGE_SWITCHER": settings.LANGUAGE_SWITCHER,
     }

--- a/hypha/core/context_processors.py
+++ b/hypha/core/context_processors.py
@@ -23,6 +23,5 @@ def global_vars(request):
         "SENTRY_PUBLIC_KEY": settings.SENTRY_PUBLIC_KEY,
         "SUBMISSIONS_TABLE_EXCLUDED_FIELDS": settings.SUBMISSIONS_TABLE_EXCLUDED_FIELDS,
         "HIJACK_ENABLE": settings.HIJACK_ENABLE,
-        "LANGUAGES": settings.LANGUAGES,
         "LANGUAGE_SWITCHER": settings.LANGUAGE_SWITCHER,
     }

--- a/hypha/settings/base.py
+++ b/hypha/settings/base.py
@@ -191,6 +191,10 @@ CONN_HEALTH_CHECKS = env.bool("CONN_HEALTH_CHECKS", True)
 # The corresponding locale dir is named: en, en_GB, en_US
 LANGUAGE_CODE = env.str("LANGUAGE_CODE", "en")
 
+# Optional language switcher
+# Set LANGUAGE setting to limit the languages available.
+LANGUAGE_SWITCHER = env.bool("LANGUAGE_SWITCHER", False)
+
 # Machine translation settings
 # NOTE: Ensure the packages in `requirements/translate.txt` have been installed!
 APPLICATION_TRANSLATIONS_ENABLED = env.bool("APPLICATION_TRANSLATIONS_ENABLED", False)

--- a/hypha/settings/base.py
+++ b/hypha/settings/base.py
@@ -189,11 +189,23 @@ CONN_HEALTH_CHECKS = env.bool("CONN_HEALTH_CHECKS", True)
 
 # Language code in standard language id format: en, en-gb, en-us
 # The corresponding locale dir is named: en, en_GB, en_US
+# Make sure the set lang code is included in LANGUAGES setting.
 LANGUAGE_CODE = env.str("LANGUAGE_CODE", "en")
 
 # Optional language switcher
 # Set LANGUAGE setting to limit the languages available.
 LANGUAGE_SWITCHER = env.bool("LANGUAGE_SWITCHER", False)
+
+# By default only English is activ.
+# When LANGUAGE_SWITCHER is on we activate all the languages there are complete translations for.
+if LANGUAGE_SWITCHER:
+    LANGUAGES = [
+        ("en", "English"),
+        ("ru", "Russian"),
+        ("zh-hans", "Simplified Chinese"),
+    ]
+else:
+    LANGUAGES = [("en", "English")]
 
 # Machine translation settings
 # NOTE: Ensure the packages in `requirements/translate.txt` have been installed!

--- a/hypha/settings/base.py
+++ b/hypha/settings/base.py
@@ -201,6 +201,7 @@ LANGUAGE_SWITCHER = env.bool("LANGUAGE_SWITCHER", False)
 if LANGUAGE_SWITCHER:
     LANGUAGES = [
         ("en", "English"),
+        ("cs", "Czech"),
         ("ru", "Russian"),
         ("zh-hans", "Simplified Chinese"),
     ]

--- a/hypha/settings/django.py
+++ b/hypha/settings/django.py
@@ -76,6 +76,7 @@ INSTALLED_APPS = [
 
 MIDDLEWARE = [
     "django.middleware.security.SecurityMiddleware",
+    "django.middleware.locale.LocaleMiddleware",
     "django.middleware.common.CommonMiddleware",
     "whitenoise.middleware.WhiteNoiseMiddleware",
     "django.contrib.sessions.middleware.SessionMiddleware",
@@ -177,6 +178,7 @@ DATE_FORMAT = "N j, Y"
 DATETIME_FORMAT = "N j, Y, H:i"
 SHORT_DATE_FORMAT = "Y-m-d"
 SHORT_DATETIME_FORMAT = "Y-m-d H:i"
+LANGUAGE_COOKIE_NAME = "hypha_language"
 
 DATETIME_INPUT_FORMATS = [
     "%Y-%m-%d %H:%M:%S",  # '2006-10-25 14:30:59'

--- a/hypha/templates/base-apply.html
+++ b/hypha/templates/base-apply.html
@@ -25,6 +25,10 @@
                 {% include "includes/menu-notifications.html" %}
             {% endif %}
 
+            {% if LANGUAGE_SWITCHER %}
+                {% include "includes/language-switcher.html" %}
+            {% endif %}
+
             {% if request.path != '/auth/' and request.path != '/login/' %}
                 {% include "includes/user_menu.html" %}
             {% endif %}

--- a/hypha/templates/includes/language-switcher.html
+++ b/hypha/templates/includes/language-switcher.html
@@ -24,32 +24,24 @@
         role="dialog"
         aria-labelledby="dialogtitle"
         @click.outside="open = false"
-        class="overflow-y-scroll fixed top-0 z-30 bg-white rounded border shadow-md md:absolute md:top-auto start-0 end-0 md:start-auto md:min-w-[400px] md:max-h-[500px]"
+        class="overflow-y-auto absolute right-0 z-30 bg-white rounded border shadow-md"
     >
-        <header class="flex gap-2 justify-between items-center py-2 px-3 bg-gray-100 border-b subheading">
-            <span id="dialogtitle" class="font-medium">
-                {% trans "Language switcher" %}
-            </span>
-            <button type="button" @click='open = false' class="opacity-70 appearance-none hover:opacity-100" aria-label="{% trans "Close" %}">
-                {% heroicon_solid "x-mark" aria_hidden="true" fill="currentColor" %}
-            </button>
-        </header>
 
-        <div id="id-language-switcher" class="p-4">
+        <div id="id-language-switcher" class="">
             {% get_available_languages as LANGUAGES %}
             {% get_language_info_list for LANGUAGES as languages %}
             {% if languages|length > 1 %}
-                <form action="{% url 'set_language' %}" method="post" class="my-2" x-ref="langForm">
+                <form action="{% url 'set_language' %}" method="post" class="p-4" x-ref="langForm">
                     {% csrf_token %}
                     <input name="next" type="hidden" value="{{ request.path }}">
-                    <fieldset class="grid grid-cols-2 gap-x-4">
+                    <fieldset class="grid gap-1">
                         {% for language in languages %}
                             <div>
                                 <input class="sr-only" name="language" id="{{ language.code }}" value="{{ language.code }}" type="radio" {% if language.code == LANGUAGE_CODE %}checked{% endif %}>
                                 <label lang="{{ language.code }}" class="font-semibold capitalize {% if language.code != LANGUAGE_CODE %}cursor-pointer hover:underline text-dark-blue{% endif %}" for="{{ language.code }}" x-on:click="$nextTick(() => { $refs.langForm.submit() })">{{ language.name_local }}</label>
                             </div>
                         {% endfor %}
-                        <button class="sr-only button button--primary button--narrow button--top-space" type="submit">{% trans "Set language" %}</button>
+                        <button class="sr-only" type="submit">{% trans "Set language" %}</button>
                     </fieldset>
                 </form>
             {% else %}

--- a/hypha/templates/includes/language-switcher.html
+++ b/hypha/templates/includes/language-switcher.html
@@ -1,53 +1,55 @@
 {% load i18n heroicons %}
 <!-- Language switcher -->
-<div
-    class="inline-block relative"
-    x-data="{open: false}"
-    x-on:keydown.escape="open = false"
-    x-init="$watch('open', value => { if (value) { document.getElementById('id-language-switcher').dispatchEvent(new Event('htmx:fetch')); } })"
->
-    <a href="{% url "todo:list" %}"
-       class="flex p-2 text-gray-900 rounded-full transition-all group"
-       aria-label="{% trans "Language switcher" %}"
-       aria-haspopup="language_switcher"
-       aria-expanded="false"
-       role="button"
-       title="{% trans "Language switcher" %}"
-       @click.prevent="open = ! open"
-       :class="open ? 'bg-gray-900 text-white' : 'hover:bg-slate-200'"
+<div x-data="{ open: false }" x-on:keydown.escape="open = false"  class="inline-block relative" >
+    <button
+        x-on:click="open = ! open"
+        aria-label="{% trans "Language switcher" %}"
+        aria-controls="id-language-switcher"
+        type="button"
+        :class="open ? 'bg-gray-900 text-white' : 'hover:bg-slate-200'"
+        :aria-expanded="open"
+        title="{% trans "Language switcher" %}"
+        class="flex p-2 text-gray-900 rounded-full transition-all group"
     >
         {% heroicon_outline "language" class="inline transition-transform group-hover:scale-110" aria_hidden="true" %}
-    </a>
+    </button>
 
     <!-- panel -->
     <div
-        class="overflow-y-scroll fixed top-0 z-30 bg-white rounded border shadow-md md:absolute md:top-auto start-0 end-0 md:start-auto md:min-w-[400px] md:max-h-[500px]"
         x-cloak
         x-show="open"
         x-trap="open"
         x-transition
         x-transition.origin.top
         @click.outside="open = false"
-        class="relative"
-        role="language_switcher"
+        class="overflow-y-scroll fixed top-0 z-30 bg-white rounded border shadow-md md:absolute md:top-auto start-0 end-0 md:start-auto md:min-w-[400px] md:max-h-[500px]"
     >
         <header class="flex gap-2 justify-between items-center py-2 px-3 bg-gray-100 border-b subheading">
             <span class="font-medium SubMenuHeading text-inherit">
                 {% trans "Language switcher" %}
             </span>
             <button type="button" @click='open = false' class="opacity-70 appearance-none hover:opacity-100">
-                {% heroicon_solid "x-mark" aria_hidden="true" class="" %}
+                {% heroicon_solid "x-mark" aria_hidden="true" fill="currentColor" %}
             </button>
         </header>
 
-        <div
-            id="id-language-switcher"
-            hx-get="{% url "users:hijack" %}"
-            hx-swap="innerHTML"
-            hx-trigger="htmx:fetch"
-        >
-            <div class="my-3 mx-4 bg-gray-200 rounded-lg animate-pulse min-h-4"></div>
-            <div class="my-3 mx-4 w-2/3 bg-gray-200 rounded-lg animate-pulse min-h-4"></div>
+        <div id="id-language-switcher" class="p-4">
+            {% get_language_info_list for LANGUAGES as languages %}
+            {% if languages|length > 1 %}
+                <form action="" method="post" class="my-2">
+                    {% csrf_token %}
+                    <fieldset class="grid grid-cols-2 gap-x-4">
+                        {% for language in languages %}
+                            <div>
+                                <input class="sr-only" name="language" id="{{ language.code }}" value="{{ language.code }}" type="radio" {% if language.code == LANGUAGE_CODE %}checked{% endif %} onchange="this.form.submit()">
+                                <label class="font-semibold capitalize cursor-pointer hover:underline text-dark-blue" for="{{ language.code }}">{{ language.name_local }}</label>
+                            </div>
+                        {% endfor %}
+                    </fieldset>
+                </form>
+            {% else %}
+                <span class="text-red-500">{% trans "Can't switch language. Only one language is active." %}</span>
+            {% endif %}
         </div>
     </div>
 </div>

--- a/hypha/templates/includes/language-switcher.html
+++ b/hypha/templates/includes/language-switcher.html
@@ -1,0 +1,53 @@
+{% load i18n heroicons %}
+<!-- Language switcher -->
+<div
+    class="inline-block relative"
+    x-data="{open: false}"
+    x-on:keydown.escape="open = false"
+    x-init="$watch('open', value => { if (value) { document.getElementById('id-language-switcher').dispatchEvent(new Event('htmx:fetch')); } })"
+>
+    <a href="{% url "todo:list" %}"
+       class="flex p-2 text-gray-900 rounded-full transition-all group"
+       aria-label="{% trans "Language switcher" %}"
+       aria-haspopup="language_switcher"
+       aria-expanded="false"
+       role="button"
+       title="{% trans "Language switcher" %}"
+       @click.prevent="open = ! open"
+       :class="open ? 'bg-gray-900 text-white' : 'hover:bg-slate-200'"
+    >
+        {% heroicon_outline "language" class="inline transition-transform group-hover:scale-110" aria_hidden="true" %}
+    </a>
+
+    <!-- panel -->
+    <div
+        class="overflow-y-scroll fixed top-0 z-30 bg-white rounded border shadow-md md:absolute md:top-auto start-0 end-0 md:start-auto md:min-w-[400px] md:max-h-[500px]"
+        x-cloak
+        x-show="open"
+        x-trap="open"
+        x-transition
+        x-transition.origin.top
+        @click.outside="open = false"
+        class="relative"
+        role="language_switcher"
+    >
+        <header class="flex gap-2 justify-between items-center py-2 px-3 bg-gray-100 border-b subheading">
+            <span class="font-medium SubMenuHeading text-inherit">
+                {% trans "Language switcher" %}
+            </span>
+            <button type="button" @click='open = false' class="opacity-70 appearance-none hover:opacity-100">
+                {% heroicon_solid "x-mark" aria_hidden="true" class="" %}
+            </button>
+        </header>
+
+        <div
+            id="id-language-switcher"
+            hx-get="{% url "users:hijack" %}"
+            hx-swap="innerHTML"
+            hx-trigger="htmx:fetch"
+        >
+            <div class="my-3 mx-4 bg-gray-200 rounded-lg animate-pulse min-h-4"></div>
+            <div class="my-3 mx-4 w-2/3 bg-gray-200 rounded-lg animate-pulse min-h-4"></div>
+        </div>
+    </div>
+</div>

--- a/hypha/templates/includes/language-switcher.html
+++ b/hypha/templates/includes/language-switcher.html
@@ -37,20 +37,21 @@
             {% get_available_languages as LANGUAGES %}
             {% get_language_info_list for LANGUAGES as languages %}
             {% if languages|length > 1 %}
-                <form action="{% url 'set_language' %}" method="post" class="my-2">
+                <form action="{% url 'set_language' %}" method="post" class="my-2" x-ref="langForm">
                     {% csrf_token %}
                     <input name="next" type="hidden" value="{{ request.path }}">
                     <fieldset class="grid grid-cols-2 gap-x-4">
                         {% for language in languages %}
                             <div>
-                                <input class="sr-only" name="language" id="{{ language.code }}" value="{{ language.code }}" type="radio" {% if language.code == LANGUAGE_CODE %}checked{% endif %} onchange="this.form.submit()">
-                                <label class="font-semibold capitalize cursor-pointer hover:underline text-dark-blue" for="{{ language.code }}">{{ language.name_local }}</label>
+                                <input class="sr-only" name="language" id="{{ language.code }}" value="{{ language.code }}" type="radio" {% if language.code == LANGUAGE_CODE %}checked{% endif %}>
+                                <label class="font-semibold capitalize {% if language.code != LANGUAGE_CODE %}cursor-pointer hover:underline text-dark-blue{% endif %}" for="{{ language.code }}" x-on:click="$nextTick(() => { $refs.langForm.submit() })">{{ language.name_local }}</label>
                             </div>
                         {% endfor %}
+                        <button class="sr-only button button--primary button--narrow button--top-space" type="submit">{% trans "Set" %}</button>
                     </fieldset>
                 </form>
             {% else %}
-                <span class="text-red-500">{% trans "Can't switch language. Only one language is active." %}</span>
+                <span class="text-red-500">{% trans "Can't switch language, only one language is active." %}</span>
             {% endif %}
         </div>
     </div>

--- a/hypha/templates/includes/language-switcher.html
+++ b/hypha/templates/includes/language-switcher.html
@@ -34,10 +34,12 @@
         </header>
 
         <div id="id-language-switcher" class="p-4">
+            {% get_available_languages as LANGUAGES %}
             {% get_language_info_list for LANGUAGES as languages %}
             {% if languages|length > 1 %}
-                <form action="" method="post" class="my-2">
+                <form action="{% url 'set_language' %}" method="post" class="my-2">
                     {% csrf_token %}
+                    <input name="next" type="hidden" value="{{ request.path }}">
                     <fieldset class="grid grid-cols-2 gap-x-4">
                         {% for language in languages %}
                             <div>

--- a/hypha/templates/includes/language-switcher.html
+++ b/hypha/templates/includes/language-switcher.html
@@ -21,14 +21,16 @@
         x-trap="open"
         x-transition
         x-transition.origin.top
+        role="dialog"
+        aria-labelledby="dialogtitle"
         @click.outside="open = false"
         class="overflow-y-scroll fixed top-0 z-30 bg-white rounded border shadow-md md:absolute md:top-auto start-0 end-0 md:start-auto md:min-w-[400px] md:max-h-[500px]"
     >
         <header class="flex gap-2 justify-between items-center py-2 px-3 bg-gray-100 border-b subheading">
-            <span class="font-medium SubMenuHeading text-inherit">
+            <span id="dialogtitle" class="font-medium">
                 {% trans "Language switcher" %}
             </span>
-            <button type="button" @click='open = false' class="opacity-70 appearance-none hover:opacity-100">
+            <button type="button" @click='open = false' class="opacity-70 appearance-none hover:opacity-100" aria-label="{% trans "Close" %}">
                 {% heroicon_solid "x-mark" aria_hidden="true" fill="currentColor" %}
             </button>
         </header>
@@ -44,10 +46,10 @@
                         {% for language in languages %}
                             <div>
                                 <input class="sr-only" name="language" id="{{ language.code }}" value="{{ language.code }}" type="radio" {% if language.code == LANGUAGE_CODE %}checked{% endif %}>
-                                <label class="font-semibold capitalize {% if language.code != LANGUAGE_CODE %}cursor-pointer hover:underline text-dark-blue{% endif %}" for="{{ language.code }}" x-on:click="$nextTick(() => { $refs.langForm.submit() })">{{ language.name_local }}</label>
+                                <label lang="{{ language.code }}" class="font-semibold capitalize {% if language.code != LANGUAGE_CODE %}cursor-pointer hover:underline text-dark-blue{% endif %}" for="{{ language.code }}" x-on:click="$nextTick(() => { $refs.langForm.submit() })">{{ language.name_local }}</label>
                             </div>
                         {% endfor %}
-                        <button class="sr-only button button--primary button--narrow button--top-space" type="submit">{% trans "Set" %}</button>
+                        <button class="sr-only button button--primary button--narrow button--top-space" type="submit">{% trans "Set language" %}</button>
                     </fieldset>
                 </form>
             {% else %}

--- a/hypha/templates/includes/user_menu.html
+++ b/hypha/templates/includes/user_menu.html
@@ -30,6 +30,17 @@
                 {% heroicon_outline "user" size=18 class="inline transition-transform group-hover:scale-110 group-hover:stroke-2 stroke-gray-500 group-hover:stroke-dark-blue" aria_hidden=true %}
                 {% trans 'My account' %}
             </a>
+            {% if LANGUAGE_SWITCHER %}
+                <a
+                    class="flex gap-2 items-center py-2 px-3 text-black transition-colors hover:font-semibold outline-1 border-x group hover:bg-slate-100 hover:text-dark-blue focus-visible:outline-dashed"
+                    hx-get="{% url 'users:hijack' %}?next={{ request.path }}"
+                    hx-target="#htmx-modal"
+                    x-on:click="show = false"
+                >
+                    {% heroicon_outline "language" size=18 class="inline transition-transform group-hover:scale-110 group-hover:stroke-2 stroke-gray-500 group-hover:stroke-dark-blue" aria_hidden=true %}
+                    {% trans "Language" %}
+                </a>
+            {% endif %}
             {% if request.user.is_apply_staff %}
                 <a
                     href="{% url 'activity:notifications' %}"

--- a/hypha/templates/includes/user_menu.html
+++ b/hypha/templates/includes/user_menu.html
@@ -30,17 +30,6 @@
                 {% heroicon_outline "user" size=18 class="inline transition-transform group-hover:scale-110 group-hover:stroke-2 stroke-gray-500 group-hover:stroke-dark-blue" aria_hidden=true %}
                 {% trans 'My account' %}
             </a>
-            {% if LANGUAGE_SWITCHER %}
-                <a
-                    class="flex gap-2 items-center py-2 px-3 text-black transition-colors hover:font-semibold outline-1 border-x group hover:bg-slate-100 hover:text-dark-blue focus-visible:outline-dashed"
-                    hx-get="{% url 'users:hijack' %}?next={{ request.path }}"
-                    hx-target="#htmx-modal"
-                    x-on:click="show = false"
-                >
-                    {% heroicon_outline "language" size=18 class="inline transition-transform group-hover:scale-110 group-hover:stroke-2 stroke-gray-500 group-hover:stroke-dark-blue" aria_hidden=true %}
-                    {% trans "Language" %}
-                </a>
-            {% endif %}
             {% if request.user.is_apply_staff %}
                 <a
                     href="{% url 'activity:notifications' %}"

--- a/hypha/urls.py
+++ b/hypha/urls.py
@@ -45,6 +45,11 @@ urlpatterns = [
     path("tinymce/", include("tinymce.urls")),
 ]
 
+if settings.LANGUAGE_SWITCHER:
+    urlpatterns = [
+        path("i18n/", include("django.conf.urls.i18n")),
+    ] + urlpatterns
+
 if settings.HIJACK_ENABLE:
     urlpatterns = [
         path("hijack/", include("hijack.urls", "hijack")),


### PR DESCRIPTION
Fixes #4398

- [x] Add django.middleware.locale.LocaleMiddleware
- [x] Set LANGUAGE_COOKIE_NAME to hypha_language
- [x] Add a language switcher that sets the language cookie
- [x] Make the language switcher accessible.

With "django.middleware.locale.LocaleMiddleware" Hypha will look for language preference in the following order:

1. Language set in the language cookie
2. Language set in users browser (Accept-Language HTTP header)
3. Language set in "LANGUAGE_CODE"

![Skärmavbild 2025-02-20 kl  14 55 09](https://github.com/user-attachments/assets/36c07676-3556-4867-983e-d1e157e6327f)


## Test Steps

 - [ ] Set LANGUAGE_SWITCHER to True
 - [ ] Confirm that the language switcher gets added to the header.
 - [ ] Confirm that switching language is possible and that the "hypha_language" cookie gets set.