### PR TITLE
Delete application comments with the application

### DIFF
--- a/hypha/apply/funds/views/submission_delete.py
+++ b/hypha/apply/funds/views/submission_delete.py
@@ -44,10 +44,11 @@ class SubmissionDeleteView(LoginRequiredMixin, UserPassesTestMixin, DeleteView):
                 source=submission,
             )
 
-        # Delete NEW_SUBMISSION event for this particular submission, if any.
+        # Delete NEW_SUBMISSION & COMMENT events for this particular submission, if any.
         # Otherwise, the submission deletion will fail.
         Event.objects.filter(
-            type=MESSAGES.NEW_SUBMISSION, object_id=submission.id
+            type__in=[MESSAGES.NEW_SUBMISSION, MESSAGES.COMMENT],
+            object_id=submission.id,
         ).delete()
 
         # delete submission and redirect to success url

--- a/hypha/apply/middleware.py
+++ b/hypha/apply/middleware.py
@@ -13,7 +13,7 @@ class HandleProtectionErrorMiddleware:
             messages.error(
                 request,
                 _(
-                    "The object you are trying to delete is used somewhere. Please remove any usages and try again!."
+                    "The object you are trying to delete is used somewhere. Please remove any usages and try again!"
                 ),
             )
             return HttpResponseRedirect(request.path)


### PR DESCRIPTION
Small code change to delete all associated comments from an application when the application itself is deleted. OTF has gotten lots of account deletion requests recently and this has prevented accounts from being deleted - applications are deleted but the comments prevent staff from deleting the account

There will probably be a bigger pass at these for data retention stuff later on but this is just a start