### PR TITLE
Restrict permission to invite and update co-applicant in archived submissions and complete projects

### DIFF
--- a/hypha/apply/funds/permissions.py
+++ b/hypha/apply/funds/permissions.py
@@ -236,6 +236,13 @@ def can_view_submission_screening(user, submission):
 
 
 def can_invite_co_applicants(user, submission):
+    if submission.is_archive:
+        return False, "Co-applicant can't be added to archived submission"
+    if hasattr(submission, "project"):
+        from hypha.apply.projects.models.project import COMPLETE
+
+        if submission.project.status == COMPLETE:
+            return False, "Co-applicants can't be invited to completed projects"
     if (
         submission.co_applicant_invites.all().count()
         >= settings.SUBMISSIONS_COAPPLICANT_INVITES_LIMIT
@@ -257,6 +264,13 @@ def can_view_co_applicants(user, submission):
 
 
 def can_update_co_applicant(user, invite):
+    if invite.submission.is_archive:
+        return False, "Co-applicant can't be updated to archived submission"
+    if hasattr(invite.submission, "project"):
+        from hypha.apply.projects.models.project import COMPLETE
+
+        if invite.submission.project.status == COMPLETE:
+            return False, "Co-applicants can't be updated to completed projects"
     if invite.invited_by == user:
         return True, "Same user who invited can delete the co-applicant"
     if invite.submission.user == user:

--- a/hypha/apply/funds/templates/funds/includes/co-applicant-block.html
+++ b/hypha/apply/funds/templates/funds/includes/co-applicant-block.html
@@ -1,4 +1,4 @@
-{% load i18n heroicons %}
+{% load i18n heroicons co-applicant_tags %}
 
 <div class="sidebar__inner sidebar__inner--actions" data-testid="sidebar-primary-actions">
     <details {% if user.is_applicant or not co_applicants %} open {% endif %} class="group">
@@ -7,11 +7,12 @@
                 {% trans "Co-applicants" %} <span class="text-base font-medium"> ({{ co_applicants.count }})</span>
                 {% heroicon_solid "chevron-down" size="16" class="w-4 h-4 transition-transform rotate-90 ms-2 group-open:rotate-0" %}
             </p>
+            {% can_invite_coapplicant user object as can_invite %}
             <button
                 class="flex items-center py-1 pr-4 pl-2 font-bold rounded-sm -me-2 {% if object.co_applicant_invites.count >= invite_max_limit %} text-blue-200 {% else %}transition-colors cursor-pointer text-dark-blue hover:bg-slate-200{% endif %}"
                 hx-get="{% url 'apply:submissions:invite_co_applicant' pk=object.id %}"
                 hx-target="#htmx-modal"
-                {% if object.co_applicant_invites.count >= invite_max_limit %}disabled title='{% trans "Max limit reached" %}'{% endif %}
+                {% if not can_invite %}disabled title='{% trans "Not allowed" %}'{% endif %}
                 role="button"
                 aria-label="{% trans "Invite co-applicant" %}"
             >
@@ -27,25 +28,39 @@
         {% if co_applicants %}
             <div class="flex flex-col gap-2 justify-between">
                 {% for invite in co_applicants %}
-
+                    {% can_update_coapplicant user invite as can_update %}
                     <div>
-                        <a
-                            class="font-bold line-clamp-2 group/coapplicant"
-                            href="{% url 'apply:submissions:edit_co_applicant' invite_pk=invite.id %}"
-                            hx-get="{% url 'apply:submissions:edit_co_applicant' invite_pk=invite.id %}"
-                            hx-target="#htmx-modal"
-                        >
-                            <div class="flex justify-between">
-                                {% if invite.status == "accepted" %}
-                                    {{ invite.co_applicant.user }}
-                                {% else %}
-                                    {{ invite.invited_user_email }}
-                                {% endif %}
+                        {% if can_update %}
+                            <a
+                                class="font-bold line-clamp-2 group/coapplicant"
+                                href="{% url 'apply:submissions:edit_co_applicant' invite_pk=invite.id %}"
+                                hx-get="{% url 'apply:submissions:edit_co_applicant' invite_pk=invite.id %}"
+                                hx-target="#htmx-modal"
+                            >
+                                <div class="flex justify-between">
+                                    {% if invite.status == "accepted" %}
+                                        {{ invite.co_applicant.user }}
+                                    {% else %}
+                                        {{ invite.invited_user_email }}
+                                    {% endif %}
 
-                                {% heroicon_solid "pencil" class="hidden align-middle me-1 group-hover/coapplicant:inline" width=16 height=16 stroke_width=2 aria_hidden=true %}
+                                    {% heroicon_solid "pencil" class="hidden align-middle me-1 group-hover/coapplicant:inline" width=16 height=16 stroke_width=2 aria_hidden=true %}
 
+                                </div>
+                            </a>
+                        {% else %}
+                            <div class="font-bold line-clamp-2 group/coapplicant">
+                                <div class="flex justify-between">
+                                    {% if invite.status == "accepted" %}
+                                        {{ invite.co_applicant.user }}
+                                    {% else %}
+                                        {{ invite.invited_user_email }}
+                                    {% endif %}
+
+                                </div>
                             </div>
-                        </a>
+                        {% endif %}
+
                         {% if invite.status == "accepted" %}
                             <div class="text-xs text-fg-muted" >{{ invite.co_applicant.get_role_display }}</div>
                         {% else %}

--- a/hypha/apply/funds/templatetags/co-applicant_tags.py
+++ b/hypha/apply/funds/templatetags/co-applicant_tags.py
@@ -1,0 +1,27 @@
+from django import template
+
+from hypha.apply.funds.permissions import has_permission
+
+register = template.Library()
+
+
+@register.simple_tag
+def can_invite_coapplicant(user, submission):
+    permission, _ = has_permission(
+        "co_applicant_invite",
+        user,
+        object=submission,
+        raise_exception=False,
+    )
+    return permission
+
+
+@register.simple_tag
+def can_update_coapplicant(user, invite):
+    permission, _ = has_permission(
+        "co_applicants_update",
+        user,
+        object=invite,
+        raise_exception=False,
+    )
+    return permission


### PR DESCRIPTION
<!--
Thanks for contributing to Hypha!

Please ensure your contributions pass all necessary linting/testing and that the appropriate documentation has been updated.
-->

<!--
Describe briefly what your pull request changes. If this is resolving an issue, please specify below via "Fixes #<Github Issue ID>"
-->
Co-applicant can't be invited or updated for archived submission and complete projects

## Test Steps
<!-- 
If step does not require manual testing, skip/remove this section.

Give a brief overview of the steps required for a user/dev to test this contribution. Important things to include:
 - Required user roles for where necessary (ie. "As a Staff Admin...")
 - Clear & validatable expected results (ie. "Confirm the submit button is now not clickable")
 - Language that can be understood by non-technical testers if being tested by users
-->

 - [ ] …