### PR TITLE
Fix Project lead visibility for org memeber like finance

### DIFF
--- a/hypha/apply/projects/templates/application_projects/includes/project_header.html
+++ b/hypha/apply/projects/templates/application_projects/includes/project_header.html
@@ -23,7 +23,7 @@
         </span>
     {% endif %}
 
-    {% if not HIDE_STAFF_IDENTITY or request.user.is_apply_staff %}
+    {% if not HIDE_STAFF_IDENTITY or request.user.is_org_faculty %}
         <span
             hx-get="{% url "apply:projects:project_lead" object.submission.id %}"
             hx-trigger="load, leadUpdated from:body"


### PR DESCRIPTION
<!--
Thanks for contributing to Hypha!

Please ensure your contributions pass all necessary linting/testing and that the appropriate documentation has been updated.
-->

<!--
Describe briefly what your pull request changes. If this is resolving an issue, please specify below via "Fixes #<Github Issue ID>"
-->
Fixes Project lead visibility for finance and other org faculty if Hide staff identity is True.
Project Lead shouldn't be visible to Applicant but visible to finance even if Hide Staff Identity is True.

## Test Steps
<!-- 
If step does not require manual testing, skip/remove this section.

Give a brief overview of the steps required for a user/dev to test this contribution. Important things to include:
 - Required user roles for where necessary (ie. "As a Staff Admin...")
 - Clear & validatable expected results (ie. "Confirm the submit button is now not clickable")
 - Language that can be understood by non-technical testers if being tested by users
-->

 - [ ] …