### PR TITLE
Fix dark mode not being auto dectected

### DIFF
--- a/hypha/static_src/tailwind/base/themes.css
+++ b/hypha/static_src/tailwind/base/themes.css
@@ -47,7 +47,7 @@
 @plugin "daisyui/theme" {
   name: "dark";
   default: false;
-  /* prefersdark: true; */
+  prefersdark: true;
   color-scheme: "dark";
   --color-base-100: oklch(25.33% 0.016 252.42);
   --color-base-200: oklch(23.26% 0.014 253.1);


### PR DESCRIPTION
Dark mode will be auto applied when the preference exists in the system settings