### PR TITLE
Added `ssl_check_hostname` query param for redis 6.0

### DIFF
--- a/hypha/settings/base.py
+++ b/hypha/settings/base.py
@@ -510,7 +510,10 @@ CELERY_RESULT_BACKEND = env.str("CELERY_RESULT_BACKEND", None)
 if REDIS_URL and not (CELERY_BROKER_URL or CELERY_RESULT_BACKEND):
     cert_param = ""
     if REDIS_URL.startswith("rediss") and REDIS_SSL_CERT_REQS:
-        cert_param = f"?ssl_cert_reqs={REDIS_SSL_CERT_REQS}"
+        check_hostname = REDIS_SSL_CERT_REQS != "CERT_NONE"
+        cert_param = (
+            f"?ssl_cert_reqs={REDIS_SSL_CERT_REQS}&ssl_check_hostname={check_hostname}"
+        )
     CELERY_BROKER_URL = f"{REDIS_URL}/0{cert_param}"
     CELERY_RESULT_BACKEND = f"{REDIS_URL}{cert_param}"
     # Manipulation of the environ vars is needed due to how celery processes & prioritizes settings

--- a/hypha/settings/base.py
+++ b/hypha/settings/base.py
@@ -510,7 +510,7 @@ CELERY_RESULT_BACKEND = env.str("CELERY_RESULT_BACKEND", None)
 if REDIS_URL and not (CELERY_BROKER_URL or CELERY_RESULT_BACKEND):
     cert_param = ""
     if REDIS_URL.startswith("rediss") and REDIS_SSL_CERT_REQS:
-        check_hostname = REDIS_SSL_CERT_REQS != "CERT_NONE"
+        check_hostname = str(REDIS_SSL_CERT_REQS != "CERT_NONE").lower()
         cert_param = (
             f"?ssl_cert_reqs={REDIS_SSL_CERT_REQS}&ssl_check_hostname={check_hostname}"
         )


### PR DESCRIPTION
<!--
Thanks for contributing to Hypha!

Please ensure your contributions pass all necessary linting/testing and that the appropriate documentation has been updated.
-->

<!--
Describe briefly what your pull request changes. If this is resolving an issue, please specify below via "Fixes #<Github Issue ID>"
-->
Redis 6.0 switches the default of `ssl_check_hostname` from False to True (see breaking changes [here](https://github.com/redis/redis-py/releases/tag/v6.0.0), so an extra URL param is required. 

This came up for me locally as well as on the [test instance](https://otf.sentry.io/issues/6595117738/events/0a22d20ea8d94823a583b395fe921e7f/)


## Test Steps
<!-- 
If step does not require manual testing, skip/remove this section.

Give a brief overview of the steps required for a user/dev to test this contribution. Important things to include:
 - Required user roles for where necessary (ie. "As a Staff Admin...")
 - Clear & validatable expected results (ie. "Confirm the submit button is now not clickable")
 - Language that can be understood by non-technical testers if being tested by users
-->

 - [ ] Ensure a redis SSL instance with self signed certs connects