### PR TITLE
Fix alpinejs discrepencies, typos in review score

### DIFF
--- a/hypha/apply/review/templates/review/review_edit_form.html
+++ b/hypha/apply/review/templates/review/review_edit_form.html
@@ -20,10 +20,10 @@
 
     <div class="relative my-8" x-data="reviewScore">
         <!-- Review score sticky display -->
-        <div class="hidden absolute top-0 right-0 h-full lg:block">
+        <div class="absolute top-0 right-0 h-full lg:block">
             <div
                 class="inline-block sticky top-1 py-1.5 px-3 mt-1 font-semibold text-center text-white bg-arsenic"
-                x-clock
+                x-cloak
                 x-show="showScore"
             >
                 {% trans "Score:" %} <span x-text="totalScore">-</span>
@@ -73,7 +73,7 @@
                     </button>
                 {% endif %}
 
-                <div class="text-fg-muted" x-clock x-show="showScore">
+                <div class="text-fg-muted" x-cloak x-show="showScore">
                     {% trans "Total Score:" %} <span x-text="totalScore"></span>
                 </div>
             </div>

--- a/hypha/apply/review/templates/review/review_form.html
+++ b/hypha/apply/review/templates/review/review_form.html
@@ -30,10 +30,10 @@
     {% include "forms/includes/form_errors.html" with form=form %}
 
     <section class="flex relative justify-between my-8" x-data="reviewScore">
-        <div class="hidden absolute top-0 right-0 h-full lg:block">
+        <div class="absolute top-0 right-0 h-full lg:block">
             <div
                 class="inline-block sticky top-1 py-1.5 px-3 mt-1 font-semibold text-center text-white bg-arsenic float-end"
-                x-clock
+                x-cloak
                 x-show="showScore"
             >
                 {% trans "Score:" %} <span x-text="totalScore">-</span>
@@ -74,7 +74,7 @@
                     <button class="button button--primary min-w-48" type="submit" name="submit">
                         {% trans "Submit" %}
                     </button>
-                    <div class="text-fg-muted" x-clock x-show="showScore">
+                    <div class="text-fg-muted" x-cloak x-show="showScore">
                         {% trans "Total Score:" %} <span x-text="totalScore"></span>
                     </div>
                 </div>


### PR DESCRIPTION
alpinejs, when using x-show, doesn't need the element to be hidden, as it will take care of that.  Also, x-clock should be x-cloak

Found this bug when I was merging our codebases together, and the score floating widget wasn't showing up.  The one next to the submit buttons was though.

The floating score does interact somewhat poorly with the application when "Show Application" is viewed.

I didn't create an issue for this, let me know if you want me to!