### PR TITLE
Remove added comment that made review comparisons always show up

### DIFF
--- a/hypha/apply/review/templates/review/review_detail.html
+++ b/hypha/apply/review/templates/review/review_detail.html
@@ -61,14 +61,14 @@
                     </a>
                 {% endif %}
             </div>
-            {% comment %} {% if not review.for_latest %} {% endcomment %}
-            <div class="text-end">
-                <p class="text-xs">
-                    * {% trans "Review was not against the latest version" %}<br>
-                </p>
-                <a class="button button--primary" href="{{ review.get_compare_url }}">{% trans "Compare" %}</a>
-            </div>
-        {% comment %} {% endif %} {% endcomment %}
+            {% if not review.for_latest %}
+                <div class="text-end">
+                    <p class="text-xs">
+                        * {% trans "Review was not against the latest version" %}<br>
+                    </p>
+                    <a class="button button--primary" href="{{ review.get_compare_url }}">{% trans "Compare" %}</a>
+                </div>
+            {% endif %}
         </div>
 
     </div>


### PR DESCRIPTION
It looks like in commit fdec894e01, a comment was added on the if condition of reviewer version changes that makes it so the warning "review was against not most recent version" always shows up, with a comparison link that may sometimes 500.

This undoes that comment.