### PR TITLE
Fixed translate `_` being overwritten in elevate email confirmation

### DIFF
--- a/hypha/apply/users/views.py
+++ b/hypha/apply/users/views.py
@@ -724,7 +724,7 @@ class PasswordlessSignupView(TemplateView):
 @login_required
 def send_confirm_access_email_view(request):
     """Sends email with link to login in an elevated mode."""
-    token_obj, _ = ConfirmAccessToken.objects.update_or_create(
+    token_obj, created = ConfirmAccessToken.objects.update_or_create(
         user=request.user, token=generate_numeric_token
     )
     email_context = {


### PR DESCRIPTION
Fixes #4450 as the translate `_(...)` was being overwritten earlier in the code