### PR TITLE
Update PROJECTS_ENABLED to use middleware for url blocking

### DIFF
--- a/hypha/apply/funds/urls.py
+++ b/hypha/apply/funds/urls.py
@@ -1,4 +1,3 @@
-from django.conf import settings
 from django.urls import include, path
 from django.views.generic import RedirectView
 
@@ -280,9 +279,5 @@ rounds_urls = (
 urlpatterns = [
     path("submissions/", include(submission_urls)),
     path("rounds/", include(rounds_urls)),
+    path("projects/", include(projects_urls)),
 ]
-
-if settings.PROJECTS_ENABLED:
-    urlpatterns += [
-        path("projects/", include(projects_urls)),
-    ]

--- a/hypha/apply/projects/middleware.py
+++ b/hypha/apply/projects/middleware.py
@@ -15,14 +15,14 @@ class ProjectsEnabledMiddleware:
         self.get_response = get_response
 
     def __call__(self, request):
+        # Skip processing if PROJECTS_ENABLED is true
+        if settings.PROJECTS_ENABLED:
+            return self.get_response(request)
+
         # Check if the current URL is in the projects namespace
         try:
             resolver_match = resolve(request.path)
-            if (
-                "projects" in getattr(resolver_match, "namespaces", [])
-                and not settings.PROJECTS_ENABLED
-            ):
-                # Projects are disabled, so return 404
+            if "projects" in getattr(resolver_match, "namespaces", []):
                 raise Http404("Projects functionality is disabled")
         except Resolver404:
             # Not a URL we can resolve, let Django handle it

--- a/hypha/apply/projects/middleware.py
+++ b/hypha/apply/projects/middleware.py
@@ -1,0 +1,32 @@
+from django.conf import settings
+from django.http import Http404
+from django.urls import Resolver404, resolve
+
+
+class ProjectsEnabledMiddleware:
+    """
+    Middleware to control access to project urls based on PROJECTS_ENABLED setting.
+
+    This makes the decision at runtime rather than at URL pattern registration time,
+    avoiding potential issues with module loading order and settings configuration.
+    """
+
+    def __init__(self, get_response):
+        self.get_response = get_response
+
+    def __call__(self, request):
+        # Check if the current URL is in the projects namespace
+        try:
+            resolver_match = resolve(request.path)
+            if (
+                "projects" in getattr(resolver_match, "namespaces", [])
+                and not settings.PROJECTS_ENABLED
+            ):
+                # Projects are disabled, so return 404
+                raise Http404("Projects functionality is disabled")
+        except Resolver404:
+            # Not a URL we can resolve, let Django handle it
+            pass
+
+        # Continue processing the request
+        return self.get_response(request)

--- a/hypha/apply/projects/tests/test_middleware.py
+++ b/hypha/apply/projects/tests/test_middleware.py
@@ -69,7 +69,6 @@ def test_resolver404_passes_through(middleware, rf, settings):
     middleware_instance, get_response_mock = middleware
     request = rf.get("/nonexistent/path/")
 
-    # We need to set this explicitly since the middleware now checks this first
     settings.PROJECTS_ENABLED = False
 
     with patch("hypha.apply.projects.middleware.resolve") as mock_resolve:
@@ -112,25 +111,5 @@ def test_non_project_routes_allowed(middleware, rf, settings, namespaces_value):
         response = middleware_instance(request)
 
         mock_resolve.assert_called_once_with(request.path)
-        get_response_mock.assert_called_once_with(request)
-        assert response == get_response_mock.return_value
-
-
-def test_projects_enabled_skips_url_resolution(middleware, rf, settings):
-    """
-    Test that when PROJECTS_ENABLED is True, the middleware doesn't
-    attempt to resolve the URL at all, optimizing performance.
-    """
-    # Setup
-    settings.PROJECTS_ENABLED = True
-    middleware_instance, get_response_mock = middleware
-    request = rf.get("/projects/some/path/")
-
-    with patch("hypha.apply.projects.middleware.resolve") as mock_resolve:
-        # Execute
-        response = middleware_instance(request)
-
-        # Verify
-        mock_resolve.assert_not_called()
         get_response_mock.assert_called_once_with(request)
         assert response == get_response_mock.return_value

--- a/hypha/apply/projects/tests/test_middleware.py
+++ b/hypha/apply/projects/tests/test_middleware.py
@@ -1,0 +1,109 @@
+from unittest.mock import Mock, patch
+
+import pytest
+from django.http import Http404
+from django.urls import Resolver404
+
+from hypha.apply.projects.middleware import ProjectsEnabledMiddleware
+
+
+@pytest.fixture
+def middleware():
+    get_response_mock = Mock()
+    return ProjectsEnabledMiddleware(get_response_mock), get_response_mock
+
+
+@pytest.mark.parametrize(
+    "projects_enabled,namespaces,path,should_raise_404",
+    [
+        # When projects are enabled, project URLs are accessible
+        (True, ["projects"], "/projects/some/path/", False),
+        # When projects are disabled, project URLs raise Http404
+        (False, ["projects"], "/projects/some/path/", True),
+        # When projects are disabled, non-project URLs are still accessible
+        (False, ["submissions"], "/submissions/path/", False),
+        # Nested projects namespaces are properly handled
+        (False, ["funds", "projects"], "/funds/projects/some/path/", True),
+        # Projects in nested namespaces are accessible when enabled
+        (True, ["funds", "projects"], "/funds/projects/some/path/", False),
+    ],
+)
+def test_projects_middleware_access_control(
+    middleware, rf, settings, projects_enabled, namespaces, path, should_raise_404
+):
+    """
+    Test that middleware controls access to project URLs based on settings.PROJECTS_ENABLED
+    """
+    # Setup
+    settings.PROJECTS_ENABLED = projects_enabled
+    middleware_instance, get_response_mock = middleware
+    request = rf.get(path)
+
+    with patch("hypha.apply.projects.middleware.resolve") as mock_resolve:
+        mock_resolve.return_value = Mock(
+            namespaces=namespaces, url_name="project-detail"
+        )
+
+        # Execute
+        if should_raise_404:
+            with pytest.raises(Http404):
+                middleware_instance(request)
+            get_response_mock.assert_not_called()
+        else:
+            response = middleware_instance(request)
+            get_response_mock.assert_called_once_with(request)
+            assert response == get_response_mock.return_value
+
+        mock_resolve.assert_called_once_with(request.path)
+
+
+def test_resolver404_passes_through(middleware, rf):
+    """
+    Test that Resolver404 exceptions are caught and handled properly
+    (letting Django handle them as it normally would).
+    """
+    middleware_instance, get_response_mock = middleware
+    request = rf.get("/nonexistent/path/")
+
+    with patch("hypha.apply.projects.middleware.resolve") as mock_resolve:
+        mock_resolve.side_effect = Resolver404()
+
+        response = middleware_instance(request)
+
+        mock_resolve.assert_called_once_with(request.path)
+        get_response_mock.assert_called_once_with(request)
+        assert response == get_response_mock.return_value
+
+
+@pytest.mark.parametrize(
+    "namespaces_value",
+    [
+        # Empty namespaces list
+        [],
+        # No namespaces attribute
+        None,
+    ],
+)
+def test_non_project_routes_allowed(middleware, rf, settings, namespaces_value):
+    """
+    Test that URLs with no namespaces or no namespaces attribute are allowed through.
+    """
+    settings.PROJECTS_ENABLED = False  # Even when projects are disabled
+    middleware_instance, get_response_mock = middleware
+    request = rf.get("/some/path/")
+
+    with patch("hypha.apply.projects.middleware.resolve") as mock_resolve:
+        if namespaces_value is None:
+            # Create a mock without namespaces attribute
+            mock_resolve_result = Mock(spec=["url_name"])
+        else:
+            mock_resolve_result = Mock()
+            mock_resolve_result.namespaces = namespaces_value
+
+        mock_resolve.return_value = mock_resolve_result
+
+        response = middleware_instance(request)
+
+        mock_resolve.assert_called_once_with(request.path)
+        get_response_mock.assert_called_once_with(request)
+        assert response == get_response_mock.return_value

--- a/hypha/settings/django.py
+++ b/hypha/settings/django.py
@@ -95,6 +95,7 @@ MIDDLEWARE = [
     "hypha.apply.middleware.HandleProtectionErrorMiddleware",
     "django_htmx.middleware.HtmxMiddleware",
     "hypha.core.middleware.htmx.HtmxMessageMiddleware",
+    "hypha.apply.projects.middleware.ProjectsEnabledMiddleware",
 ]
 
 # Logging


### PR DESCRIPTION
This PR introduces a runtime approach to controlling access to the
Projects feature based on the `PROJECTS_ENABLED` setting. Rather than
conditionally registering URL patterns, a new middleware is implemented
to handle access control to project-related URLs at request time. This
change improves the reliability of the feature toggle system and avoids
potential issues with module loading order and settings configuration.

## 💡 Implementation Details

The middleware works by resolving the current URL path and checking if
it belongs to a "projects" namespace. When the `PROJECTS_ENABLED`
setting is `False` and a user attempts to access a projects-related URL,
they'll receive a 404 error instead of seeing the projects
functionality.

This approach improves upon the previous implementation by:

1. Separating the concerns of URL registration and feature availability
2. Avoiding potential race conditions or initialization issues
3. Providing a more consistent user experience when the feature is
disabled

## 👀 Areas for Review Attention

- Middleware ordering in the settings file - is this the optimal
position?
- Performance impact of URL resolution for every request
- Handling of nested namespaces containing "projects"

Closes https://github.com/HyphaApp/hypha/issues/4514
