### PR TITLE
Implement modern text wrap pretty and balance

### DIFF
--- a/hypha/static_src/sass/base/_base.scss
+++ b/hypha/static_src/sass/base/_base.scss
@@ -37,6 +37,15 @@ a {
 
 p {
     margin-block: 0.5rem;
+    text-wrap: pretty;
+}
+
+dd {
+    text-wrap: pretty;
+}
+
+li {
+    text-wrap: pretty;
 }
 
 details {

--- a/hypha/static_src/sass/base/_typography.scss
+++ b/hypha/static_src/sass/base/_typography.scss
@@ -12,6 +12,7 @@ h6,
     margin-block: 0 1rem;
     font-style: inherit;
     font-weight: variables.$weight--semibold;
+    text-wrap: balance;
 }
 
 // Default sizes


### PR DESCRIPTION
Balance has good support but pretty only works in chromium bases browsers for now.

Balance: for all heading, h1-h6
Pretty: for p, and li tags (anything with long texts.)

See https://developer.mozilla.org/en-US/docs/Web/CSS/text-wrap