### PR TITLE
Fix name of python image in Dockerfile

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.12-9-bookworm
+FROM python:3.12.9-bookworm
 
 # Add venv/bin to PATH.
 ENV PATH="/opt/app/.venv/bin:/usr/local/bin:$PATH"


### PR DESCRIPTION
I noticed I was unable to build an image with the provided Dockerfile. It turns out there's a typo in the image name.

## Test Steps

`cd docker && docker build .`
