### PR TITLE
Validate ID of the user before executing an email change on an account

### DIFF
--- a/hypha/apply/users/tests/test_email_change.py
+++ b/hypha/apply/users/tests/test_email_change.py
@@ -4,6 +4,8 @@ from urllib.parse import urlencode
 from django.core.signing import TimestampSigner, dumps
 from django.test import TestCase
 from django.urls import reverse
+from django.utils.encoding import force_bytes
+from django.utils.http import urlsafe_base64_encode
 
 from .factories import OAuthUserFactory, UserFactory
 
@@ -76,7 +78,7 @@ class TestEmailChangeOAuthUserSkipsElevation(TestCase):
 
 
 class TestEmailChangeTokenValidation(TestCase):
-    """The signed token in the query string must be valid and unexpired."""
+    """The signed token in the query string must be valid, unexpired and requested by the same user that the change is being executed for."""
 
     def setUp(self):
         self.user = OAuthUserFactory()  # skip elevation
@@ -174,3 +176,41 @@ class TestEmailChangeElevatedUserWithPassword(TestCase):
             self.client.get(url_with_value(signed))
         self.user.refresh_from_db()
         self.assertEqual(self.user.full_name, "Elevated Name")
+
+
+class EmailChangeConfirmation(TestCase):
+    """Testing the view that handles the actual confirmation & token validation that comes from the confirmation email"""
+
+    def setUp(self):
+        self.user = UserFactory()
+        self.client.force_login(self.user)
+
+    def test_processing_valid_token_success(self):
+        new_email = f"new{self.user.email}"
+        signer = TimestampSigner()
+        signed_value = signer.sign(
+            dumps({"updated_email": new_email, "id": self.user.id})
+        )
+        uidb64 = urlsafe_base64_encode(force_bytes(self.user.id))
+        response = self.client.get(
+            reverse(
+                "users:confirm_email", kwargs={"uidb64": uidb64, "token": signed_value}
+            )
+        )
+        self.assertEqual(response.status_code, 200)
+
+    def test_mismatched_id_fails(self):
+        """Indicates tampering of the URL to attempt to change another user's email, should redirect to account page"""
+        other_user = UserFactory()
+        new_email = f"new{self.user.email}"
+        signer = TimestampSigner()
+        signed_value = signer.sign(
+            dumps({"updated_email": new_email, "id": self.user.id})
+        )
+        uidb64 = urlsafe_base64_encode(force_bytes(other_user.id))
+        response = self.client.get(
+            reverse(
+                "users:confirm_email", kwargs={"uidb64": uidb64, "token": signed_value}
+            )
+        )
+        self.assertEqual(response.status_code, 302)

--- a/hypha/apply/users/tests/test_email_change.py
+++ b/hypha/apply/users/tests/test_email_change.py
@@ -1,6 +1,7 @@
 from unittest.mock import patch
 from urllib.parse import urlencode
 
+from django.contrib.messages import get_messages
 from django.core.signing import TimestampSigner, dumps
 from django.test import TestCase
 from django.urls import reverse
@@ -179,7 +180,10 @@ class TestEmailChangeElevatedUserWithPassword(TestCase):
 
 
 class EmailChangeConfirmation(TestCase):
-    """Testing the view that handles the actual confirmation & token validation that comes from the confirmation email"""
+    """Testing the view that handles the actual confirmation & token validation that comes from the confirmation email
+
+    Both a valid & invalid view will result in a 302 response, the big difference is in the messages that get added.
+    """
 
     def setUp(self):
         self.user = UserFactory()
@@ -197,7 +201,10 @@ class EmailChangeConfirmation(TestCase):
                 "users:confirm_email", kwargs={"uidb64": uidb64, "token": signed_value}
             )
         )
-        self.assertEqual(response.status_code, 200)
+
+        self.assertEqual(response.status_code, 302)
+        messages = list(get_messages(response.wsgi_request))
+        self.assertIn("email has been successfully updated", messages[0].message)
 
     def test_mismatched_id_fails(self):
         """Indicates tampering of the URL to attempt to change another user's email, should redirect to account page"""
@@ -214,3 +221,5 @@ class EmailChangeConfirmation(TestCase):
             )
         )
         self.assertEqual(response.status_code, 302)
+        messages = list(get_messages(response.wsgi_request))
+        self.assertEqual(len(messages), 0)

--- a/hypha/apply/users/views.py
+++ b/hypha/apply/users/views.py
@@ -203,7 +203,9 @@ def account_email_change(request):
     if request.user.email != value["updated_email"]:
         send_confirmation_email(
             request.user,
-            signer.sign(dumps(value["updated_email"])),
+            signer.sign(
+                dumps({"updated_email": value["updated_email"], "id": request.user.id})
+            ),
             updated_email=value["updated_email"],
             site=Site.find_for_request(request),
         )
@@ -262,7 +264,17 @@ def oauth(request):
 class EmailChangeConfirmationView(TemplateView):
     def get(self, request, *args, **kwargs):
         user = self.get_user(kwargs.get("uidb64"))
-        email = self.unsigned(kwargs.get("token"))
+        value = self.unsigned(kwargs.get("token"))
+
+        # A non-dict `value` means an expired, tampered, or legacy-format token.
+        if not isinstance(value, dict):
+            return render(request, "users/email_change/invalid_link.html")
+
+        # Verify that the user who requested this change is the same as the current user
+        # ie. an attacker didn't swap out the uidb64 ID for another user's
+        if user and user.id != value.get("id"):
+            return redirect("users:account")
+        email = value.get("updated_email")
         if user and email:
             if user.email != email:
                 user.email = email


### PR DESCRIPTION
<!--
Thanks for contributing to Hypha!

Please ensure your contributions pass all necessary linting/testing and that the appropriate documentation has been updated.
-->

<!--
Describe briefly what your pull request changes. If this is resolving an issue, please specify below via "Fixes #<Github Issue ID>"
-->
Fixes the issue of user IDs not being validated when an email change magic link is utilized.