### PR TITLE
Fixed `NoReverseMatch` on submitting status update

### DIFF
--- a/hypha/apply/projects/templates/application_projects/partials/invoice_status_table.html
+++ b/hypha/apply/projects/templates/application_projects/partials/invoice_status_table.html
@@ -17,7 +17,7 @@
                 {% if user_can_edit_request %}
                     <a
                         class="data-block__action-icon-link"
-                        href="{% url "apply:projects:invoice-edit" pk=object.submission.pk invoice_pk=invoice.pk %}"
+                        href="{% url 'apply:projects:invoice-edit' pk=invoice.project.submission.pk invoice_pk=invoice.pk %}"
                     >
                         {% heroicon_micro "pencil-square" aria_hidden=true class="me-1" %}
                         {% trans "Edit" %}


### PR DESCRIPTION
<!--
Thanks for contributing to Hypha!

Please ensure your contributions pass all necessary linting/testing and that the appropriate documentation has been updated.
-->

<!--
Describe briefly what your pull request changes. If this is resolving an issue, please specify below via "Fixes #<Github Issue ID>"
-->
Invoice edit URL was trying to get the project pk from a different place than the rest of the calls (delete & edit were correct)


## Test Steps
<!-- 
If step does not require manual testing, skip/remove this section.

Give a brief overview of the steps required for a user/dev to test this contribution. Important things to include:
 - Required user roles for where necessary (ie. "As a Staff Admin...")
 - Clear & validatable expected results (ie. "Confirm the submit button is now not clickable")
 - Language that can be understood by non-technical testers if being tested by users
-->

 - [ ] You can submit an invoice status update from the project invoice table