### PR TITLE
Better error handling for dates, added submitted filter criteria

### DIFF
--- a/hypha/apply/funds/templates/submissions/all.html
+++ b/hypha/apply/funds/templates/submissions/all.html
@@ -365,12 +365,17 @@
             <nav x-show="!showSelectedSubmissions"
                  class="flex flex-wrap gap-2 items-center menu-filters"
             >
-                <div id="filterupdated" aria-label="Filter by Updated" class="flex items-center">
+                <div id="filtersubmitted" aria-label="Filter by Submitted" class="flex items-center" data-query="submitted">
+                    <button class="flex justify-between items-center py-1 w-full font-medium text-gray-600 border cursor-pointer md:p-0 md:border-none hover:bg-gray-50 ps-2 pe-2 md:pe-4 md:hover:bg-transparent md:hover:text-blue-700">
+                        {% trans "Submitted" %}
+                        {% heroicon_mini "chevron-down" aria_hidden="true" width=18 height=18 class="hidden md:inline-block" %}
+                    </button>
+                </div>
+                <div id="filterupdated" aria-label="Filter by Updated" class="flex items-center" data-query="updated">
                     <button class="flex justify-between items-center py-1 w-full font-medium text-gray-600 border cursor-pointer md:p-0 md:border-none hover:bg-gray-50 ps-2 pe-2 md:pe-4 md:hover:bg-transparent md:hover:text-blue-700">
                         {% trans "Updated" %}
                         {% heroicon_mini "chevron-down" aria_hidden="true" width=18 height=18 class="hidden md:inline-block" %}
                     </button>
-
                 </div>
 
                 {% dropdown_menu title="Status" heading="Filter by current status" enable_search=True %}
@@ -609,23 +614,28 @@
             var start = moment().subtract(29, 'days');
             var end = moment();
 
-            $('#filterupdated').daterangepicker({
-                startDate: start,
-                endDate: end,
-                ranges: {
-                    '{% trans "Today" %}': [moment(), moment()],
-                    '{% trans "Yesterday" %}': [moment().subtract(1, 'days'), moment().subtract(1, 'days')],
-                    '{% trans "Last 7 Days" %}': [moment().subtract(6, 'days'), moment()],
-                    '{% trans "Last 30 Days" %}': [moment().subtract(29, 'days'), moment()],
-                    '{% trans "This Month" %}': [moment().startOf('month'), moment().endOf('month')],
-                    '{% trans "Last Month" %}': [moment().subtract(1, 'month').startOf('month'), moment().subtract(1, 'month').endOf('month')]
-                }
-            });
+            // Add the picker for all elements that need it
+            $.each(['#filterupdated', '#filtersubmitted'], (index, element) => {
+                $(element).daterangepicker({
+                    startDate: start,
+                    endDate: end,
+                    ranges: {
+                        '{% trans "Today" %}': [moment(), moment()],
+                        '{% trans "Yesterday" %}': [moment().subtract(1, 'days'), moment().subtract(1, 'days')],
+                        '{% trans "Last 7 Days" %}': [moment().subtract(6, 'days'), moment()],
+                        '{% trans "Last 30 Days" %}': [moment().subtract(29, 'days'), moment()],
+                        '{% trans "This Month" %}': [moment().startOf('month'), moment().endOf('month')],
+                        '{% trans "Last Month" %}': [moment().subtract(1, 'month').startOf('month'), moment().subtract(1, 'month').endOf('month')]
+                    }
+                });
 
-            $('#filterupdated').on('apply.daterangepicker', function(ev, picker) {
-                $('#search-navbar').val(`updated:>=${picker.startDate.format('YYYY-MM-DD')} updated:<=${picker.endDate.format('YYYY-MM-DD')}`);
-                $('#search-navbar').closest('form').trigger('submit');
-            });
+                var query = $(element).attr("data-query");
+
+                $(element).on('apply.daterangepicker', function(ev, picker) {
+                    $('#search-navbar').val(`${query}:>=${picker.startDate.format('YYYY-MM-DD')} ${query}:<=${picker.endDate.format('YYYY-MM-DD')}`);
+                    $('#search-navbar').closest('form').trigger('submit');
+                });
+            })
         });
     </script>
 {% endblock %}

