### PR TITLE
Can not use i18n when sending mail with MarkdownMail.

### DIFF
--- a/hypha/apply/users/views.py
+++ b/hypha/apply/users/views.py
@@ -737,9 +737,7 @@ def send_confirm_access_email_view(request):
         "user": request.user,
         "timeout_minutes": settings.PASSWORDLESS_LOGIN_TIMEOUT // 60,
     }
-    subject = _("Confirmation code for {org_long_name}: {token}").format(
-        **email_context
-    )
+    subject = "Confirmation code for {org_long_name}: {token}".format(**email_context)
     email = MarkdownMail("users/emails/confirm_access.md")
     email.send(
         to=request.user.email,


### PR DESCRIPTION
Fix https://otf.sentry.io/issues/6334022483/?project=1268368&referrer=slack

