### PR TITLE
Correct project template urls.

### DIFF
--- a/hypha/apply/projects/templates/application_projects/partials/contracting_category_documents.html
+++ b/hypha/apply/projects/templates/application_projects/partials/contracting_category_documents.html
@@ -27,7 +27,7 @@
                                 {% if document_category.required %}<span class="text-red-700">*</span>{% endif %}
                                 {% if document_category.template %}
                                     {% heroicon_mini "information-circle" class="inline align-middle fill-light-blue" aria_hidden=true %}
-                                    <a class="font-semibold border-b-2 border-dashed" href="{% url 'apply:projects:category_template' pk=object.pk type='contract_document' category_pk=document_category.pk %}" target="_blank">{% trans "View template" %}</a>
+                                    <a class="font-semibold border-b-2 border-dashed" href="{% url 'apply:projects:category_template' pk=object.submission.pk type='contract_document' category_pk=document_category.pk %}" target="_blank">{% trans "View template" %}</a>
                                 {% endif %}
                             </span>
                             {% if document_category not in remaining_contract_document_categories %}

--- a/hypha/apply/projects/templates/application_projects/partials/supporting_documents.html
+++ b/hypha/apply/projects/templates/application_projects/partials/supporting_documents.html
@@ -22,7 +22,7 @@
                                 {% if document_category.required %}<span class="text-red-700">*</span>{% endif %}
                                 {% if document_category.template %}
                                     <a class="font-semibold transition-opacity hover:opacity-70"
-                                       href="{% url 'apply:projects:category_template' pk=object.pk type='project_document' category_pk=document_category.pk %}"
+                                       href="{% url 'apply:projects:category_template' pk=object.submission.pk type='project_document' category_pk=document_category.pk %}"
                                        target="_blank"
                                     >
                                         <span class="border-b-2 border-dashed">


### PR DESCRIPTION
The optional templates for project and contract documents have an incorrect url:

![Skärmavbild 2025-06-06 kl  10 20 53](https://github.com/user-attachments/assets/02060ce9-dc6f-45c1-8fda-445e9da16296)
