### PR TITLE
Fix report file path issue and duplicate file issue, Fix file path issue for Project and SOW Form

### DIFF
--- a/hypha/apply/funds/files.py
+++ b/hypha/apply/funds/files.py
@@ -22,7 +22,7 @@ class PrivateStreamFieldFile(StreamFieldFile):
 
     def get_entity_id(self):
         from hypha.apply.funds.models import ApplicationRevision
-        from hypha.apply.projects.reports.models import ReportVersion
+        from hypha.apply.projects.reports.models import Report, ReportVersion
 
         entity_id = self.instance.pk
 
@@ -30,15 +30,13 @@ class PrivateStreamFieldFile(StreamFieldFile):
             entity_id = self.instance.submission.pk
         elif isinstance(self.instance, ReportVersion):
             # Reports are project documents.
-            entity_id = self.instance.report.project.pk
+            entity_id = self.instance.report.project.submission.pk
+        elif isinstance(self.instance, Report):
+            entity_id = self.instance.project.submission.pk
         return entity_id
 
     def generate_filename(self):
-        from hypha.apply.projects.reports.models import ReportVersion
-
         path_start = "submission"
-        if isinstance(self.instance, ReportVersion):
-            path_start = "project"
         return generate_private_file_path(
             self.get_entity_id(),
             self.field.id,
@@ -48,14 +46,10 @@ class PrivateStreamFieldFile(StreamFieldFile):
 
     @property
     def url(self):
-        from hypha.apply.projects.reports.models import ReportVersion
-
         view_name = "apply:submissions:serve_private_media"
         kwargs = {
             "pk": self.get_entity_id(),
             "field_id": self.field.id,
             "file_name": self.basename,
         }
-        if isinstance(self.instance, ReportVersion):
-            view_name = "apply:projects:document"
         return reverse(viewname=view_name, kwargs=kwargs)

--- a/hypha/apply/funds/files.py
+++ b/hypha/apply/funds/files.py
@@ -22,17 +22,20 @@ class PrivateStreamFieldFile(StreamFieldFile):
 
     def get_entity_id(self):
         from hypha.apply.funds.models import ApplicationRevision
+        from hypha.apply.projects.models.project import Project, ProjectSOW
         from hypha.apply.projects.reports.models import Report, ReportVersion
 
         entity_id = self.instance.pk
 
-        if isinstance(self.instance, ApplicationRevision):
+        if isinstance(self.instance, ApplicationRevision) or isinstance(
+            self.instance, Project
+        ):
             entity_id = self.instance.submission.pk
+        elif isinstance(self.instance, Report) or isinstance(self.instance, ProjectSOW):
+            entity_id = self.instance.project.submission.pk
         elif isinstance(self.instance, ReportVersion):
             # Reports are project documents.
             entity_id = self.instance.report.project.submission.pk
-        elif isinstance(self.instance, Report):
-            entity_id = self.instance.project.submission.pk
         return entity_id
 
     def generate_filename(self):

--- a/hypha/apply/projects/reports/forms.py
+++ b/hypha/apply/projects/reports/forms.py
@@ -57,7 +57,10 @@ class ReportEditForm(StreamBaseForm, forms.ModelForm, metaclass=MixedMetaClass):
             if field.split("_")[0] in instance.question_field_ids
         }
         # In case there are stream form file fields, process those here.
-        instance.process_file_data(self.cleaned_data["form_data"])
+        instance.process_file_data(
+            self.cleaned_data["form_data"],
+            latest_existing_data=instance.current.form_data,
+        )
 
         is_draft = "save" in self.data
         version = ReportVersion.objects.create(
@@ -68,7 +71,10 @@ class ReportEditForm(StreamBaseForm, forms.ModelForm, metaclass=MixedMetaClass):
             draft=is_draft,
             author=self.user,
         )
-        version.process_file_data(self.cleaned_data["form_data"])
+        version.process_file_data(
+            self.cleaned_data["form_data"],
+            latest_existing_data=instance.current.form_data,
+        )
         version.save()
 
         if is_draft:

--- a/hypha/apply/projects/reports/forms.py
+++ b/hypha/apply/projects/reports/forms.py
@@ -59,7 +59,9 @@ class ReportEditForm(StreamBaseForm, forms.ModelForm, metaclass=MixedMetaClass):
         # In case there are stream form file fields, process those here.
         instance.process_file_data(
             self.cleaned_data["form_data"],
-            latest_existing_data=instance.current.form_data,
+            latest_existing_data=instance.current.form_data
+            if instance.current
+            else None,
         )
 
         is_draft = "save" in self.data
@@ -73,7 +75,9 @@ class ReportEditForm(StreamBaseForm, forms.ModelForm, metaclass=MixedMetaClass):
         )
         version.process_file_data(
             self.cleaned_data["form_data"],
-            latest_existing_data=instance.current.form_data,
+            latest_existing_data=instance.current.form_data
+            if instance.current
+            else None,
         )
         version.save()
 


### PR DESCRIPTION
<!--
Thanks for contributing to Hypha!

Please ensure your contributions pass all necessary linting/testing and that the appropriate documentation has been updated.
-->

<!--
Describe briefly what your pull request changes. If this is resolving an issue, please specify below via "Fixes #<Github Issue ID>"
-->
Fixes #4574 

As reports are project documents so we added a different path for its files but we used ReportVersion instance checks and missed Report instances so reports files and its version files were having different path and were creating issues. We could solve it in that way as well but I realise as projects are also the extension of submission and we have been trying to merge them so keep everything similar with same url pattern.

Now it uses submission id to generate path and render the file similar to other submission files.

Now, it also handles the duplicate file issue on every upload. It was resolved for the application form but not for the report forms.


## Test Steps
<!-- 
If step does not require manual testing, skip/remove this section.

Give a brief overview of the steps required for a user/dev to test this contribution. Important things to include:
 - Required user roles for where necessary (ie. "As a Staff Admin...")
 - Clear & validatable expected results (ie. "Confirm the submit button is now not clickable")
 - Language that can be understood by non-technical testers if being tested by users
-->

 - [ ] Upload a file to report form.
 - [ ] Check if it is accessible.
 - [ ] Edit and submit form without uploading new file, file name shouldn't be changed like it used to `filename_<some hex code>.ext`