### PR TITLE
Modernize the task-list UI

### DIFF
--- a/hypha/apply/activity/templates/activity/notifications.html
+++ b/hypha/apply/activity/templates/activity/notifications.html
@@ -35,7 +35,7 @@
                             <div class="relative timeline-item" id="communications#{{ activity.id }}">
                                 {% ifchanged activity.source.id %}
                                     <div class="py-0.5 mt-4 bg-gray-100 ps-5 pe-2 border-s-2 border-slate-300">
-                                        <span class="text-sm font-semibold text-fg-muted">{{ activity.source_content_type.name|source_type }}</span> <a href="{{ activity.source.get_absolute_url }}">{{ activity.source.fund_name }} #{{ activity.source.application_id }}: {{ activity.source.title|capfirst|truncatechars:50|truncatechars:50 }}</a>
+                                        <span class="text-sm font-semibold text-fg-muted">{{ activity.source_content_type.name|source_type }}</span> <a href="{{ activity.source.get_absolute_url }}">{{ activity.source.fund_name }} #{{ activity.source.application_id }}: {{ activity.source.title|capfirst|truncatechars:50 }}</a>
                                     </div>
                                 {% endifchanged %}
                                 <div

--- a/hypha/apply/activity/templates/activity/notifications.html
+++ b/hypha/apply/activity/templates/activity/notifications.html
@@ -35,7 +35,7 @@
                             <div class="relative timeline-item" id="communications#{{ activity.id }}">
                                 {% ifchanged activity.source.id %}
                                     <div class="py-0.5 mt-4 bg-gray-100 ps-5 pe-2 border-s-2 border-slate-300">
-                                        <span class="text-sm font-semibold text-fg-muted">{{ activity.source_content_type.name|source_type }}</span> <a href="{{ activity.source.get_absolute_url }}">{{ activity.source.title|capfirst }}</a>
+                                        <span class="text-sm font-semibold text-fg-muted">{{ activity.source_content_type.name|source_type }}</span> <a href="{{ activity.source.get_absolute_url }}">{{ activity.source.fund_name }} #{{ activity.source.application_id }}: {{ activity.source.title|capfirst|truncatechars:50|truncatechars:50 }}</a>
                                     </div>
                                 {% endifchanged %}
                                 <div

