### PR TITLE
Fixed procfile having wrong order of arguments

### DIFF
--- a/Procfile
+++ b/Procfile
@@ -1,3 +1,3 @@
 release: python manage.py migrate --noinput && python manage.py clear_cache --cache=default && python manage.py sync_roles
 web: gunicorn hypha.wsgi:application --log-file -
-worker: celery worker --app=hypha.celery --autoscale=6,2 --events
+worker: celery --app=hypha.celery worker --autoscale=6,2 --events


### PR DESCRIPTION
Celery worker errors out due to the worker being before the app arg
