### PR TITLE
Add coment visibility options for when a coapplicant exists on an application

### DIFF
--- a/hypha/apply/activity/forms.py
+++ b/hypha/apply/activity/forms.py
@@ -43,9 +43,11 @@ class CommentForm(FileFormMixin, forms.ModelForm):
             "message": PagedownWidget(),
         }
 
-    def __init__(self, *args, user=None, **kwargs):
+    def __init__(self, *args, user=None, has_coapplicants=False, **kwargs):
         super().__init__(*args, **kwargs)
-        self.visibility_choices = self._meta.model.visibility_choices_for(user)
+        self.visibility_choices = self._meta.model.visibility_choices_for(
+            user, has_coapplicants
+        )
         visibility = self.fields["visibility"]
         # Set default visibility to "Applicant" for staff and staff can view everything.
         visibility.initial = self.visibility_choices[0]

--- a/hypha/apply/activity/models.py
+++ b/hypha/apply/activity/models.py
@@ -289,7 +289,9 @@ class Activity(models.Model):
         return [ALL]
 
     @classmethod
-    def visibility_choices_for(cls, user) -> List[Tuple[str, str]]:
+    def visibility_choices_for(
+        cls, user, has_coapplicants=False
+    ) -> List[Tuple[str, str]]:
         """Gets activity visibility choices for the specified user
 
         Args:
@@ -309,7 +311,10 @@ class Activity(models.Model):
             ]
 
         if user.is_applicant:
-            return [(APPLICANT, VISIBILITY[APPLICANT])]
+            applicant_choices = [(APPLICANT, VISIBILITY[APPLICANT])]
+            if has_coapplicants:
+                applicant_choices.append((TEAM, VISIBILITY[TEAM]))
+            return applicant_choices
 
         if user.is_reviewer:
             return [(REVIEWER, VISIBILITY[REVIEWER])]

--- a/hypha/apply/funds/views/comments.py
+++ b/hypha/apply/funds/views/comments.py
@@ -30,7 +30,11 @@ def comments_view(request, pk):
 
     form = None
     if user_can_view_post_comment_form(user=request.user, submission=submission):
-        form = CommentForm(user=request.user, data=request.POST or None)
+        form = CommentForm(
+            user=request.user,
+            data=request.POST or None,
+            has_coapplicants=submission.co_applicants.exists(),
+        )
         if request.method == "POST":
             form.instance.user = request.user
             form.instance.source = submission


### PR DESCRIPTION
As it stands applicants do not have any visibility options and are always set to the default of "Applicant" - there may be scenarios where an applicant only wants to staff to see a comment, not the other coapplicants

## Test Steps
<!-- 
If step does not require manual testing, skip/remove this section.

Give a brief overview of the steps required for a user/dev to test this contribution. Important things to include:
 - Required user roles for where necessary (ie. "As a Staff Admin...")
 - Clear & validatable expected results (ie. "Confirm the submit button is now not clickable")
 - Language that can be understood by non-technical testers if being tested by users
-->
Ensure that with only the role of applicant, an application with...
 - [ ] ...no coapplicants does not show a visibility section on the comments form
 - [ ] ...one or more coapplicants does show a visibility section with the options of "Applicants" and "Staff only"