### PR TITLE
Fix overlapping lines in header of submission PDF

### DIFF
--- a/hypha/apply/utils/pdfs.py
+++ b/hypha/apply/utils/pdfs.py
@@ -349,6 +349,7 @@ def draw_title_block(canvas, doc, page_title, title, meta, page_width, page_heig
     pos -= meta_size * 2
 
     for line in split_meta:
+        pos -= meta_size
         canvas.drawString(
             doc.leftMargin + FRAME_PADDING,
             pos,


### PR DESCRIPTION
I noticed that when the name of the lead on an application is quite long, the "meta" text in the PDF goes over several lines and ends up overlapping (see attached screenshots).

I tracked it down to what I believe is a missing line in `apply/utils/pdfs.py` (compared to the similar logic in handling `split_title` in the same function).

This seemed like a minor change so I didn't create an issue, please let me know if you'd prefer I did that.


## Screenshots 

<details>
<summary>Before</summary>

![Screenshot 2025-06-03 at 15-30-51 asdf - asdf-11 pdf](https://github.com/user-attachments/assets/c864a526-8ccd-4e4c-9780-dd256809b9f3)

</details>

<details>
<summary>After</summary>

![Screenshot 2025-06-03 at 15-30-34 asdf - asdf-12 pdf](https://github.com/user-attachments/assets/8c46e46e-8f21-4720-bd9a-a60794a0ff76)

</details>

## Test Steps

1. Set up a hypha instance (with `USE_PROJECTS=True` for PDF download to work, see #4566)
2. Log in as an admin user (so you have access to PDF download)
3. Change your display name to something fairly long (~80 characters, with spaces)
4. Go to a submission's detail page and download the PDF (Actions to take > More actions > Download PDF)