### PR TITLE
Set label in project header to "Project lead:" instead of only "Lead:"

### DIFF
--- a/hypha/apply/projects/templates/application_projects/partials/project_lead.html
+++ b/hypha/apply/projects/templates/application_projects/partials/project_lead.html
@@ -6,9 +6,9 @@
        hx-get="{% url 'apply:projects:lead_update' object.submission.id %}"
        hx-target="#htmx-modal"
     >
-        <u>{% trans "Lead" %}: {{ object.lead }}</u>
+        <u>{% trans "Project lead" %}: {{ object.lead }}</u>
         {% heroicon_micro "pencil-square" class="inline ms-1" aria_hidden=true %}
     </a>
 {% else %}
-    <span>{% trans "Lead" %}: {{ object.lead }}</span>
+    <span>{% trans "Project lead" %}: {{ object.lead }}</span>
 {% endif %}


### PR DESCRIPTION
When a project exist the project header is used for submission detail view as well. This spells out that what you see in the header is the project lead, not the submission lead.