### PR TITLE
Fix fund_name attribute error for determination

### DIFF
--- a/hypha/apply/todo/options.py
+++ b/hypha/apply/todo/options.py
@@ -70,7 +70,7 @@ template_map = {
     },
     DETERMINATION_DRAFT: {
         "text": _(
-            '<span class="text-xs">{related.fund_name} #{related.application_id}</span><br>Determination draft for submission <span class="truncate inline-block max-w-32 align-bottom">"{related.submission.title}"</span> is waiting to be submitted',
+            '<span class="text-xs">{related.submission.fund_name} #{related.submission.application_id}</span><br>Determination draft for submission <span class="truncate inline-block max-w-32 align-bottom">"{related.submission.title}"</span> is waiting to be submitted',
         ),
         "icon": "pencil-square",
         "url": "{link}",
@@ -129,7 +129,7 @@ template_map = {
     },
     PAF_WAITING_APPROVAL: {
         "text": _(
-            '<span class="text-xs">{related.submission.fund_name} #{related.submission.application_id}</span><br> Project form is waiting for your approval'
+            '<span class="text-xs">{related.fund_name} #{related.application_id}</span><br> Project form is waiting for your approval'
         ),
         "icon": "clipboard-document-list",
         "url": "{link}",


### PR DESCRIPTION
<!--
Thanks for contributing to Hypha!

Please ensure your contributions pass all necessary linting/testing and that the appropriate documentation has been updated.
-->

<!--
Describe briefly what your pull request changes. If this is resolving an issue, please specify below via "Fixes #<Github Issue ID>"
-->
Fixes Todo list latest updates misses

Draft determination message uses fund_name attribute while determination doesn't have one. So, fixed it by using determination.submission.fund_name. 
Also make it consistent for project, use only project fund name property for project related items.

## Test Steps
<!-- 
If step does not require manual testing, skip/remove this section.

Give a brief overview of the steps required for a user/dev to test this contribution. Important things to include:
 - Required user roles for where necessary (ie. "As a Staff Admin...")
 - Clear & validatable expected results (ie. "Confirm the submit button is now not clickable")
 - Language that can be understood by non-technical testers if being tested by users
-->

 - [ ] …