### PR TITLE
Separate permissions for submission edit and submission actions

### DIFF
--- a/hypha/apply/funds/permissions.py
+++ b/hypha/apply/funds/permissions.py
@@ -18,6 +18,16 @@ def has_permission(action, user, object=None, raise_exception=True):
     return value, reason
 
 
+def can_take_submission_actions(user, submission):
+    if not user.is_authenticated:
+        return False, "Login Required"
+
+    if submission.is_archive:
+        return False, "Archived Submission"
+
+    return True, ""
+
+
 def can_edit_submission(user, submission):
     if not user.is_authenticated:
         return False, "Login Required"
@@ -266,6 +276,7 @@ def user_can_view_post_comment_form(user, submission):
 permissions_map = {
     "submission_view": is_user_has_access_to_view_submission,
     "submission_edit": can_edit_submission,
+    "submission_action": can_take_submission_actions,
     "can_view_submission_screening": can_view_submission_screening,
     "archive_alter": can_alter_archived_submissions,
     "co_applicant_invite": can_invite_co_applicants,

--- a/hypha/apply/funds/views/partials.py
+++ b/hypha/apply/funds/views/partials.py
@@ -476,7 +476,7 @@ def partial_screening_card(request, pk):
         "can_view_submission_screening", request.user, submission, raise_exception=False
     )
     can_edit, _ = has_permission(
-        "submission_edit", request.user, submission, raise_exception=False
+        "submission_action", request.user, submission, raise_exception=False
     )
 
     if not view_permission:

--- a/hypha/apply/funds/views/reminders.py
+++ b/hypha/apply/funds/views/reminders.py
@@ -49,7 +49,7 @@ class ReminderCreateView(View):
     def dispatch(self, request, *args, **kwargs):
         self.submission = get_object_or_404(ApplicationSubmission, id=kwargs.get("pk"))
         permission, reason = has_permission(
-            "submission_edit",
+            "submission_action",
             request.user,
             object=self.submission,
             raise_exception=False,

--- a/hypha/apply/funds/views/submission_edit.py
+++ b/hypha/apply/funds/views/submission_edit.py
@@ -346,7 +346,7 @@ class ProgressSubmissionView(View):
     def dispatch(self, request, *args, **kwargs):
         self.submission = get_object_or_404(ApplicationSubmission, id=kwargs.get("pk"))
         permission, reason = has_permission(
-            "submission_edit",
+            "submission_action",
             request.user,
             object=self.submission,
             raise_exception=False,
@@ -401,7 +401,7 @@ class CreateProjectView(View):
     def dispatch(self, request, *args, **kwargs):
         self.submission = get_object_or_404(ApplicationSubmission, id=kwargs.get("pk"))
         permission, reason = has_permission(
-            "submission_edit",
+            "submission_action",
             request.user,
             object=self.submission,
             raise_exception=False,
@@ -520,7 +520,7 @@ class UpdateLeadView(View):
     def dispatch(self, request, *args, **kwargs):
         self.object = get_object_or_404(ApplicationSubmission, id=kwargs.get("pk"))
         permission, reason = has_permission(
-            "submission_edit", request.user, object=self.object, raise_exception=False
+            "submission_action", request.user, object=self.object, raise_exception=False
         )
         if not permission:
             messages.warning(self.request, reason)
@@ -575,7 +575,7 @@ class UpdateReviewersView(View):
     def dispatch(self, request, *args, **kwargs):
         self.submission = get_object_or_404(ApplicationSubmission, id=kwargs.get("pk"))
         permission, reason = has_permission(
-            "submission_edit",
+            "submission_action",
             request.user,
             object=self.submission,
             raise_exception=False,
@@ -652,7 +652,7 @@ class UpdatePartnersView(View):
     def dispatch(self, request, *args, **kwargs):
         self.submission = get_object_or_404(ApplicationSubmission, id=kwargs.get("pk"))
         permission, reason = has_permission(
-            "submission_edit",
+            "submission_action",
             request.user,
             object=self.submission,
             raise_exception=False,
@@ -732,7 +732,7 @@ class UpdateMetaTermsView(View):
     def dispatch(self, request, *args, **kwargs):
         self.submission = get_object_or_404(ApplicationSubmission, id=kwargs.get("pk"))
         permission, reason = has_permission(
-            "submission_edit",
+            "submission_action",
             request.user,
             object=self.submission,
             raise_exception=False,


### PR DESCRIPTION
<!--
Thanks for contributing to Hypha!

Please ensure your contributions pass all necessary linting/testing and that the appropriate documentation has been updated.
-->

<!--
Describe briefly what your pull request changes. If this is resolving an issue, please specify below via "Fixes #<Github Issue ID>"
-->
There was a recent update to submission_edit permission for co-applicants that are breaking things for actions like Update status, Lead Update, etc. This PR added a separate permission submission_action with same permissions, excluding workflow edit permission needed only for submission edit. Now submission edit and actions can have separate permissions, and should be working just fine.


## Test Steps
<!-- 
If step does not require manual testing, skip/remove this section.

Give a brief overview of the steps required for a user/dev to test this contribution. Important things to include:
 - Required user roles for where necessary (ie. "As a Staff Admin...")
 - Clear & validatable expected results (ie. "Confirm the submit button is now not clickable")
 - Language that can be understood by non-technical testers if being tested by users
-->

 - [ ] ...