### PR TITLE
Easy fix for duplicate file issue

### DIFF
--- a/hypha/apply/funds/models/mixins.py
+++ b/hypha/apply/funds/models/mixins.py
@@ -99,15 +99,16 @@ class AccessFormData:
         for field in self.form_fields:
             if isinstance(field.block, UploadableMediaBlock):
                 new_file = data.get(field.id, [])
-                existing_file = latest_existing_data.get(field.id, [])
+                if latest_existing_data:
+                    existing_file = latest_existing_data.get(field.id, [])
+                else:
+                    existing_file = None
 
                 # processing files before checking because placeholder files can't be read
                 new_stream_file = self.process_file(self, field, new_file)
-                # existing_stream_file = self.process_file(self, field, existing_file)
 
                 # save only if it is not the same file(s)
-                same_file = self._is_same_file(existing_file, new_stream_file)
-                if not same_file:
+                if not self._is_same_file(existing_file, new_stream_file):
                     try:
                         new_stream_file.save()
                     except (AttributeError, FileNotFoundError):

--- a/hypha/apply/funds/models/submissions.py
+++ b/hypha/apply/funds/models/submissions.py
@@ -743,7 +743,9 @@ class ApplicationSubmission(
     def clean_submission(self):
         self.process_form_data()
         self.ensure_user_has_account()
-        self.process_file_data(self.form_data)
+        # pass current submission data to avoid file save on every submit(if file is not updated)
+        current_submission = ApplicationSubmission.objects.get(id=self.id)
+        self.process_file_data(self.form_data, current_submission.from_draft().raw_data)
 
     def get_assigned_meta_terms(self):
         """Returns assigned meta terms excluding the 'root' term"""
@@ -795,7 +797,7 @@ class ApplicationSubmission(
                     f"{self.get_from_parent('submission_id_prefix')}{self.id}"
                 )
 
-            self.process_file_data(files)
+            self.process_file_data(files, self.from_draft().raw_data)
             AssignedReviewers.objects.bulk_create_reviewers(
                 list(self.get_from_parent("reviewers").all()),
                 self,

--- a/hypha/apply/funds/models/submissions.py
+++ b/hypha/apply/funds/models/submissions.py
@@ -662,9 +662,10 @@ class ApplicationSubmission(
         Returns:
             Self with the `form_data` attribute updated.
         """
-        self.form_data = self.deserialised_data(
-            self, self.draft_revision.form_data, self.form_fields
-        )
+        if self.draft_revision:
+            self.form_data = self.deserialised_data(
+                self, self.draft_revision.form_data, self.form_fields
+            )
 
         return self
 
@@ -744,8 +745,13 @@ class ApplicationSubmission(
         self.process_form_data()
         self.ensure_user_has_account()
         # pass current submission data to avoid file save on every submit(if file is not updated)
-        current_submission = ApplicationSubmission.objects.get(id=self.id)
-        self.process_file_data(self.form_data, current_submission.from_draft().raw_data)
+        if self.id:
+            current_submission = ApplicationSubmission.objects.get(id=self.id)
+            self.process_file_data(
+                self.form_data, current_submission.from_draft().raw_data
+            )
+        else:
+            self.process_file_data(self.form_data)
 
     def get_assigned_meta_terms(self):
         """Returns assigned meta terms excluding the 'root' term"""
@@ -797,7 +803,7 @@ class ApplicationSubmission(
                     f"{self.get_from_parent('submission_id_prefix')}{self.id}"
                 )
 
-            self.process_file_data(files, self.from_draft().raw_data)
+            self.process_file_data(files)
             AssignedReviewers.objects.bulk_create_reviewers(
                 list(self.get_from_parent("reviewers").all()),
                 self,


### PR DESCRIPTION
<!--
Thanks for contributing to Hypha!

Please ensure your contributions pass all necessary linting/testing and that the appropriate documentation has been updated.
-->

<!--
Describe briefly what your pull request changes. If this is resolving an issue, please specify below via "Fixes #<Github Issue ID>"
-->
Fixes #4484   Alternative of #4489 

field_id-uploads have path as file id for already uploaded file but for a new uploaded file it only have the uuid. So, either we can check for the path like instance_type/id/... or we can just look for the file name. For now, I checked only for name but we may check for both name and path like pattern. What do you think @frjo @theskumar

uploads data for existing file `[{'id': 'submission/268/509bee14-f03a-4f3a-bea4-66ad17e97635/20230915-testing-draft-with-specific-1_6.pdf', 'name': '20230915-testing-draft-with-specific-1 (6).pdf', 'size': 3345, 'type': 'placeholder'}]`
but for a new file id is just a uuid 'ef65de0a-e43b-4ebe-93d0-db9784083af'


## Test Steps
<!-- 
If step does not require manual testing, skip/remove this section.

Give a brief overview of the steps required for a user/dev to test this contribution. Important things to include:
 - Required user roles for where necessary (ie. "As a Staff Admin...")
 - Clear & validatable expected results (ie. "Confirm the submit button is now not clickable")
 - Language that can be understood by non-technical testers if being tested by users
-->

 - [ ] …