--- a/hypha/apply/activity/templates/messages/email/batch_ready_to_review.html
+++ b/hypha/apply/activity/templates/messages/email/batch_ready_to_review.html
@@ -6,7 +6,7 @@
 {% block content %}{# fmt:off #}
 {% trans "New applications have been added to your review list." %}
 {% for submission in sources %}
-{% trans "ID" %}: {{ submission.public_id|default:submission.id }}
+{% trans "ID" %}: {{ submission.application_id }}
 {% trans "Title" %}: {{ submission.title }}
 {% trans "Link" %}: {{ request.scheme }}://{{ request.get_host }}{{ submission.get_absolute_url }}
 {% endfor %}

--- a/hypha/apply/activity/templates/messages/email/partners_update_applicant.html
+++ b/hypha/apply/activity/templates/messages/email/partners_update_applicant.html
@@ -6,7 +6,7 @@
 {% for partner in added %}
     * {{ partner }}
 {% endfor %}
-{% trans "ID" %}: {{ source.public_id|default:source.id }}
+{% trans "ID" %}: {{ source.application_id }}
 {% trans "Title" %}: {{ source.title }}
 {% trans "Link" %}: {{ request.scheme }}://{{ request.get_host }}{{ source.get_absolute_url }}
 {% endblock %}{# fmt:on #}

--- a/hypha/apply/activity/templates/messages/email/partners_update_partner.html
+++ b/hypha/apply/activity/templates/messages/email/partners_update_partner.html
@@ -6,7 +6,7 @@
 {% block content %}{# fmt:off #}
 {% trans "You have been added as a partner the following submission." %}
 
-{% trans "ID" %}: {{ source.public_id|default:source.id }}
+{% trans "ID" %}: {{ source.application_id }}
 {% trans "Title" %}: {{ source.title }}
 {% trans "Link" %}: {{ request.scheme }}://{{ request.get_host }}{{ source.get_absolute_url }}
 {% endblock %}{# fmt:on #}

--- a/hypha/apply/activity/templates/messages/email/submission_confirmation.html
+++ b/hypha/apply/activity/templates/messages/email/submission_confirmation.html
@@ -15,7 +15,7 @@
 
 {% with email_context=source.page.specific %}{{ email_context.confirmation_text_extra }}{% endwith %}
 
-{% trans "Project ID" %}: {{ source.public_id|default:source.id }}
+{% trans "Project ID" %}: {{ source.application_id }}
 {% trans "Project name" %}: {{ source.title }}
 {% trans "Contact name" %}: {{ source.user.get_full_name }}
 {% trans "Contact email" %}: {{ source.user.email }}

--- a/hypha/apply/dashboard/templates/dashboard/community_dashboard.html
+++ b/hypha/apply/dashboard/templates/dashboard/community_dashboard.html
@@ -52,7 +52,7 @@
                                 <h3 class="text-base font-bold heading heading--no-margin">
                                     <a class="{% if not submission.is_active %} text-slate-500 {% endif %} hover:underline" href="{% url 'funds:submissions:detail' submission.id %}">
                                         {{ submission.title }}
-                                        <span class="text-gray-400">#{{ submission.public_id|default:submission.id }}</span>
+                                        <span class="text-gray-400">#{{ submission.application_id }}</span>
                                     </a>
                                 </h3>
                                 <p class="text-sm heading heading--no-margin text-fg-muted">

--- a/hypha/apply/dashboard/templates/dashboard/includes/my-tasks.html
+++ b/hypha/apply/dashboard/templates/dashboard/includes/my-tasks.html
@@ -1,13 +1,13 @@
 {% load i18n %}
 
-<div class="mx-auto mb-10 max-w-3xl" id="task-list" hx-swap-oob="true">
+<section class="mx-auto mb-10 max-w-4xl" id="task-list" hx-swap-oob="true">
     {% if my_tasks.data %}
         <h2 class="font-light text-center">{% trans "My tasks" %}</h2>
 
         <div class="border divide-y shadow-xs task--list">
             {% for task in my_tasks.data %}
-                {% include "todo/todolist_item.html" with button_type_class="button--transparent" %}
+                {% include "todo/todolist_item.html" %}
             {% endfor %}
         </div>
     {% endif %}
-</div>
+</section>

--- a/hypha/apply/dashboard/templates/dashboard/partials/applicant_submissions.html
+++ b/hypha/apply/dashboard/templates/dashboard/partials/applicant_submissions.html
@@ -8,7 +8,7 @@
                 <h4 class="mb-0 font-bold heading line-clamp-3 hover:line-clamp-none">
                     <a class="{% if not submission.is_active %} text-slate-500 {% endif %} hover:underline" href="{% url 'funds:submissions:detail' submission.id %}">
                         {{ submission.title }}
-                        <span class="text-gray-400">#{{ submission.public_id|default:submission.id }}</span>
+                        <span class="text-gray-400">#{{ submission.application_id }}</span>
                     </a>
                 </h4>
                 <p class="m-0 mb-4 text-sm text-fg-muted">

--- a/hypha/apply/determinations/templates/determinations/determination_detail.html
+++ b/hypha/apply/determinations/templates/determinations/determination_detail.html
@@ -12,7 +12,9 @@
         {% endslot %}
 
         {% slot header %} {% trans "Determination" %} {% if determination.is_draft %}[{% trans "DRAFT" %}] {% endif %}{% endslot %}
-        {% slot sub_heading %}{% trans "For" %} <a class="text-blue-300 hover:underline" href="{% url "funds:submissions:detail" determination.submission.id %}">{{ determination.submission.title_text_display }}</a>{% endslot %}
+        {% slot sub_heading %}
+            {% trans "For" %} <a class="text-blue-300 hover:underline" href="{% url "funds:submissions:detail" determination.submission.id %}">{{ determination.submission.title_text_display }}</a>
+        {% endslot %}
 
     {% endadminbar %}
 

--- a/hypha/apply/determinations/templates/determinations/determination_detail.html
+++ b/hypha/apply/determinations/templates/determinations/determination_detail.html
@@ -7,7 +7,7 @@
     {% adminbar %}
         {% slot back_link %}
             <a class="admin-bar__back-link" href="{{ determination.submission.get_absolute_url }}">
-                {% trans "View submission" %}
+                {% trans "View application" %}
             </a>
         {% endslot %}
 

--- a/hypha/apply/determinations/templates/determinations/includes/determination_button.html
+++ b/hypha/apply/determinations/templates/determinations/includes/determination_button.html
@@ -1,6 +1,9 @@
 {% load i18n determination_tags workflow_tags %}
 {% if request.user|show_determination_button:submission %}
-    <a target="_blank" href="{% url 'apply:submissions:determinations:form' submission_pk=submission.id %}" class="button button--primary button--full-width {{ class }}">
+    <a
+        href="{% url 'apply:submissions:determinations:form' submission_pk=submission.id %}"
+        class="button button--primary button--full-width {{ class }}"
+    >
         {% if submission.determinations.last.is_draft %}
             {% if draft_text %}
                 {{ draft_text }}

--- a/hypha/apply/funds/management/commands/export_submissions_csv.py
+++ b/hypha/apply/funds/management/commands/export_submissions_csv.py
@@ -64,7 +64,7 @@ class Command(BaseCommand):
                     submission_value = 0
                 writer.writerow(
                     [
-                        submission.public_id or submission.id,
+                        submission.application_id,
                         submission.title,
                         submission.full_name,
                         submission.email,

--- a/hypha/apply/funds/models/submissions.py
+++ b/hypha/apply/funds/models/submissions.py
@@ -27,6 +27,7 @@ from django.db.models.functions import Cast
 from django.dispatch import receiver
 from django.urls import reverse
 from django.utils import timezone
+from django.utils.functional import cached_property
 from django.utils.html import strip_tags
 from django.utils.text import slugify
 from django.utils.translation import gettext_lazy as _
@@ -520,7 +521,9 @@ class ApplicationSubmission(
         """
         ctx = {
             "title": self.title,
-            "public_id": self.public_id or self.id,
+            "public_id": self.application_id,
+            "fund_name": self.fund_name,
+            "application_id": self.application_id,
         }
         return strip_tags(settings.SUBMISSION_TITLE_TEXT_TEMPLATE.format(**ctx))
 
@@ -599,6 +602,14 @@ class ApplicationSubmission(
         except AttributeError:
             # We are a lab submission
             return getattr(self.page.specific, attribute)
+
+    @cached_property
+    def fund_name(self):
+        return self.page
+
+    @cached_property
+    def application_id(self):
+        return self.public_id or self.id
 
     @property
     def is_determination_form_attached(self):
@@ -891,7 +902,7 @@ class ApplicationSubmission(
 
     def index_components(self):
         return {
-            "A": " ".join([f"id:{self.public_id or self.id}", self.title]),
+            "A": " ".join([f"id:{self.application_id}", self.title]),
             "C": " ".join([self.full_name, self.email]),
             "B": " ".join(self.get_searchable_contents()),
         }

--- a/hypha/apply/funds/models/submissions.py
+++ b/hypha/apply/funds/models/submissions.py
@@ -519,10 +519,12 @@ class ApplicationSubmission(
 
         Use SUBMISSION_TITLE_TEXT_TEMPLATE setting to change format.
         """
+
         ctx = {
             "title": self.title,
             "public_id": self.application_id,
             "fund_name": self.fund_name,
+            "round": self.round if self.round else self.page,
             "application_id": self.application_id,
         }
         return strip_tags(settings.SUBMISSION_TITLE_TEXT_TEMPLATE.format(**ctx))

--- a/hypha/apply/funds/templates/funds/applicationsubmission_detail.html
+++ b/hypha/apply/funds/templates/funds/applicationsubmission_detail.html
@@ -185,7 +185,7 @@
                                             {{ submission.title }}
                                         </a>
                                         <div class="text-sm text-fg-muted">
-                                            <span>#{{ submission.public_id|default:submission.id }}</span>
+                                            <span>#{{ submission.application_id }}</span>
                                             <relative-time datetime='{{ submission.submit_time|date:"c" }}'>{{ submission.submit_time|date:"SHORT_DATETIME_FORMAT" }}</relative-time>
                                             in {{ submission.round|default_if_none:submission.page }}
                                             &middot;

--- a/hypha/apply/funds/templates/funds/applicationsubmission_form.html
+++ b/hypha/apply/funds/templates/funds/applicationsubmission_form.html
@@ -1,11 +1,11 @@
 {% extends "base-apply.html" %}
 {% load i18n static %}
-{% block title %}{% trans "Editing" %}: {% if object.public_id %}{{ object.public_id }}: {% endif %}{{object.title }}{% endblock %}
+{% block title %}{% trans "Editing" %}: {{ object.application_id }}: {{object.title }}{% endblock %}
 {% block body_class %}bg-white{% endblock %}
 
 {% block content %}
     {% adminbar %}
-        {% slot header %}{% trans "Editing" %}: {{ object.title }} <span class="text-gray-400">#{{ object.public_id|default:object.id }}</span>{% endslot %}
+        {% slot header %}{% trans "Editing" %}: {{ object.title }} <span class="text-gray-400">#{{ object.application_id }}</span>{% endslot %}
     {% endadminbar %}
 
     {% include "forms/includes/form_errors.html" with form=form %}

--- a/hypha/apply/funds/templates/funds/includes/application_header.html
+++ b/hypha/apply/funds/templates/funds/includes/application_header.html
@@ -8,20 +8,19 @@
 <div class="mt-1 text-sm font-medium heading heading--meta">
     <span>
         {{ object.page }}
-        {% if object.round %} /
-            {% if request.user.is_apply_staff %}
-                <span>
-                    <a class="text-white hover:underline"
-                       href="{% url 'apply:submissions:list' %}?round={{ object.round.pk }}"
-                    >{{ object.round }}</a>
-                </span>
-            {% else %}
-                <span>{{ object.round }}</span>
-            {% endif %}
-        {% endif %}
-
-        #{{ object.application_id }}
     </span>
+
+    {% if object.round %}
+        {% if request.user.is_apply_staff %}
+            <span>
+                <a class="text-white hover:underline"
+                   href="{% url 'apply:submissions:list' %}?round={{ object.round.pk }}"
+                >{{ object.round }}</a>
+            </span>
+        {% else %}
+            <span>{{ object.round }}</span>
+        {% endif %}
+    {% endif %}
 
     <span>{{ object.stage }}</span>
 

--- a/hypha/apply/funds/templates/funds/includes/application_header.html
+++ b/hypha/apply/funds/templates/funds/includes/application_header.html
@@ -1,23 +1,29 @@
 {% load i18n statusbar_tags %}
 
 <h1 class="mb-0 font-medium">
-    <span id="app-title">{{ object.title }}</span><span class="text-gray-400"> #{{ object.public_id|default:object.id }}</span>
+    <span id="app-title">{{ object.title }}</span>
+    <span class="text-gray-400">#{{ object.application_id }}</span>
 </h1>
 
 <div class="mt-1 text-sm font-medium heading heading--meta">
-    <span>{{ object.stage }}</span>
-    <span>{{ object.page }}</span>
-    {% if object.round %}
-        {% if request.user.is_apply_staff %}
-            <span>
-                <a class="text-white underline"
-                   href="{% url 'apply:submissions:list' %}?round={{ object.round.pk }}"
-                >{{ object.round }}</a>
-            </span>
-        {% else %}
-            <span>{{ object.round }}</span>
+    <span>
+        {{ object.page }}
+        {% if object.round %} /
+            {% if request.user.is_apply_staff %}
+                <span>
+                    <a class="text-white hover:underline"
+                       href="{% url 'apply:submissions:list' %}?round={{ object.round.pk }}"
+                    >{{ object.round }}</a>
+                </span>
+            {% else %}
+                <span>{{ object.round }}</span>
+            {% endif %}
         {% endif %}
-    {% endif %}
+
+        #{{ object.application_id }}
+    </span>
+
+    <span>{{ object.stage }}</span>
 
     <span
         hx-get="{% url "apply:submissions:partial-get-lead" object.id %}"

--- a/hypha/apply/funds/templates/funds/includes/submission-list-row.html
+++ b/hypha/apply/funds/templates/funds/includes/submission-list-row.html
@@ -71,7 +71,7 @@
 
         <div class="pt-1">
             <p class="m-0 text-xs">
-                #{{ s.public_id|default:s.id }}
+                #{{ s.application_id }}
                 submitted <relative-time datetime="{{ s.submit_time|date:"c" }}">{{ s.submit_time|date:"SHORT_DATE_FORMAT" }}</relative-time>
                 {% if s|show_applicant_identity:request.user %}by <a
                     href="{% url "apply:submissions:list" %}{% modify_query "only_query_string" "page" applicants=s.user.id %}"

--- a/hypha/apply/funds/templates/funds/includes/submission-table-row.html
+++ b/hypha/apply/funds/templates/funds/includes/submission-table-row.html
@@ -46,7 +46,7 @@
             class="text-base font-semibold break-words transition-colors hover:text-blue-600 text-[#404041] line-clamp-2"
         >{{ s.form_data.title }}</a>
         <div class="text-xs text-fg-muted">
-            #{{ s.public_id|default:s.id }}
+            #{{ s.application_id }}
             submitted <relative-time datetime="{{ s.submit_time|date:"c" }}">{{ s.submit_time|date:"SHORT_DATE_FORMAT" }}</relative-time>
             • {{ s.stage }}
             {% if s.project %}

--- a/hypha/apply/funds/templates/submissions/partials/submission-lead.html
+++ b/hypha/apply/funds/templates/submissions/partials/submission-lead.html
@@ -1,11 +1,11 @@
 {% load i18n heroicons %}
 {% if request.user.is_apply_staff %}
-    <a class="transition-opacity hover:opacity-70 is-active"
+    <a class="flex items-center text-blue-400 transition-opacity hover:opacity-80 is-active"
        href="{% url 'funds:submissions:lead_update' pk=submission.pk %}"
        hx-get="{% url 'funds:submissions:lead_update' pk=submission.pk %}"
        hx-target="#htmx-modal"
     >
-        <u>{% trans "Lead" %}: {{ submission.lead }}</u>
+        {% trans "Lead" %}: {{ submission.lead }}
         {% heroicon_micro "pencil-square" class="inline ms-1" aria_hidden=true %}
     </a>
 {% elif request.user.is_org_faculty or not HIDE_STAFF_IDENTITY %}

--- a/hypha/apply/funds/templates/submissions/partials/submission-title.html
+++ b/hypha/apply/funds/templates/submissions/partials/submission-title.html
@@ -1,1 +1,1 @@
-<h1 class="mb-0 font-medium">{{ object.title }}<span class="text-gray-400"> #{{ object.public_id|default:object.id }}</span></h1>
+<h1 class="mb-0 font-medium">{{ object.title }}<span class="text-gray-400"> #{{ object.application_id }}</span></h1>

--- a/hypha/apply/funds/templatetags/submission_tags.py
+++ b/hypha/apply/funds/templatetags/submission_tags.py
@@ -20,8 +20,8 @@ def submission_links(value):
             Q(id__in=numeric_ids) | Q(public_id__in=matches)
         )
         for submission in qs:
-            links[rf"\#{submission.public_id or submission.id}"] = (
-                f'<a href="{submission.get_absolute_url()}">{submission.title} <span class="text-gray-400">#{submission.public_id or submission.id}</span></a>'
+            links[rf"\#{submission.application_id}"] = (
+                f'<a href="{submission.get_absolute_url()}">{submission.title} <span class="text-gray-400">#{submission.application_id}</span></a>'
             )
 
     if links:

--- a/hypha/apply/funds/templatetags/submission_tags.py
+++ b/hypha/apply/funds/templatetags/submission_tags.py
@@ -20,8 +20,8 @@ def submission_links(value):
             Q(id__in=numeric_ids) | Q(public_id__in=matches)
         )
         for submission in qs:
-            links[rf"\#{submission.application_id}"] = (
-                f'<a href="{submission.get_absolute_url()}">{submission.title} <span class="text-gray-400">#{submission.application_id}</span></a>'
+            links[f"#{submission.application_id}"] = (
+                f'<a href="{submission.get_absolute_url()}">{submission.title_text_display}</a>'
             )
 
     if links:

--- a/hypha/apply/funds/tests/test_tags.py
+++ b/hypha/apply/funds/tests/test_tags.py
@@ -15,17 +15,15 @@ class TestTemplateTags(TestCase):
         )
 
     def test_submission_tags(self):
-        submission = ApplicationSubmissionFactory()
+        submission = ApplicationSubmissionFactory(public_id="S123")
         template = Template(
             "{% load submission_tags %}{{ content|submission_links|safe }}"
         )
-        context = Context(
-            {"content": f"Lorem ipsum dolor #{submission.application_id} sit amet."}
-        )
+        context = Context({"content": "Lorem ipsum dolor #S123 sit amet."})
         output = template.render(context)
         assert (
             output
-            == f'Lorem ipsum dolor <a href="{submission.get_absolute_url()}">{submission.title} <span class="text-gray-400">#{submission.application_id}</span></a> sit amet.'
+            == f'Lorem ipsum dolor <a href="{submission.get_absolute_url()}">{submission.title_text_display}</a> sit amet.'
         )
 
     @override_settings(APPLICATION_TRANSLATIONS_ENABLED=True)

--- a/hypha/apply/funds/tests/test_tags.py
+++ b/hypha/apply/funds/tests/test_tags.py
@@ -20,12 +20,12 @@ class TestTemplateTags(TestCase):
             "{% load submission_tags %}{{ content|submission_links|safe }}"
         )
         context = Context(
-            {"content": f"Lorem ipsum dolor #{submission.public_id} sit amet."}
+            {"content": f"Lorem ipsum dolor #{submission.application_id} sit amet."}
         )
         output = template.render(context)
         assert (
             output
-            == f'Lorem ipsum dolor <a href="{submission.get_absolute_url()}">{submission.title} <span class="text-gray-400">#{submission.public_id or submission.id}</span></a> sit amet.'
+            == f'Lorem ipsum dolor <a href="{submission.get_absolute_url()}">{submission.title} <span class="text-gray-400">#{submission.application_id}</span></a> sit amet.'
         )
 
     @override_settings(APPLICATION_TRANSLATIONS_ENABLED=True)

--- a/hypha/apply/projects/models/project.py
+++ b/hypha/apply/projects/models/project.py
@@ -25,6 +25,7 @@ from django.db.models.signals import post_delete
 from django.dispatch.dispatcher import receiver
 from django.urls import reverse
 from django.utils import timezone
+from django.utils.functional import cached_property
 from django.utils.translation import gettext_lazy as _
 from modelcluster.fields import ParentalKey, ParentalManyToManyField
 from modelcluster.models import ClusterableModel
@@ -307,6 +308,14 @@ class Project(BaseStreamForm, AccessFormData, models.Model):
     @property
     def status_display(self):
         return self.get_status_display()
+
+    @cached_property
+    def fund_name(self):
+        return self.submission.fund_name
+
+    @cached_property
+    def application_id(self):
+        return self.submission.application_id
 
     def get_address_display(self):
         return ""  # todo: need to figure out

--- a/hypha/apply/projects/templates/application_projects/includes/project_header.html
+++ b/hypha/apply/projects/templates/application_projects/includes/project_header.html
@@ -9,7 +9,7 @@
 </h1>
 
 <div class="mt-1 text-sm font-medium heading heading--meta">
-    <span>{{ object.submission.page }}</span>
+    <span>{{ object.fund_name }}</span>
 
     {% if object.submission.round %}
         {% if request.user.is_apply_staff %}

--- a/hypha/apply/projects/templates/application_projects/partials/project_title.html
+++ b/hypha/apply/projects/templates/application_projects/partials/project_title.html
@@ -1,7 +1,7 @@
 {% load heroicons i18n %}
 
 <span id="app-title">{{ object.title }}</span>
-<span class="text-gray-400">#{{ object.submission.public_id|default:object.submission.id }}</span>
+<span class="text-gray-400">#{{ object.submission.application_id }}</span>
 
 {% if request.user.is_apply_staff %}
     <a class="transition-opacity hover:opacity-70 is-active"

--- a/hypha/apply/projects/templates/application_projects/report_detail.html
+++ b/hypha/apply/projects/templates/application_projects/report_detail.html
@@ -10,7 +10,7 @@
                 {% trans "View project page" %}
             </a>
         {% endslot %}
-        {% slot header %}{{ object.project.title }} <span class="text-gray-400">#{{ object.project.submission.public_id|default:object.project.submission.id }}</span>{% endslot %}
+        {% slot header %}{{ object.project.title }} <span class="text-gray-400">#{{ object.project.application_id }}</span>{% endslot %}
         {% slot sub_heading %}{% trans "Report" %}{% endslot %}
     {% endadminbar %}
 

--- a/hypha/apply/review/templates/review/includes/review_button.html
+++ b/hypha/apply/review/templates/review/includes/review_button.html
@@ -1,7 +1,7 @@
 {% load i18n review_tags workflow_tags %}
 {% if request.user|has_review_perm:submission %}
     {% if request.user|has_draft:submission or request.user|can_review:submission %}
-        <a target="_blank" href="{% url 'apply:submissions:reviews:form' submission_pk=submission.id %}" class="button button--primary {{ class }}">
+        <a href="{% url 'apply:submissions:reviews:form' submission_pk=submission.id %}" class="button button--primary {{ class }}">
             {% if request.user|has_draft:submission %}
                 {{ draft_text|default:"Update draft" }}
             {% elif request.user|can_review:submission %}

--- a/hypha/apply/review/templates/review/review_detail.html
+++ b/hypha/apply/review/templates/review/review_detail.html
@@ -6,12 +6,12 @@
     {% adminbar %}
         {% slot back_link %}
             <a class="admin-bar__back-link" href="{{ review.submission.get_absolute_url }}">
-                {% trans "View submission" %}
+                {% trans "View application" %}
             </a>
         {% endslot %}
         {% slot header %}{% trans "Review" %}{% endslot %}
         {% slot sub_heading %}
-            {% trans "For" %}: {{ review.submission.title }} {% trans "by" %}
+            {% trans "For" %} {{ review.submission.title_text_display }} {% trans "by" %}
             {% if HIDE_STAFF_IDENTITY and not request.user.is_org_faculty and not request.user == review.author.reviewer %}
                 {% trans "Reviewer" %}
             {% else %}

--- a/hypha/apply/review/templates/review/review_form.html
+++ b/hypha/apply/review/templates/review/review_form.html
@@ -12,7 +12,7 @@
     {% adminbar %}
         {% slot header %}{{ title }}{% endslot %}
         {% slot sub_heading %}
-            {% trans "For" %} <a class="text-blue-300 hover:underline" href="{% url "funds:submissions:detail" submission.id %}">{{ submission.title }}</a>
+            <a class="text-gray-200 hover:underline" href="{% url "funds:submissions:detail" submission.id %}">{{ submission.title_text_display }}</a>
         {% endslot %}
         {% slot buttons %}
             <button

--- a/hypha/apply/todo/options.py
+++ b/hypha/apply/todo/options.py
@@ -62,7 +62,7 @@ template_map = {
     # :todo: actions for multiple stages of submission
     SUBMISSION_DRAFT: {
         "text": _(
-            '<span class="text-xs">{related.fund_name} #{related.application_id}</span><br>A draft application <span class="truncate inline-block max-w-32 align-bottom ">"{related.title}")</span> is waiting to be submitted'
+            '<span class="text-xs">{related.fund_name} #{related.application_id}</span><br>A draft application <span class="truncate inline-block max-w-32 align-bottom ">"{related.title}"</span> is waiting to be submitted'
         ),
         "icon": "chat-bubble-left-ellipsis",
         "url": "{link}",

--- a/hypha/apply/todo/options.py
+++ b/hypha/apply/todo/options.py
@@ -52,7 +52,7 @@ template_map = {
     # Use heroicons for "icon".
     COMMENT_TASK: {
         "text": _(
-            '{related.user} assigned you a comment on [<span class="truncate inline-block max-w-32 align-bottom ">{related.source.title}</span>]({link} "{related.source.title}"):\n<span class="line-clamp-2 italic align-bottom ">{msg}</span>'
+            '<span class="text-xs">{related.source.fund_name} #{related.source.application_id}</span><br>{related.user} assigned you a comment: <q class="text-fg-muted italic align-bottom">{msg}</q>'
         ),
         "icon": "chat-bubble-left-ellipsis",
         "url": "{link}",
@@ -62,7 +62,7 @@ template_map = {
     # :todo: actions for multiple stages of submission
     SUBMISSION_DRAFT: {
         "text": _(
-            'A Submission draft [<span class="truncate inline-block max-w-32 align-bottom ">{related.title}</span>]({link} "{related.title}") is waiting to be submitted'
+            '<span class="text-xs">{related.fund_name} #{related.application_id}</span><br>A draft application <span class="truncate inline-block max-w-32 align-bottom ">"{related.title}")</span> is waiting to be submitted'
         ),
         "icon": "chat-bubble-left-ellipsis",
         "url": "{link}",
@@ -70,7 +70,7 @@ template_map = {
     },
     DETERMINATION_DRAFT: {
         "text": _(
-            'Determination draft for submission [<span class="truncate inline-block max-w-32 align-bottom ">{related.submission.title}</span>]({link} "{related.submission.title}") is waiting to be submitted',
+            '<span class="text-xs">{related.fund_name} #{related.application_id}</span><br>Determination draft for submission <span class="truncate inline-block max-w-32 align-bottom">"{related.submission.title}"</span> is waiting to be submitted',
         ),
         "icon": "pencil-square",
         "url": "{link}",
@@ -78,7 +78,7 @@ template_map = {
     },
     REVIEW_DRAFT: {
         "text": _(
-            'Review draft for submission [<span class="truncate inline-block max-w-32 align-bottom ">{related.submission.title}</span>]({link} "{related.submission.title}") is waiting to be submitted'
+            '<span class="text-xs">{related.submission.fund_name} #{related.submission.application_id}</span><br>Review draft for submission <span class="truncate inline-block max-w-32 align-bottom">"{related.submission.title}"</span> is waiting to be submitted'
         ),
         "icon": "pencil-square",
         "url": "{link}",
@@ -88,7 +88,7 @@ template_map = {
     # draft state (staff action)
     PROJECT_WAITING_PF: {
         "text": _(
-            'Project [<span class="truncate inline-block max-w-32 align-bottom ">{related.title}</span>]({link} "{related.title}") is waiting for project form'
+            '<span class="text-xs">{related.fund_name} #{related.application_id}</span><br>Project is waiting for project form'
         ),
         "icon": "clipboard-document-list",
         "url": "{link}",
@@ -96,7 +96,7 @@ template_map = {
     },
     PROJECT_WAITING_SOW: {
         "text": _(
-            'Project [<span class="truncate inline-block max-w-32 align-bottom ">{related.title}</span>]({link} "{related.title}") is waiting for scope of work'
+            '<span class="text-xs">{related.fund_name} #{related.application_id}</span><br>Project is waiting for scope of work'
         ),
         "icon": "clipboard-document-list",
         "url": "{link}",
@@ -104,7 +104,7 @@ template_map = {
     },
     PROJECT_SUBMIT_PAF: {
         "text": _(
-            'Project [<span class="truncate inline-block max-w-32 align-bottom ">{related.title}</span>]({link} "{related.title}") is waiting for project form(s) submission'
+            '<span class="text-xs">{related.fund_name} #{related.application_id}</span><br>Project is waiting for project form(s) submission'
         ),
         "icon": "clipboard-document-list",
         "url": "{link}",
@@ -112,7 +112,7 @@ template_map = {
     },
     PAF_REQUIRED_CHANGES: {
         "text": _(
-            'Project form for project [<span class="truncate inline-block max-w-32 align-bottom ">{related.title}</span>]({link} "{related.title}") required changes or more information'
+            '<span class="text-xs">{related.fund_name} #{related.application_id}</span><br>Project form requires changes or more information'
         ),
         "icon": "clipboard-document-list",
         "url": "{link}",
@@ -121,7 +121,7 @@ template_map = {
     # internal approval state (approvers/finance... action)
     PAF_WAITING_ASSIGNEE: {
         "text": _(
-            'Project form for project [<span class="truncate inline-block max-w-32 align-bottom ">{related.title}</span>]({link} "{related.title}") is waiting for assignee'
+            '<span class="text-xs">{related.fund_name} #{related.application_id}</span><br>Project form is waiting for assignee'
         ),
         "icon": "clipboard-document-list",
         "url": "{link}",
@@ -129,7 +129,7 @@ template_map = {
     },
     PAF_WAITING_APPROVAL: {
         "text": _(
-            'Project form for project [<span class="truncate inline-block max-w-32 align-bottom ">{related.title}</span>]({link} "{related.title}") is waiting for your approval'
+            '<span class="text-xs">{related.submission.fund_name} #{related.submission.application_id}</span><br> Project form is waiting for your approval'
         ),
         "icon": "clipboard-document-list",
         "url": "{link}",
@@ -138,7 +138,7 @@ template_map = {
     # contracting state (vendor/staff/contracting team action)
     PROJECT_WAITING_CONTRACT: {
         "text": _(
-            'Project [<span class="truncate inline-block max-w-32 align-bottom ">{related.title}</span>]({link} "{related.title}") is waiting for contract'
+            '<span class="text-xs">{related.fund_name} #{related.application_id}</span><br>Project is waiting for contract'
         ),
         "icon": "document-duplicate",
         "url": "{link}",
@@ -146,7 +146,7 @@ template_map = {
     },
     PROJECT_WAITING_CONTRACT_DOCUMENT: {
         "text": _(
-            'Project [<span class="truncate inline-block max-w-32 align-bottom ">{related.title}</span>]({link} "{related.title}") is waiting for contracting documents'
+            '<span class="text-xs">{related.fund_name} #{related.application_id}</span><br>Project is waiting for contracting documents'
         ),
         "icon": "arrow-down-on-square",
         "url": "{link}",
@@ -154,7 +154,7 @@ template_map = {
     },
     PROJECT_WAITING_CONTRACT_REVIEW: {
         "text": _(
-            'Contract for project [<span class="truncate inline-block max-w-32 align-bottom ">{related.title}</span>]({link} "{related.title}") is waiting for review'
+            '<span class="text-xs">{related.fund_name} #{related.application_id}</span><br>Contract for project is waiting for review'
         ),
         "icon": "document-duplicate",
         "url": "{link}",
@@ -163,7 +163,7 @@ template_map = {
     # invoicing and reporting (vendor/staff/finance team action)
     PROJECT_WAITING_INVOICE: {
         "text": _(
-            'Project [<span class="truncate inline-block max-w-32 align-bottom ">{related.title}</span>]({link} "{related.title}") is waiting for invoice'
+            '<span class="text-sm">{related.project.fund_name} #{related.project.application_id}</span><br>Project <span class="truncate inline-block max-w-32 align-bottom">"{related.title}"</span> is waiting for invoice'
         ),
         "icon": "document-currency-dollar",
         "url": "{link}",
@@ -171,7 +171,7 @@ template_map = {
     },
     INVOICE_REQUIRED_CHANGES: {
         "text": _(
-            "Invoice [{related.invoice_number}]({link}) required changes or more information"
+            "<span class='text-xs'>{related.project.fund_name} #{related.project.application_id}</span><br>Invoice no. {related.invoice_number} required changes or more information"
         ),
         "icon": "document-currency-dollar",
         "url": "{link}",
@@ -179,21 +179,23 @@ template_map = {
     },
     INVOICE_WAITING_APPROVAL: {
         "text": _(
-            "Invoice [{related.invoice_number}]({link}) is waiting for your approval"
+            "<span class='text-xs'>{related.project.fund_name} #{related.project.application_id}</span><br>Invoice no. {related.invoice_number} is waiting for your approval"
         ),
         "icon": "document-currency-dollar",
         "url": "{link}",
         "type": _("project"),
     },
     INVOICE_WAITING_PAID: {
-        "text": _("Invoice [{related.invoice_number}]({link}) is waiting to be paid"),
+        "text": _(
+            "<span class='text-xs'>{related.project.fund_name} #{related.project.application_id}</span><br>Invoice no. {related.invoice_number} is waiting to be paid"
+        ),
         "icon": "document-currency-dollar",
         "url": "{link}",
         "type": _("project"),
     },
     REPORT_DUE: {
         "text": _(
-            'Report for project [<span class="truncate inline-block max-w-32 align-bottom ">{related.title}</span>]({link} "{related.title}") is due'
+            '<span class="text-xs">{related.project.fund_name} #{related.project.application_id}</span><br>Report for project <span class="truncate inline-block max-w-32 align-bottom ">"{related.title}"</span> is due'
         ),
         "icon": "document-text",
         "url": "{link}",
@@ -220,11 +222,17 @@ def get_task_template(request, task, **kwargs):
         "link": link_to(related_obj, request),
     }
     if task.code == COMMENT_TASK:
-        # Replace all newlines with spaces
-        template_kwargs["msg"] = " ".join(related_obj.message.splitlines())
+        # Replace all newlines with spaces and truncate to 60 characters
+        message = " ".join(related_obj.message.splitlines())
+        if len(message) > 60:
+            template_kwargs["msg"] = message[:57] + "..."
+        else:
+            template_kwargs["msg"] = message
     template["text"] = template["text"].format(**template_kwargs)
     template["url"] = template["url"].format(**template_kwargs)
+
     # additional field
     template["id"] = task.id
     template["user"] = task.user
+    template["created_at"] = task.created_at
     return template

--- a/hypha/apply/todo/options.py
+++ b/hypha/apply/todo/options.py
@@ -225,7 +225,7 @@ def get_task_template(request, task, **kwargs):
         # Replace all newlines with spaces and truncate to 60 characters
         message = " ".join(related_obj.message.splitlines())
         if len(message) > 60:
-            template_kwargs["msg"] = message[:57] + "..."
+            template_kwargs["msg"] = message[:57] + "…"
         else:
             template_kwargs["msg"] = message
     template["text"] = template["text"].format(**template_kwargs)

--- a/hypha/apply/todo/templates/todo/todolist_dropdown.html
+++ b/hypha/apply/todo/templates/todo/todolist_dropdown.html
@@ -1,7 +1,7 @@
 {% load i18n %}
-<div id="nav-task-list">
+<div class="text-sm divide-y nav-task-list">
     {% for task in my_tasks.data %}
-        {% include "todo/todolist_item.html" with button_type_class=" button--transparent button--narrow" %}
+        {% include "todo/todolist_item.html" %}
     {% empty %}
         <p class="p-3 m-0 border-b-2 last:border-b-0 border-light-grey">
             {% trans "No pending task." %}

--- a/hypha/apply/todo/templates/todo/todolist_item.html
+++ b/hypha/apply/todo/templates/todo/todolist_item.html
@@ -1,29 +1,55 @@
 {% load i18n markdown_tags nh3_tags heroicons %}
 
-<div class="flex items-center p-2 bg-white group">
-    {% heroicon_outline task.icon class="w-6 h-6 ms-1 me-2" aria_hidden=true %}
-    <div class="flex flex-1 items-center">
-        <span>{{ task.text|markdown|nh3 }}</span>
-        {% if task.type == "Draft" %}
-            <span
-                class="inline-block hidden px-2 pt-0.5 pb-1 my-2 text-sm font-medium text-gray-800 whitespace-nowrap bg-red-200 rounded-full sm:block ms-1"
-            >
-                {{ task.type }}
-            </span>
+<div
+    class="flex relative gap-2 items-center px-3 bg-white border-l-2 transition-colors hover:bg-gray-50 group text-fg-default border-l-transparent hover:border-l-light-blue"
+>
+    <a
+        class="flex flex-1 gap-2 items-center py-2 text-gray-600 hover:text-inherit"
+        href="{{ task.url }}"
+    >
+        <span class="inline-block">
+            {% heroicon_outline task.icon class="w-4 h-4 group-hover:stroke-2 stroke-fg-muted" aria_hidden=true %}
+        </span>
+        <span>
+            {{ task.text|nh3 }}
+
+            {% if task.type == "Draft" %}
+                <span
+                    class="inline-block py-1 px-2 -mt-1 text-xs font-medium text-gray-800 align-middle whitespace-nowrap bg-red-200 rounded-full"
+                >
+                    {{ task.type }}
+                </span>
+            {% endif %}
+        </span>
+    </a>
+
+    <div class="w-24 text-right">
+        <relative-time
+            datetime="{{ task.created_at|date:'c' }}"
+            prefix=""
+            format-style="narrow"
+            class="text-sm text-gray-500 group-hover:hidden"
+        >
+            {{ task.created_at }}
+        </relative-time>
+
+        {% if task.user %}
+            <div class="hidden absolute top-0 right-0 bottom-0 z-10 items-center group-hover:flex">
+                <button
+                    role="button"
+                    class="p-1.5 bg-gray-100 rounded-sm border cursor-pointer hover:bg-gray-200 shadow-xs me-2"
+                    data-tippy-content="{% trans 'Remove from your task list' %}"
+                    data-tippy-placement="left"
+                    hx-delete="{% url 'todo:delete' pk=task.id %}"
+                    hx-target="this"
+                    hx-swap="none"
+                    hx-confirm='{% trans "Are you sure you want to remove this task from your task list? This can not be undone." %}'
+                >
+                    {% heroicon_mini "x-mark" aria_hidden=true class="text-gray-500 stroke-current" %}
+                    <span class="sr-only">"{% trans 'Remove' %}"</span>
+                </button>
+            </div>
+
         {% endif %}
     </div>
-    {% if task.user %}
-        <button
-            class="hidden p-2 group-hover:block hover:bg-gray-100"
-            data-tippy-content="{% trans 'Remove this task' %}"
-            hx-delete="{% url 'todo:delete' pk=task.id %}"
-            hx-target="this"
-            hx-swap="none"
-            hx-confirm='{% trans "Are you sure you want to remove this task? It will remove this task from your task list." %}'
-        >
-            {% heroicon_solid "x-mark" aria_hidden=true %}
-            <span class="sr-only">"{% trans 'Remove this task' %}"</span>
-        </button>
-    {% endif %}
-    <a class="button {{ button_type_class }} ms-2" href="{{ task.url }}">{% trans "View" %}</a>
 </div>

--- a/hypha/apply/todo/views.py
+++ b/hypha/apply/todo/views.py
@@ -195,7 +195,7 @@ def get_tasks_for_user(user):
     for group in user.groups.all():
         user_group_tasks = user_group_tasks.filter(user_group__id=group.id)
 
-    return user_tasks.union(user_group_tasks)
+    return user_tasks.union(user_group_tasks).order_by("-created_at")
 
 
 def render_task_templates_for_user(request, user):

--- a/hypha/core/templates/components/admin_bar.html
+++ b/hypha/core/templates/components/admin_bar.html
@@ -5,7 +5,7 @@
         <div>
             {% render_slot slots.back_link %}
             <h1 class="mb-2 text-2xl font-medium md:m-0 md:text-3xl">{% render_slot slots.header %}</h1>
-            {% if slots.sub_heading %}<p class="m-0 text-sm">{% render_slot slots.sub_heading %}</p>{% endif %}
+            {% if slots.sub_heading %}<p class="m-0 max-w-3xl text-sm truncate">{% render_slot slots.sub_heading %}</p>{% endif %}
         </div>
         {% if slots.buttons %}<div class="self-end -mb-5">{% render_slot slots.buttons %}</div>{% endif %}
         {% render_slot slots.inner_block %}

--- a/hypha/settings/base.py
+++ b/hypha/settings/base.py
@@ -63,9 +63,9 @@ SUBMISSIONS_ARCHIVED_VIEW_ACCESS_STAFF_ADMIN = env.bool(
     "SUBMISSIONS_ARCHIVED_ACCESS_STAFF_ADMIN", True
 )
 
-# Possible values are: "public_id" and "title"
+# Possible values are: "application_id", "fund_name" and "title"
 SUBMISSION_TITLE_TEXT_TEMPLATE = env(
-    "SUBMISSION_TITLE_TEMPLATE", default="{title} (#{public_id})"
+    "SUBMISSION_TITLE_TEMPLATE", default="{fund_name} #{application_id} - {title}"
 )
 
 # Provide permissions for archiving submissions
@@ -414,6 +414,7 @@ SOCIAL_AUTH_PIPELINE = (
 NH3_ALLOWED_TAGS = [
     "a",
     "b",
+    "q",
     "big",
     "blockquote",
     "br",

--- a/hypha/settings/base.py
+++ b/hypha/settings/base.py
@@ -63,9 +63,9 @@ SUBMISSIONS_ARCHIVED_VIEW_ACCESS_STAFF_ADMIN = env.bool(
     "SUBMISSIONS_ARCHIVED_ACCESS_STAFF_ADMIN", True
 )
 
-# Possible values are: "application_id", "fund_name" and "title"
+# Possible values are: "application_id", "fund_name", "round" and "title"
 SUBMISSION_TITLE_TEXT_TEMPLATE = env(
-    "SUBMISSION_TITLE_TEMPLATE", default="{fund_name} #{application_id} - {title}"
+    "SUBMISSION_TITLE_TEMPLATE", default="{title} (#{application_id})"
 )
 
 # Provide permissions for archiving submissions


### PR DESCRIPTION
### Notable changes:

- Show tasks in chronological order
- Add relative timestamp against each tasks
- Review view button to save some spaces and make the row clickable
- Update the tasks copy to include the fund name and application id
- admin bar sub-heading truncates now for submissions with long title

### Worth considering (up for discussion):

- should be update and make use of `[fund_name] #{application_id}` as generic indentier for applications instead of the current "title" only.
- When it comes to selecting a main fund name, should use priorities name of the "round" or name of the "fund" from which the round is derived.

## Internal changes

Included `fund_name` and `application_id` on both the submission and project instance to easily access them, while abstracting the complexity around fallback on submission.id when the `submission.public_id` is missing

![Screenshot 2025-03-24 at 8  59 02](https://github.com/user-attachments/assets/872a7fc0-02ca-4240-9495-2d76b2c382c6)


