### PR TITLE
Show invoice stamping for approval steps & all after

### DIFF
--- a/hypha/apply/projects/views/payment.py
+++ b/hypha/apply/projects/views/payment.py
@@ -60,11 +60,14 @@ from ..forms import (
     EditInvoiceForm,
 )
 from ..models.payment import (
+    APPROVED_BY_FINANCE,
     APPROVED_BY_STAFF,
     CHANGES_REQUESTED_BY_FINANCE,
     CHANGES_REQUESTED_BY_STAFF,
     DECLINED,
     INVOICE_TRANSITION_TO_RESUBMITTED,
+    PAID,
+    PAYMENT_FAILED,
     Invoice,
 )
 from ..models.project import Project
@@ -446,10 +449,12 @@ class InvoicePrivateMedia(UserPassesTestMixin, PrivateMediaView):
             return document.document
 
         # if not, then it's for invoice document
-        if (
-            self.invoice.status == APPROVED_BY_STAFF
-            and self.invoice.document.file.name.endswith(".pdf")
-        ):
+        if self.invoice.status in [
+            APPROVED_BY_STAFF,
+            APPROVED_BY_FINANCE,
+            PAID,
+            PAYMENT_FAILED,
+        ] and self.invoice.document.file.name.endswith(".pdf"):
             if activities := Activity.actions.filter(
                 related_content_type__model="invoice",
                 related_object_id=self.invoice.id,


### PR DESCRIPTION
Currently the invoice stamps will only appear if the invoice has the status of `APPROVED_BY_STAFF`, this makes it so all approval/paid statuses will have the stamped page.

## Test Steps
<!-- 
If step does not require manual testing, skip/remove this section.

Give a brief overview of the steps required for a user/dev to test this contribution. Important things to include:
 - Required user roles for where necessary (ie. "As a Staff Admin...")
 - Clear & validatable expected results (ie. "Confirm the submit button is now not clickable")
 - Language that can be understood by non-technical testers if being tested by users
-->

 - [ ] Ensure the approvals list/stamp page of the invoice PDF is generated not only in the `APPROVED_BY_STAFF` phase but in `APPROVED_BY_FINANCE`, `PAID`, and `PAYMENT_FAILED`