### PR TITLE
Show and link to associated project in submisison list view

### DIFF
--- a/hypha/apply/funds/templates/funds/includes/submission-list-row.html
+++ b/hypha/apply/funds/templates/funds/includes/submission-list-row.html
@@ -119,6 +119,10 @@
                             {{ s.page }}</a>
                     {% endif %}
                 {% endif %}
+
+                {% if s.project %}
+                    • <a href="{% url "apply:projects:detail" s.id %}" class="hover:underline text-inherit">{% trans "Project" %}</a>
+                {% endif %}
             </p>
         </div>
     </div>

--- a/hypha/apply/funds/templates/funds/includes/submission-table-row.html
+++ b/hypha/apply/funds/templates/funds/includes/submission-table-row.html
@@ -49,10 +49,14 @@
             #{{ s.public_id|default:s.id }}
             submitted <relative-time datetime="{{ s.submit_time|date:"c" }}">{{ s.submit_time|date:"SHORT_DATE_FORMAT" }}</relative-time>
             • {{ s.stage }}
+            {% if s.project %}
+                • <a href="{% url "apply:projects:detail" s.id %}" class="hover:underline text-inherit">{% trans "Project" %}</a>
+            {% endif %}
         </div>
     </td>
 
     <td class="p-2 text-center align-top">
+
         <a
             hx-target="#main"
             hx-push-url="true"


### PR DESCRIPTION
Add a non-intrustive way to display that a submission/application has
been converted to project and also link to the project tab directly from
it.

I considered showing the status of the project as well, but it felt little
too much of info, so just displaying the text - "Project"

![Screenshot 2025-02-25 at 3  39 13@2x](https://github.com/user-attachments/assets/39283430-0471-4007-8bb5-aea3c9300a31)