--- a/hypha/apply/search/filters.py
+++ b/hypha/apply/search/filters.py
@@ -66,4 +66,4 @@ def date_filter_tokens_to_q_obj(tokens: list, field: str) -> Q:
                 return Q(**{f"{field}__year": year})
             else:
                 return Q(**{f"{field}__year": year})
-    return Q(None)
+    return Q()

--- a/hypha/apply/search/filters.py
+++ b/hypha/apply/search/filters.py
@@ -14,6 +14,8 @@ def apply_date_filter(qs, field, values):
 
         if q := date_filter_tokens_to_q_obj(tokens=tokens, field=field):
             q_obj &= q
+        else:
+            return qs.none()
 
     return qs.filter(q_obj)
 
@@ -66,4 +68,4 @@ def date_filter_tokens_to_q_obj(tokens: list, field: str) -> Q:
                 return Q(**{f"{field}__year": year})
             else:
                 return Q(**{f"{field}__year": year})
-    return Q()
+    return None

--- a/hypha/apply/search/query_parser.py
+++ b/hypha/apply/search/query_parser.py
@@ -87,6 +87,10 @@ def tokenize_date_filter_value(date_str: str) -> list:
     # Match the regex pattern to the value
     match = re.match(regex_pattern, date_str)
 
+    if match is None:
+        # Invalid date string
+        return []
+
     # Extract the operator and date from the match object
     operator = match.group(1)
     date_str = match.group(2)

--- a/hypha/apply/search/tests/test_filters.py
+++ b/hypha/apply/search/tests/test_filters.py
@@ -39,8 +39,8 @@ from ..filters import date_filter_tokens_to_q_obj
         (["<", 2023], "date_field", Q(date_field__year__lt=2023)),
         ([None, 2023], "date_field", Q(date_field__year=2023)),
         ([None, 2023], "date_field", Q(date_field__year=2023)),
-        ([], "date_field", Q()),
-        ([], "date_field", Q()),
+        ([], "date_field", None),
+        ([], "date_field", None),
     ],
 )
 def test_date_filter_tokens_to_q_obj(tokens, field, expected):

--- a/hypha/apply/search/tests/test_filters.py
+++ b/hypha/apply/search/tests/test_filters.py
@@ -39,8 +39,8 @@ from ..filters import date_filter_tokens_to_q_obj
         (["<", 2023], "date_field", Q(date_field__year__lt=2023)),
         ([None, 2023], "date_field", Q(date_field__year=2023)),
         ([None, 2023], "date_field", Q(date_field__year=2023)),
-        ([], "date_field", Q(None)),
-        ([], "date_field", Q(None)),
+        ([], "date_field", Q()),
+        ([], "date_field", Q()),
     ],
 )
 def test_date_filter_tokens_to_q_obj(tokens, field, expected):


### PR DESCRIPTION
<!--
Thanks for contributing to Hypha!

Please ensure your contributions pass all necessary linting/testing and that the appropriate documentation has been updated.
-->

<!--
Describe briefly what your pull request changes. If this is resolving an issue, please specify below via "Fixes #<Github Issue ID>"
-->
Fixes #4548. This handles an invalid date the same as invalid/non-existent query params rather than erroring out. ~~In the long term, it would be better to indicate to the user that something wasn't right with their query though or no results were brought.~~ When an invalid query is entered, it'll show the no results prompt!

I also added the submitted drop down filter, as staff have been using that a bit recently

## Test Steps
<!-- 
If step does not require manual testing, skip/remove this section.

Give a brief overview of the steps required for a user/dev to test this contribution. Important things to include:
 - Required user roles for where necessary (ie. "As a Staff Admin...")
 - Clear & validatable expected results (ie. "Confirm the submit button is now not clickable")
 - Language that can be understood by non-technical testers if being tested by users
-->

 - [ ] Ensure putting an incorrectly formatted date in the query bar doesn't result in a 500 error
     - ie. `submitted:>=205-04-01 submitted:<=2025-04-30`
 - [ ] Ensure applications can be filtered by submitted date using the new drop down