### PR TITLE
Fixes for bugs around exporting applications

### DIFF
--- a/hypha/apply/funds/blocks.py
+++ b/hypha/apply/funds/blocks.py
@@ -176,6 +176,7 @@ class DurationBlock(ApplicationSingleIncludeFieldBlock):
         12: "12 months",
         18: "18 months",
         24: "24 months",
+        36: "36 months",
     }
     field_class = forms.ChoiceField
     duration_type = blocks.ChoiceBlock(

--- a/hypha/apply/funds/utils.py
+++ b/hypha/apply/funds/utils.py
@@ -118,7 +118,7 @@ def export_submissions_to_csv(submissions_list, request):
             question_field = submission.serialize(field_id)
             field_name = question_field["question"]
             field_value = question_field["answer"]
-            if field_id == "address":
+            if field_id == "address" and isinstance(field_value, dict):
                 address = []
                 for key, value in field_value.items():
                     address.append(f"{key}: {value}")


### PR DESCRIPTION
<!--
Thanks for contributing to Hypha!

Please ensure your contributions pass all necessary linting/testing and that the appropriate documentation has been updated.
-->

<!--
Describe briefly what your pull request changes. If this is resolving an issue, please specify below via "Fixes #<Github Issue ID>"
-->
Fixes #4460 along with another issue where a month duration somehow had a value of `36` (I believe it was an older application, so maybe some removed code?) so I added it to the duration block's constants. Once this gets merged I'm going to add translation strings for the duration block too as I noticed it was missing a few

## Test Steps
<!-- 
If step does not require manual testing, skip/remove this section.

Give a brief overview of the steps required for a user/dev to test this contribution. Important things to include:
 - Required user roles for where necessary (ie. "As a Staff Admin...")
 - Clear & validatable expected results (ie. "Confirm the submit button is now not clickable")
 - Language that can be understood by non-technical testers if being tested by users
-->

 - [ ] Ensure applications that have address fields containing `-`/no value don't result in an error when exporting