### PR TITLE
Allow for using "Forgot Password" even when a password isn't set

### DIFF
--- a/hypha/apply/users/forms.py
+++ b/hypha/apply/users/forms.py
@@ -1,7 +1,10 @@
+import unicodedata
+
 from django import forms
 from django.conf import settings
 from django.contrib.auth import get_user_model
 from django.contrib.auth.forms import AuthenticationForm
+from django.contrib.auth.forms import PasswordResetForm as DJPasswordResetForm
 from django.utils.safestring import mark_safe
 from django.utils.translation import gettext_lazy as _
 from rolepermissions import roles
@@ -302,3 +305,40 @@ class Disable2FAConfirmationForm(forms.Form):
                 code="confirmation_text_incorrect",
             )
         return text
+
+
+class PasswordResetForm(DJPasswordResetForm):
+    @staticmethod
+    def _unicode_ci_compare(s1, s2):
+        """
+        Perform case-insensitive comparison of two identifiers, using the
+        recommended algorithm from Unicode Technical Report 36, section
+        2.11.2(B)(2).
+
+        Pulled directly from django.contrib.auth.forms
+        """
+        return (
+            unicodedata.normalize("NFKC", s1).casefold()
+            == unicodedata.normalize("NFKC", s2).casefold()
+        )
+
+    def get_users(self, email):
+        """Given an email, return matching user(s) who should receive a reset.
+
+        This allows subclasses to more easily customize the default policies
+        that prevent inactive users and users with unusable passwords from
+        resetting their password.
+        """
+        UserModel = get_user_model()
+        email_field_name = UserModel.get_email_field_name()
+        active_users = UserModel._default_manager.filter(
+            **{
+                "%s__iexact" % email_field_name: email,
+                "is_active": True,
+            }
+        )
+        return (
+            u
+            for u in active_users
+            if self._unicode_ci_compare(email, getattr(u, email_field_name))
+        )

--- a/hypha/apply/users/templates/users/password_reset/confirm.html
+++ b/hypha/apply/users/templates/users/password_reset/confirm.html
@@ -9,7 +9,7 @@
         {% if validlink %}
 
             <h2 class="text-2xl">{% trans "Reset password" %}</h2>
-            <p>{% trans "Please enter your new password twice so we can verify you typed it in correctly." %}</p>
+            <p class="text-sm whitespace-normal label">{% trans "Please enter your new password twice so we can verify you typed it in correctly." %}</p>
 
             <form class="form" method="post" novalidate>
                 {% csrf_token %}
@@ -39,7 +39,7 @@
                     {% include "forms/includes/field.html" %}
                 {% endfor %}
 
-                <button class="btn btn-primary btn-wide" type="submit">{% trans 'Reset' %}</button>
+                <button class="mt-4 btn btn-wide btn-primary" type="submit">{% trans 'Reset' %}</button>
             </form>
         {% else %}
             <p>{% trans "The password reset link was invalid, possibly because it has already been used. Please request a new password reset." %}</p>

--- a/hypha/apply/users/templates/users/password_reset/done.html
+++ b/hypha/apply/users/templates/users/password_reset/done.html
@@ -8,13 +8,13 @@
 
     <div class="mt-12 w-full max-w-xl">
 
-        <h2 class="text-xl">
+        <h2 class="text-2xl">
             {% trans "Check your inbox for a password reset email!" %}
         </h2>
-        <p>
+        <p class="text-sm whitespace-normal label">
             {% blocktrans %}We have sent an email to you with a password recovery link, open the link in the email to change your password.{% endblocktrans %}
         </p>
-        <p>
+        <p class="text-sm whitespace-normal label">
             {% blocktrans %}Check your "Spam" folder, if you don't find the email in your inbox.{% endblocktrans %}
         </p>
     </div>

--- a/hypha/apply/users/views.py
+++ b/hypha/apply/users/views.py
@@ -61,6 +61,7 @@ from .forms import (
     CustomAuthenticationForm,
     Disable2FAConfirmationForm,
     PasswordlessAuthForm,
+    PasswordResetForm,
     ProfileForm,
 )
 from .models import ConfirmAccessToken, PendingSignup
@@ -383,6 +384,7 @@ class PasswordResetView(DjPasswordResetView):
     email_template_name = "users/password_reset/email.txt"
     template_name = "users/password_reset/form.html"
     success_url = reverse_lazy("users:password_reset_done")
+    form_class = PasswordResetForm
 
     def get_context_data(self, **kwargs):
         ctx = super().get_context_data(**kwargs)


### PR DESCRIPTION
<!--
Thanks for contributing to Hypha!

Please ensure your contributions pass all necessary linting/testing and that the appropriate documentation has been updated.
-->

<!--
Describe briefly what your pull request changes. If this is resolving an issue, please specify below via "Fixes #<Github Issue ID>"
-->
If a user doesn't have a password set in Hypha and they select "Forgot Password", they will get a prompt notifying them that a password reset email has been sent while Django **quietly** [ignores the sending of the email](https://github.com/django/django/blob/main/django/contrib/auth/forms.py#L440). This overrides the default `get_users` method in Django's `PasswordResetForm` to include users without a usable password.

As OTF has seen more outlook users have issues with magic links, this would be a nice alternative (even though maybe an annoying extra step) for the time being until we can properly block the link previews.

This PR also includes some very minor UI tweaks I noticed in testing that make reset prompts similar to the rest of Hypha's headers, help texts & buttons.


## Test Steps
<!-- 
If step does not require manual testing, skip/remove this section.

Give a brief overview of the steps required for a user/dev to test this contribution. Important things to include:
 - Required user roles for where necessary (ie. "As a Staff Admin...")
 - Clear & validatable expected results (ie. "Confirm the submit button is now not clickable")
 - Language that can be understood by non-technical testers if being tested by users
-->

 - [ ] Ensure that a user without a password can select the "Forgot Password" option during passworded logins to set a password on their account