### PR TITLE
Update view link to use heroicon instead of SVG

### DIFF
--- a/hypha/apply/activity/templates/activity/ui/activity-comment-item.html
+++ b/hypha/apply/activity/templates/activity/ui/activity-comment-item.html
@@ -96,8 +96,8 @@
                         <div class="px-3">
                             {% with url=activity.related_object.get_absolute_url %}
                                 {% if url %}
-                                    <a href="{{ url }}">
-                                        {% trans "View " %}{{ activity.related_object|model_verbose_name }} <svg class="inline icon"><use xlink:href="#arrow-head-pixels--solid"></use></svg>
+                                    <a href="{{ url }}" class="font-semibold uppercase">
+                                        {% trans "View " %}{{ activity.related_object|model_verbose_name }} {% heroicon_outline "arrow-right" aria_hidden="true" stroke_width=2 class="inline w-4 h-4 align-baseline ms-1" %}
                                     </a>
                                 {% endif %}
                             {% endwith %}


### PR DESCRIPTION
Update the "View Determination" to use heroicons instead of svg.

Also, the svg sprite was missing.

## Before

![Screenshot 2025-03-23 at 8  07 47@2x](https://github.com/user-attachments/assets/7813ad63-4cd3-4440-9ad1-5ff0f45a1783)


## After
![Screenshot 2025-03-23 at 8  06 55@2x](https://github.com/user-attachments/assets/78157360-b69b-40f0-a7e0-f54a3205baf8)

