### PR TITLE
Show "message from determination" for comments linked to determinations.

### DIFF
--- a/hypha/apply/activity/templates/activity/ui/activity-comment-item.html
+++ b/hypha/apply/activity/templates/activity/ui/activity-comment-item.html
@@ -44,7 +44,11 @@ Params:
                             <a href="#communications--{{activity.id}}" class="flex gap-1 hover:underline">
                                 <span class="text-fg-muted">
                                     {% if not submission_title and activity|user_can_see_related:request.user %}
-                                        {% blocktrans with related_name=activity.related_object|model_verbose_name|with_indefinite_article %}commented on {{ related_name }}{% endblocktrans %}
+                                        {% if activity.related_object|is_determination %}
+                                            {% trans "message from determination" %}
+                                        {% else %}
+                                            {% blocktrans with related_name=activity.related_object|model_verbose_name|with_indefinite_article %}commented on {{ related_name }}{% endblocktrans %}
+                                        {% endif %}
                                     {% else %}
                                         {% trans "commented" %}
                                     {% endif %}

--- a/hypha/apply/utils/templatetags/apply_tags.py
+++ b/hypha/apply/utils/templatetags/apply_tags.py
@@ -40,6 +40,12 @@ def instance_verbose_name(instance):
 
 
 @register.filter
+def is_determination(instance):
+    Determination = apps.get_model("determinations", "Determination")
+    return isinstance(instance, Determination)
+
+
+@register.filter
 def format_number_as_currency(amount: float | decimal.Decimal | str | None):
     """Formats a number as currency"""
     if amount is None:


### PR DESCRIPTION
When a determination of type "request for more info" is sent out the message is added as a comment, for auditing I assume.

This PR change the text from "… commented on determination [date]" to "… message from determination [date]". I think this is more clear and correct. This is not a real comment.